### PR TITLE
Solving problem with missing CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ else()
     endif()
 endif()
 
-project(NeXusDefinitions LANGUAGES NONE)
+project(NeXusDefinitions  NONE)
 
 #set cmake module path
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_include)


### PR DESCRIPTION
Removed the LANGUAGES keyword from the project command.

Hoping to get Jenkins to build successfully before the weekend.