### PR TITLE
Updates from NIAC 2016

### DIFF
--- a/contributed_definitions/NXreflections.nxdl.xml
+++ b/contributed_definitions/NXreflections.nxdl.xml
@@ -79,7 +79,33 @@
     </field>
 
     <field name="flags" type="NX_INT" minOccurs="1">
-      <doc> Status flags describing the reflection. This is a bit mask. XXX possible flags enumeration here </doc>
+      <doc> Status flags describing the reflection. This is a bit mask. The bits in the mask follow the convention used by DIALS, and have the following names:
+        * bit 0: predicted
+        * bit 1: observed
+        * bit 2: indexed
+        * bit 3: used_in_refinement
+        * bit 4: strong
+        * bit 5: reference_spot
+        * bit 6: dont_integrate
+        * bit 7: integrated_sum
+        * bit 8: integrated_prf
+        * bit 9: integrated
+        * bit 10: overloaded
+        * bit 11: overlapped
+        * bit 12: overlapped_fg
+        * bit 13: in_powder_ring
+        * bit 14: foreground_includes_bad_pixels
+        * bit 15: background_includes_bad_pixels
+        * bit 16: includes_bad_pixels
+        * bit 17: bad_shoebox
+        * bit 18: bad_spot
+        * bit 19: used_in_modelling
+        * bit 20: centroid_outlier
+        * bit 21: failed_during_background_modelling
+        * bit 22: failed_during_summation
+        * bit 23: failed_during_profile_fitting
+        * bit 24: bad_reference
+      </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
@@ -276,7 +302,7 @@
       </attribute>
     </field>
 
-    <field name="bbx" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
+    <field name="bounding_box" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
       <doc> 
         The bounding box around the recorded recorded reflection. Should be
 	an integer array of length 6, where the 6 values are pixel positions
@@ -291,6 +317,10 @@
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
+      <dimensions rank="2">
+	  <dim index="1" value="n" />
+	  <dim index="2" value="6" />
+      </dimensions>
     </field>
 
     <field name="background_mean" type="NX_FLOAT" minOccurs="1">
@@ -370,7 +400,7 @@
 
     <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE" minOccurs="0">
       <doc> 
-        XXX
+        Polar angle of reflection centroid, following the NeXus simple (spherical polar) coordinate system
       </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
@@ -379,7 +409,7 @@
 
     <field name="azimuthal_angle" type="NX_FLOAT" units="NX_ANGLE" minOccurs="0">
       <doc> 
-        XXX
+        Azimuthal angle of reflection centroid, following the NeXus simple (spherical polar) coordinate system
       </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>

--- a/contributed_definitions/NXreflections.nxdl.xml
+++ b/contributed_definitions/NXreflections.nxdl.xml
@@ -23,21 +23,21 @@
       <doc> The experiments from which the reflection data derives </doc>
     </field>
 
-    <field name="h" type="NX_INT" minOccurs="1">
+    <field name="h" type="NX_NUMBER" minOccurs="1">
       <doc> The h component of the miller index </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
     </field>
 
-    <field name="k" type="NX_INT" minOccurs="1">
+    <field name="k" type="NX_NUMBER" minOccurs="1">
       <doc> The k component of the miller index </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
     </field>
 
-    <field name="l" type="NX_INT" minOccurs="1">
+    <field name="l" type="NX_NUMBER" minOccurs="1">
       <doc> The l component of the miller index </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
@@ -45,7 +45,7 @@
     </field>
 
     <field name="id" type="NX_INT" minOccurs="1">
-      <doc>
+      <doc> 
         The id of the experiment which resulted in the reflection. If the value
         is greater than 0, the experiments must link to a multi-experiment NXmx
         group 
@@ -79,7 +79,7 @@
     </field>
 
     <field name="flags" type="NX_INT" minOccurs="1">
