### PR TITLE
NXdata: prefixed axes attribute?

### DIFF
--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -85,7 +85,7 @@
 			of the plottable data, use a "." in that position.  
 			Such as::
 			
-				@I_axes="time", ".", "."
+				@axes="time", ".", "."
 			
 			Since there are three items in the list, the the *signal* field
 			must must be a three-dimensional array (rank=3).  The first dimension


### PR DESCRIPTION
An example in the documentation contains a reference to an attribute called `@I_axes`, which suggests that these axes belong to a particular dataset in the NXdata, even though the standard does not mention this case.

Typo?