### PR TITLE
allow NX_NUMBER for arrays with times

### DIFF
--- a/base_classes/NXevent_data.nxdl.xml
+++ b/base_classes/NXevent_data.nxdl.xml
@@ -51,11 +51,8 @@
     every five minutes. The cue_index will then contain the
     index into the event_id,event_time_offset pair of arrays for that
     courser cue_timestamp_zero. 
-
-    
-    
   </doc>
-	<field name="event_time_offset" type="NX_INT" units="NX_TIME_OF_FLIGHT">
+	<field name="event_time_offset" type="NX_NUMBER" units="NX_TIME_OF_FLIGHT">
 		<doc>
 			A list of timestamps for each event as it comes in. 
 		</doc>
@@ -68,7 +65,7 @@
 		</doc>
 		<dimensions rank="1"><dim index="1" value="i"/></dimensions>
 	</field>
-	<field name="event_time_zero" type="NX_INT" units="NX_TIME">
+	<field name="event_time_zero" type="NX_NUMBER" units="NX_TIME">
 		<doc>
 			The time that each pulse started with respect to the offset
 		</doc>
@@ -111,4 +108,3 @@
 	  </doc>
 	</field>
 </definition>
-


### PR DESCRIPTION
The exiting use at ISIS is floats. We wanted to allow ints.
NX_NUMBER sounds like a sensible compromise.
Don't think we deliberately picked NX_INT.