### PR TITLE
NXexperiment and NXexperimentdata 

### DIFF
--- a/contributed_definitions/NXexperiment.nxdl.xml
+++ b/contributed_definitions/NXexperiment.nxdl.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+# 
+# Copyright (C) 2012-2017 NeXus International Advisory Committee (NIAC)
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+
+<definition name="NXexperiment" extends="NXobject" type="group"
+	    version="1.0"  
+	    category="contributed"
+	    xmlns="http://definition.nexusformat.org/nxdl/3.1"
+	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+	<doc>
+      Describe the contents of an NXentry resulting from a data collection using multiple detectors,
+      generating raw and derived data, potentially being scanned across multiple dimensions.
+      
+      It is not uncommon for a beamline at a synchrotron to collect data from multiple detectors in during a single scan. NeXus files
+      from these scans will contain many :ref:`NXdata` either containing direct links to :ref:`NXdetector` data, or data derived from
+      this data. The aim of the :ref:`NXexperiment` class is to store NeXus classes in a way that better represents the *experiment* performed,
+      rather than the *instrument* the experiment was performed on.
+      
+      For example, a small-angle scattering beamline with a detector for SAXS,
+      WAXS, XRF, a diode for transmitted intensity and an XY stage performs a single grid scan: The XRF raw data
+      might be have multiple channels that are summed to give the MCA, then small regions of this sum may also
+      be summed to produce simple elemental maps.
+      
+      This file contains multiple plottable datasets, therefore multiple NXdata groups and NXdetectors, 
+      but with no obvious way to discern what was measured and how the plottable datasets are related.
+      
+      The :ref:`NXexperimentdata` class allows (multiple) :ref:`NXdata` to be related to each other (through the ``DATANAME_origin`` attribute in :ref:`NXexperimentdata`), and back to the :ref:`NXdetector`
+      used to collect the data.
+      
+      (**required**) :ref:`NXexperimentdata` container for :ref:`NXdata` and single :ref:`NXdetector` used for the measurement
+      
+  </doc>
+  <group type="NXexperimentdata" />
+  
+</definition>

--- a/contributed_definitions/NXexperimentdata.nxdl.xml
+++ b/contributed_definitions/NXexperimentdata.nxdl.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+# 
+# Copyright (C) 2012-2017 NeXus International Advisory Committee (NIAC)
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+
+<definition name="NXexperimentdata" extends="NXobject" type="group"
+	    version="1.0"  
+	    category="contributed"
+	    xmlns="http://definition.nexusformat.org/nxdl/3.1"
+	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
+	    >
+	<doc>
+		Describe all the plottable data from a single detector in a single entity. To be used
+		inside :ref:`NXexperiment`
+		
+		Allows data to be related back to the detector that collected it.
+		
+		(**required**) :ref:`NXdetector` detector used to acquire data.
+		
+		(**required**) :ref:`NXdata` at least one NXdata, related to the NXdetector
+  </doc>
+  <attribute name="DATANAME_origin">
+    <doc>
+      Best description of the origin of this data, use . for the :ref:`NXdetector`. ``DATANAME`` refers to the 
+      name of an :ref:`NXdata` that must be in the same :ref:`NXexperimentdata`.
+    </doc>
+  </attribute>
+  <attribute name="primary">
+    <doc>
+      Default :ref:`NXdata` to plot to represent this detector.
+    </doc>
+  </attribute>
+  <group type="NXdetector" />
+  <group type="NXdata" />
+ 
+</definition>


### PR DESCRIPTION
Contributed definitions to allow NXdata groups to be related to each other and an NXdetector.

With the aim of making writing software for visualisation and processing of data collections with multiple detectors in the same scan easier by explicitly describing how the NXdata groups are released to each other and the corresponding NXDetector.