-      <doc> Status flags describing the reflection </doc>
+      <doc> Status flags describing the reflection. This is a bit mask. XXX possible flags enumeration here </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
@@ -93,14 +93,14 @@
     </field>
     
     <field name="partiality" type="NX_FLOAT" minOccurs="1">
-      <doc> The partiality of the reflection </doc>
+      <doc> The partiality of the reflection. Dividing by this number will inflate the measured intensity to the full reflection equivalent. </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
     </field>
 
-    <field name="prd_frame" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="predicted_frame" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The frame on which the bragg peak of the reflection is predicted
       </doc>
       <attribute name="description">
@@ -108,9 +108,9 @@
       </attribute>
     </field>
 
-    <field name="prd_mm_x" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
-      <doc>
-        The x millimetre position at which the bragg peak of the reflection
+    <field name="predicted_x" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
+      <doc> 
+        The x position at which the bragg peak of the reflection
         is predicted 
       </doc>
       <attribute name="description">
@@ -118,9 +118,9 @@
       </attribute>
     </field>
 
-    <field name="prd_mm_y" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
-      <doc>
-        The y millimetre position at which the bragg peak of the reflection
+    <field name="predicted_y" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
+      <doc> 
+        The y position at which the bragg peak of the reflection
         is predicted 
       </doc>
       <attribute name="description">
@@ -128,7 +128,7 @@
       </attribute>
     </field>
 
-    <field name="prd_phi" type="NX_FLOAT" units="NX_ANGLE" minOccurs="1">
+    <field name="predicted_phi" type="NX_FLOAT" units="NX_ANGLE" minOccurs="1">
       <doc> The phi angle at which the bragg peak of the reflection is predicted
       </doc>
       <attribute name="description">
@@ -136,8 +136,8 @@
       </attribute>
     </field>
 
-    <field name="prd_px_x" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="predicted_px_x" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The x pixel position at which the bragg peak of the reflection is
         predicted 
       </doc>
@@ -146,8 +146,8 @@
       </attribute>
     </field>
 
-    <field name="prd_px_y" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="predicted_px_y" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The y pixel position at which the bragg peak of the reflection is
         predicted 
       </doc>
@@ -156,8 +156,8 @@
       </attribute>
     </field>
     
-    <field name="obs_frame_val" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="observed_frame" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The estimate of the frame at which the central impact of the
         reflection was recorded 
       </doc>
@@ -166,8 +166,8 @@
       </attribute>
     </field>
 
-    <field name="obs_frame_var" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="observed_frame_var" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The variance on the estimate of the frame at which the central
         impact of the reflection was recorded 
       </doc>
@@ -176,8 +176,8 @@
       </attribute>
     </field>
 
-    <field name="obs_px_x_val" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="observed_px_x" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The estimate of the pixel x position at which the central impact of
         the reflection was recorded 
       </doc>
@@ -186,8 +186,8 @@
       </attribute>
     </field>
 
-    <field name="obs_px_x_var" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="observed_px_x_var" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The variance on the estimate of the pixel x position at which the
         central impact of the reflection was recorded 
       </doc>
@@ -196,8 +196,8 @@
       </attribute>
     </field>
 
-    <field name="obs_px_y_val" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
+    <field name="observed_px_y" type="NX_FLOAT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
         The estimate of the pixel y position at which the central impact of
         the reflection was recorded 
       </doc>
@@ -206,8 +206,8 @@
       </attribute>
     </field>
 
-    <field name="obs_px_y_var" type="NX_FLOAT" units="NX_UNITLESS"  minOccurs="1">
-      <doc>
+    <field name="observed_px_y_var" type="NX_FLOAT" units="NX_UNITLESS"  minOccurs="1">
+      <doc> 
         The variance on the estimate of the pixel y position at which the
         central impact of the reflection was recorded 
       </doc>
@@ -216,8 +216,8 @@
       </attribute>
     </field>
 
