### PR TITLE
Renames relative_molecular_mass

### DIFF
--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -182,8 +182,11 @@
 			<dim index="1" value="n_comp"/>
 		</dimensions>
 	</field>
-	<field name="relative_molecular_mass" type="NX_FLOAT" units="NX_MASS">
-		<doc>Relative Molecular Mass of sample</doc>
+	<field name="chemical_formula_weight" type="NX_FLOAT" units="NX_MASS">
+		<doc>
+			Relative Molecular Mass of each component, the summed weight of all 
+			atoms in the chemical_formula.
+		</doc>
 		<dimensions rank="1">
 			<dim index="1" value="n_comp"/>
 		</dimensions>

--- a/base_classes/NXsample_component.nxdl.xml
+++ b/base_classes/NXsample_component.nxdl.xml
@@ -103,8 +103,11 @@
 	<field name="density" type="NX_FLOAT" units="NX_MASS_DENSITY">
 		<doc>Density of sample component</doc>
 	</field>
-	<field name="relative_molecular_mass" type="NX_FLOAT" units="NX_MASS">
-		<doc>Relative Molecular Mass of sample component</doc>
+	<field name="chemical_formula_weight" type="NX_FLOAT" units="NX_MASS">
+		<doc>
+			Relative Molecular Mass of component, the summed weight of all 
+			atoms in the chemical_formula.
+		</doc>
 	</field>
 	<field name="description">
 		<doc>


### PR DESCRIPTION
relative_molecular_mass was carried over from the contributed 
definition NXcontainer. For consistency with the chemical_formula field
and also with (e.g.) the CIF definitions, it should be renamed 
chemical_formula_weight.

This was discussed (some time ago) with @markbasham 

Signed-off-by: Michael Wharmby <michael.wharmby@diamond.ac.uk>