### PR TITLE
Fix NxTransformations matrix order

### DIFF
--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
+#
 # Copyright (C) 2014-2017 NeXus International Advisory Committee (NIAC)
-# 
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -21,11 +21,11 @@
 #
 # For further information, see http://www.nexusformat.org
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" 
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1"
 	category="base"
-	name="NXtransformations" 
+	name="NXtransformations"
 	version="1.1"
-	type="group" 
+	type="group"
 	extends="NXobject"
 	ignoreExtraGroups="true"
 	ignoreExtraFields="true"
@@ -33,61 +33,54 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	>
-	
+
 	<doc>
 		Collection of axis-based translations and rotations to describe a geometry.
 		May also contain axes that do not move and therefore do not have a transformation
 		type specified, but are useful in understanding coordinate frames within which
 		transformations are done, or in documenting important directions, such as the
 		direction of gravity.
-		
-		A nested sequence of transformations lists the offset and rotation steps 
+
+		A nested sequence of transformations lists the offset and rotation steps
 		needed to describe the position and orientation of any movable or fixed device.
-		
+
 		There will be one or more transformations (axes) defined by one or more fields
 		for each transformation.  The all-caps name ``AXISNAME`` designates the
 		particular axis generating a transformation (e.g. a rotation axis or a translation
 		axis or a general axis).   The attribute ``units="NX_TRANSFORMATION"`` designates the
 		units will be appropriate to the ``transformation_type`` attribute:
-		
+
 		* ``NX_LENGTH`` for ``translation``
-		* ``NX_ANGLE`` for ``rotation`` 
+		* ``NX_ANGLE`` for ``rotation``
 		* ``NX_UNITLESS`` for axes for which no transformation type is specified
-		
+
 		This class will usually contain all axes of a sample stage or goniometer or
 		a detector.  The NeXus default McSTAS coordinate frame is assumed, but additional
 		useful coordinate axes may be defined by using axes for which no transformation
 		type has been specified.
-		
+
 		The entry point (``depends_on``) will be outside of this class and point to a
-		field in here. Following the chain may also require following ``depends_on`` 
+		field in here. Following the chain may also require following ``depends_on``
 		links to transformations outside, for example to a common base table.  If
 		a relative path is given, it is relative to the group enclosing the ``depends_on``
 		specification.
-		
+
 		For a chain of three transformations, where :math:`T_1` depends on :math:`T_2`
 		and that in turn depends on :math:`T_3`, the final transformation :math:`T_f` is
-		
-		.. math::
-		
-		T_f = T_3 T_2 T_1
-		
+
+		.. math:: T_f = T_3 T_2 T_1
+
 		In explicit terms, the transformations are a subset of affine transformations
 		expressed as 4x4 matrices that act on homogeneous coordinates, :math:`w=(x,y,z,1)^T`.
-		
+
 		For rotation and translation,
-		
-		.. math::
-		
-		T_r &amp;= \left( \begin{matrix} R  &amp; o \\
-		0_3 &amp; 1 \end{matrix} \right) \\
-		T_t &amp;= \left( \begin{matrix} I_3  &amp; t + o \\
-		0_3 &amp; 1 \end{matrix} \right)
-		
+
+		.. math:: T_r &amp;= \begin{pmatrix} R &amp; o \\ 0_3 &amp; 1 \end{pmatrix} \\ T_t &amp;= \begin{pmatrix} I_3  &amp; t + o \\ 0_3 &amp; 1 \end{pmatrix}
+
 		where :math:`R` is the usual 3x3 rotation matrix, :math:`o` is an offset vector,
 		:math:`0_3` is a row of 3 zeros, :math:`I_3` is the 3x3 identity matrix and
 		:math:`t` is the translation vector.
-		
+
 		:math:`o` is given the ``offset`` attribute, :math:`t` is given by the ``vector``
 		attribute multiplied by the field value, and :math:`R` is defined as a rotation
 		about an axis in the direction of ``vector``, of angle of the field value.
@@ -95,12 +88,12 @@
 	<field name="AXISNAME" nameType="any" units="NX_TRANSFORMATION" type="NX_NUMBER" maxOccurs="unbounded">
 		<doc>
 			Units need to be appropriate for translation or rotation
-			
+
 			The name of this field is not forced.  The user is free to use any name
 			that does not cause confusion.  When using more than one ``AXISNAME`` field,
 			make sure that each field name is unique in the same group, as required
 			by HDF5.
-			
+
 			The values given should be the start points of exposures for the corresponding
 			frames.  The end points should be given in ``AXISNAME_end``.
 		</doc>
@@ -109,7 +102,7 @@
 				The transformation_type may be ``translation``, in which case the
 				values are linear displacements along the axis, ``rotation``,
 				in which case the values are angular rotations around the axis.
-				
+
 				If this attribute is omitted, this is an axis for which there
 				is no motion to be specifies, such as the direction of gravity,
 				or the direction to the source, or a basis vector of a
@@ -132,7 +125,7 @@
 			</doc>
 			<dimensions rank="1">
 				<dim index="1" value="3" />
-			</dimensions> 
+			</dimensions>
 		</attribute>
 		<attribute name="offset" type="NX_NUMBER">
 			<doc>
@@ -140,7 +133,7 @@
 			</doc>
 			<dimensions rank="1">
 				<dim index="1" value="3" />
-			</dimensions> 
+			</dimensions>
 		</attribute>
 		<attribute name="offset_units" type="NX_CHAR">
 			<doc>
@@ -158,7 +151,7 @@
 		<doc>
 			``AXISNAME_end`` is a placeholder for a name constructed from the actual
 			name of an axis to which ``_end`` has been appended.
-			
+
 			The values in this field are the end points of the motions that start
 			at the corresponding positions given in the ``AXISNAME`` field.
 		</doc>
@@ -167,12 +160,12 @@
 		<doc>
 			``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
 			name of an axis to which ``_increment_set`` has been appended.
-			
+
 			The value of this optional field is the intended average range through which
 			the corresponding axis moves during the exposure of a frame.  Ideally, the
 			value of this field added to each value of ``AXISNAME`` would agree with the
 			corresponding values of ``AXISNAME_end``, but there is a possibility of significant
-			differences.  Use of ``AXISNAME_end`` is recommended. 
+			differences.  Use of ``AXISNAME_end`` is recommended.
 		</doc>
 	</field>
 </definition>

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -65,8 +65,8 @@
 		a relative path is given, it is relative to the group enclosing the ``depends_on``
 		specification.
 
-		For a chain of three transformations, where :math:`T_1` depends on :math:`T_2`
-		and that in turn depends on :math:`T_3`, the final transformation :math:`T_f` is
+		For a chain of three transformations, where :math:`T_3` depends on :math:`T_2`
+		and that in turn depends on :math:`T_1`, the final transformation :math:`T_f` is
 
 		.. math:: T_f = T_3 T_2 T_1
 


### PR DESCRIPTION
If a transformation depends on another, the one it depends on should be applied first and should therefore be further to the right in the expression for T_f. Therefore, in the NxTransformation documentation this does not look correct to me:

> For a chain of three transformations, where T_1 depends on T_2 and that in turn depends on T_3, the final transformation T_f is
T_f = T_3 T_2 T_1

 Please check I have not misunderstood the existing documentation before merging!