-    <field name="obs_phi_val" type="NX_FLOAT" units="NX_ANGLE" minOccurs="1">
-      <doc>
+    <field name="observed_phi" type="NX_FLOAT" units="NX_ANGLE" minOccurs="1">
+      <doc> 
         The estimate of the phi angle at which the central impact of the
         reflection was recorded 
       </doc>
@@ -226,8 +226,8 @@
       </attribute>
     </field>
 
-    <field name="obs_phi_var" type="NX_FLOAT" units="NX_ANGLE" minOccurs="1">
-      <doc>
+    <field name="observed_phi_var" type="NX_FLOAT" units="NX_ANGLE" minOccurs="1">
+      <doc> 
         The variance on the estimate of the phi angle at which the central
         impact of the reflection was recorded 
       </doc>
@@ -236,9 +236,9 @@
       </attribute>
     </field>
 
-    <field name="obs_mm_x_val" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
-      <doc>
-        The estimate of the millimetre x position at which the central
+    <field name="observed_x" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
+      <doc> 
+        The estimate of the x position at which the central
         impact of the reflection was recorded 
       </doc>
       <attribute name="description">
@@ -246,9 +246,9 @@
       </attribute>
     </field>
 
-    <field name="obs_mm_x_var" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
-      <doc>
-        The variance on the estimate of the millimetre x position at which
+    <field name="observed_x_var" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
+      <doc> 
+        The variance on the estimate of the x position at which
         the central impact of the reflection was recorded 
       </doc>
       <attribute name="description">
@@ -256,9 +256,9 @@
       </attribute>
     </field>
 
-    <field name="obs_mm_y_val" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
-      <doc>
-        The estimate of the millimetre y position at which the central
+    <field name="observed_y" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
+      <doc> 
+        The estimate of the y position at which the central
         impact of the reflection was recorded 
       </doc>
       <attribute name="description">
@@ -266,9 +266,9 @@
       </attribute>
     </field>
 
-    <field name="obs_mm_y_var" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
-      <doc>
-        The variance on the estimate of the millimetre y position at which
+    <field name="observed_y_var" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1">
+      <doc> 
+        The variance on the estimate of the y position at which
         the central impact of the reflection was recorded 
       </doc>
       <attribute name="description">
@@ -276,68 +276,25 @@
       </attribute>
     </field>
 
-    <field name="bbx0" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
-        The lower pixel x position of the bounding box around the recorded
-        reflection 
+    <field name="bbx" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
+      <doc> 
+        The bounding box around the recorded recorded reflection. Should be
+	an integer array of length 6, where the 6 values are pixel positions
+	or frame numbers, as follows:
+        0) The lower pixel x position
+        1) The upper pixel x position
+        2) The lower pixel y position
+        3) The upper pixel y position
+        4) The lower frame number
+        5) The upper frame number
       </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
       </attribute>
     </field>
 
-    <field name="bbx1" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
-        The upper pixel x position of the bounding box around the recorded
-        reflection 
-      </doc>
-      <attribute name="description">
-        <doc> Describes the dataset </doc>
-      </attribute>
-    </field>
-
-    <field name="bby0" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
-        The lower pixel y position of the bounding box around the recorded
-        reflection 
-      </doc>
-      <attribute name="description">
-        <doc> Describes the dataset </doc>
-      </attribute>
-    </field>
-
-    <field name="bby1" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
-        The upper pixel y position of the bounding box around the recorded
-        reflection 
-      </doc>
-      <attribute name="description">
-        <doc> Describes the dataset </doc>
-      </attribute>
-    </field>
-
-    <field name="bbz0" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
-        The lower frame number of the bounding box around the recorded
-        reflection 
-      </doc>
-      <attribute name="description">
-        <doc> Describes the dataset </doc>
-      </attribute>
-    </field>
-
-    <field name="bbz1" type="NX_INT" units="NX_UNITLESS" minOccurs="1">
-      <doc>
-        The upper frame number of the bounding box around the recorded
-        reflection 
-      </doc>
-      <attribute name="description">
-        <doc> Describes the dataset </doc>
-      </attribute>
-    </field>
-
-    <field name="bkg_mean" type="NX_FLOAT" minOccurs="1">
-      <doc>
+    <field name="background_mean" type="NX_FLOAT" minOccurs="1">
+      <doc> 
         The mean background under the reflection peak 
       </doc>
       <attribute name="description">
