### PR TITLE
Adds missing nComp dimensions

### DIFF
--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -70,6 +70,9 @@
 			  
 			* This is the *Hill* system used by Chemical Abstracts.
 		</doc>
+		<dimensions rank="1">
+			<dim index="1" value="n_comp"/>
+		</dimensions>
 	</field>
 	<field name="temperature" type="NX_FLOAT" units="NX_TEMPERATURE">
 		<doc>Sample temperature. This could be a scanned variable</doc>
@@ -128,13 +131,15 @@
 	<field name="unit_cell_abc" type="NX_FLOAT" units="NX_LENGTH">
 		<doc>Crystallography unit cell parameters a, b, and c</doc>
 		<dimensions>
-			<dim index="1" value="3"/>
+			<dim index="1" value="n_comp"/>
+			<dim index="2" value="3"/>
 		</dimensions>
 	</field>
 	<field name="unit_cell_alphabetagamma" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>Crystallography unit cell parameters alpha, beta, and gamma</doc>
 		<dimensions>
-			<dim index="1" value="3"/>
+			<dim index="1" value="n_comp"/>
+			<dim index="2" value="3"/>
 		</dimensions>
 	</field>
 	<field name="unit_cell" type="NX_FLOAT" units="NX_LENGTH">
@@ -278,6 +283,9 @@
                 <doc>
                         In case it is all we know and we want to record/document it
                 </doc>
+                <dimensions>
+                    <dim index="1" value="n_comp"/>
+                </dimensions>
                 <enumeration>
                         <item value="triclinic" />
                         <item value="monoclinic" />


### PR DESCRIPTION
Added nComp arrays to four fields which need them. This is only necessary 
if it is intended to continue using the nComp arrays, rather than using 
NXsample_component. Nxsample_component looks like the better solution,
however.

Signed-off-by: Michael Wharmby <michael.wharmby@diamond.ac.uk>