### PR TITLE
Update NXdetector.nxdl.xml

### DIFF
--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -242,6 +242,10 @@
   <field name="description">
     <doc>name/manufacturer/model/etc. information</doc>
   </field>
+	
+  <field name="serial_number">
+    <doc>Serial number for the detector</doc>
+  </field>
 
   <field name="local_name">
     <doc>Local name for the detector</doc>


### PR DESCRIPTION
Add serial_number field to explicitly identify different detectors.

The serial number on a detector is a useful key to allow different detectors identified without having to parse the multiple values in the descriptions field.

Having a explicit field for the serial number would make it much easier to determine which detector was actually used for a measurement, especially in facilities with detector loan pools.