### PR TITLE
add NXlog as child group of NXentry

### DIFF
--- a/base_classes/NXentry.nxdl.xml
+++ b/base_classes/NXentry.nxdl.xml
@@ -187,5 +187,6 @@
 	<group type="NXparameters" />
 	<group type="NXprocess" />
 	<group type="NXsubentry" />
+	<group type="NXlog" />
 </definition>
 

--- a/base_classes/NXsubentry.nxdl.xml
+++ b/base_classes/NXsubentry.nxdl.xml
@@ -183,5 +183,6 @@
 	<group type="NXdata" />
 	<group type="NXparameters" />
 	<group type="NXprocess" />
+	<group type="NXlog" />
 </definition>
 


### PR DESCRIPTION
This is a proposition.

some example data files (such as scan101.nxs from NeXpy) have this

Looks like the general intent of NXlog could convince someone to place it as a child of NXentry, such as when the NXlog contains the result of data reduction or analysis