@@ -345,8 +302,8 @@
       </attribute>
     </field>
 
-    <field name="int_prf_val" type="NX_FLOAT" minOccurs="0">
-      <doc>
+    <field name="int_prf" type="NX_FLOAT" minOccurs="0">
+      <doc> 
         The estimate of the reflection intensity by profile fitting 
       </doc>
       <attribute name="description">
@@ -355,7 +312,7 @@
     </field>
 
     <field name="int_prf_var" type="NX_FLOAT" minOccurs="0">
-      <doc>
+      <doc> 
         The variance on the estimate of the reflection intensity by profile
         fitting 
       </doc>
@@ -364,7 +321,7 @@
       </attribute>
     </field>
 
-    <field name="int_sum_val" type="NX_FLOAT" minOccurs="1">
+    <field name="int_sum" type="NX_FLOAT" minOccurs="1">
       <doc> The estimate of the reflection intensity by summation </doc>
       <attribute name="description">
         <doc> Describes the dataset </doc>
@@ -372,7 +329,7 @@
     </field>
 
     <field name="int_sum_var" type="NX_FLOAT" minOccurs="1">
-      <doc>
+      <doc> 
         The variance on the estimate of the reflection intensity by
         summation 
       </doc>
@@ -382,7 +339,7 @@
     </field>
 
     <field name="lp" type="NX_FLOAT" minOccurs="1">
-      <doc>
+      <doc> 
         The LP correction factor to be applied to the reflection intensities
       </doc>
       <attribute name="description">
@@ -391,7 +348,7 @@
     </field>
 
     <field name="prf_cc" type="NX_FLOAT" minOccurs="0">
-      <doc>
+      <doc> 
         The correlation of the reflection profile with the reference profile
         used in profile fitting 
       </doc>
@@ -401,7 +358,7 @@
     </field>
 
     <field name="overlaps" type="NX_INT" minOccurs="0">
-      <doc>
+      <doc> 
         An adjacency list specifying the spatial overlaps of reflections. The
         adjacency list is specified using an array data type where the elements
         of the array are the indices of the adjacent overlapped reflection 
@@ -411,5 +368,22 @@
       </attribute>
     </field>
 
+    <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE" minOccurs="0">
+      <doc> 
+        XXX
+      </doc>
+      <attribute name="description">
+        <doc> Describes the dataset </doc>
+      </attribute>
+    </field>
+
+    <field name="azimuthal_angle" type="NX_FLOAT" units="NX_ANGLE" minOccurs="0">
+      <doc> 
+        XXX
+      </doc>
+      <attribute name="description">
+        <doc> Describes the dataset </doc>
+      </attribute>
+    </field>
   </group>
 </definition>


### PR DESCRIPTION
Action items from minutes completed:
-H,K,L change to NX_number for incommensurate structures
-Discussion on flags, change to bitfield, no enum for efficiency
-Expand the description of partiality
-Need to keep mm and pixel positions because of parallax
-Write out predicted and observed
-Drop the mm in names, rather use units
-bounding_box as array, document the usage
-Spell out background
-Drop the val on the intensities, keep the _var version
code is not in place we defer it for now.
-Add polar_angle and azimuthal_angle

TODO
-Need documentation for polar_angle and azimuthal_angle
-Need to add some examples of flags. Would like to use the DIALS flags.

Deferred:
-overlaps is a list of overlapped reflections. This is a ragged array. As the