### PR TITLE
fixes #547: defines ``vector_units`` attribute for NXtransformations

### DIFF
--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -130,7 +130,7 @@
 				<!-- <item value="general" /> -->
 			</enumeration>
 		</attribute>
-		<attribute name="vector" units="NX_DIMENSIONLESS" type="NX_NUMBER">
+		<attribute name="vector" type="NX_NUMBER">
 			<doc>
 				Three values that define the axis for this transformation.
 				The axis should be normalized to unit length, making it
@@ -140,6 +140,11 @@
 				increasing displacement.
 			</doc>
 			<dimensions rank="1" value="3" />
+		</attribute>
+		<attribute name="vector_units" type="NX_CHAR">
+			<doc>
+				The units for the ``vector`` attribute should be consistent with :ref:`NX_UNITLESS`.
+			</doc>
 		</attribute>
 		<attribute name="offset" type="NX_NUMBER">
 			<doc>

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -141,11 +141,6 @@
 			</doc>
 			<dimensions rank="1" value="3" />
 		</attribute>
-		<attribute name="vector_units" type="NX_CHAR">
-			<doc>
-				The units for the ``vector`` attribute should be consistent with :ref:`NX_UNITLESS`.
-			</doc>
-		</attribute>
 		<attribute name="offset" type="NX_NUMBER">
 			<doc>
 				A fixed offset applied before the transformation (three vector components).


### PR DESCRIPTION
#547: defines ``vector_units`` attribute