### PR TITLE
Remove NXcontainer duplicates

### DIFF
--- a/contributed_definitions/NXcontainer.nxdl.xml
+++ b/contributed_definitions/NXcontainer.nxdl.xml
@@ -67,11 +67,14 @@
 		   the changes to the beampath would need to be accounted for.
 		
 		This class encodes the position of the container with respect to the 
-		sample and allows the calculation of the beampath through the container.
-		It also includes sufficient data to model beam absorption of the 
-		container and a link to a dataset containing a measurement of the 
-		container with nothing inside, to allow data corrections (at a specific
-		beam energy/measurement time) to be made.
+		sample and allows the calculation of the beampath through the 
+		container. Other data necessary to model beam absorption by the 
+		container should be included in the reference dataset. Typically, the 
+		reference dataset is a measurement of the empty container (included in 
+		this NXcontainer as a link) which can be used to make data corrections 
+		(at a specific beam energy/measurement time). The beam, orientation 
+		and shape fields are included to allow the same reference dataset to 
+		be used even if the container is used with a different geometry/energy.
 	</doc>
 	<field name="name">
 		<doc>

--- a/contributed_definitions/NXcontainer.nxdl.xml
+++ b/contributed_definitions/NXcontainer.nxdl.xml
@@ -84,57 +84,6 @@
 			experimental set up.
 		</doc>
 	</field>
-	<field name="chemical_formula">
-		<doc>
-			Chemical composition of the material the container is made from.
-			Specified using CIF conventions. Abbreviated version of CIF 
-			standard: 
-			
-			* Only recognized element symbols may be used.
-			* Each element symbol is followed by a 'count' number. A count of 
-			  '1' may be omitted.
-			* A space or parenthesis must separate each cluster of (element 
-			  symbol + count).
-			* Where a group of elements is enclosed in parentheses, the 
-			  multiplier for the group must follow the closing parentheses. 
-			  That is, all element and group multipliers are assumed to be 
-			  printed as subscripted numbers.
-			* Unless the elements are ordered in a manner that corresponds to 
-			  their chemical structure, the order of the elements within any 
-			  group or moiety depends on whether or not carbon is present.
-			* If carbon is present, the order should be: 
-			
-			  - C, then H, then the other elements in alphabetical order of 
-			    their symbol. 
-			  - If carbon is not present, the elements are listed purely in 
-			    alphabetic order of their symbol. 
-			  
-			* This is the *Hill* system used by Chemical Abstracts.
-		</doc>
-	</field>
-	<field name="density" type="NX_FLOAT" units="NX_MASS_DENSITY">
-		<doc>
-			Density of the material the container is made from.
-		</doc>
-		<dimensions rank="1">
-			<dim index="1" value="n_comp"/>
-		</dimensions>
-	</field>
-	<field name="packing_fraction" type="NX_FLOAT" units="NX_UNITLESS">
-		<doc>
-			Fraction of the volume of the container occupied by the material 
-			forming the container.
-		</doc>
-		<dimensions>
-			<dim index="1" value="n_comp"/>
-		</dimensions>
-	</field>
-	<field name="relative_molecular_mass" type="NX_FLOAT" units="NX_MASS">
-		<doc>Relative molecular mass of container.</doc>
-		<dimensions rank="1">
-			<dim index="1" value="n_comp"/>
-		</dimensions>
-	</field>
 	<group name="beam" type="NXbeam">
 		<doc>
 			Details of beam incident on container, including the position 


### PR DESCRIPTION
This PR removes fields which were moved over into NXsample and are therefore no longer necessary in the NXcontainer class. This was discussed (again, some time ago!) with @markbasham 

Signed-off-by: Michael Wharmby <michael.wharmby@diamond.ac.uk>