### PR TITLE
NXptycho contributed definition

### DIFF
--- a/contributed_definitions/NXbeam.nxdl.xml
+++ b/contributed_definitions/NXbeam.nxdl.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+# 
+# Copyright (C) 2008-2018 NeXus International Advisory Committee (NIAC)
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" category="base"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
+    name="NXbeam"
+    version="1.0"
+    type="group" extends="NXobject">
+
+    <doc>
+        Properties of the neutron or X-ray beam at a given location. 
+        
+        It will be referenced
+        by beamline component groups within the :ref:`NXinstrument` group or by the :ref:`NXsample` group. Note
+        that variables such as the incident energy could be scalar values or arrays. This group is
+        especially valuable in storing the results of instrument simulations in which it is useful
+        to specify the beam profile, time distribution etc. at each beamline component. Otherwise,
+        its most likely use is in the :ref:`NXsample` group in which it defines the results of the neutron
+        scattering by the sample, e.g., energy transfer, polarizations. </doc>
+    <field name="distance" type="NX_FLOAT" units="NX_LENGTH">
+        <doc>Distance from sample</doc>
+    </field>
+    <field name="incident_energy" type="NX_FLOAT" units="NX_ENERGY">
+        <doc>Energy on entering beamline component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="final_energy" type="NX_FLOAT" units="NX_ENERGY">
+        <doc>Energy on leaving beamline component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="energy_transfer" type="NX_FLOAT" units="NX_ENERGY">
+        <doc>Energy change caused by beamline component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="incident_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH">
+        <doc>Wavelength on entering beamline component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="incident_wavelength_spread" type="NX_FLOAT" units="NX_WAVELENGTH">
+        <doc>Wavelength spread FWHM on entering component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="incident_beam_divergence" type="NX_FLOAT" units="NX_ANGLE">
+        <doc>Divergence of beam entering this component</doc>
+        <dimensions rank="2"><!-- [2,:] -->
+            <dim index="1" value="2"/>
+            <dim index="2" value="j"/>
+        </dimensions>
+    </field>
+    <field name="extent" type="NX_FLOAT" units="NX_LENGTH">
+        <doc>Size of the beam entering this component</doc>
+        <dimensions rank="2"><!-- [2,:] -->
+            <dim index="1" value="2"/>
+            <dim index="2" value="j"/>
+        </dimensions>
+    </field>
+    <field name="final_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH">
+        <doc>Wavelength on leaving beamline component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="incident_polarization" type="NX_FLOAT" units="NX_ANY">
+        <doc>Polarization vector on entering beamline component</doc>
+        <dimensions rank="2"><!-- [2,:] -->
+            <dim index="1" value="2"/>
+            <dim index="2" value="j"/>
+        </dimensions>
+    </field>
+    <field name="final_polarization" type="NX_FLOAT" units="NX_ANY">
+        <doc>Polarization vector on leaving beamline component</doc>
+        <dimensions rank="2"><!-- [2,:] -->
+            <dim index="1" value="2"/>
+            <dim index="2" value="j"/>
+        </dimensions>
+    </field>
+    <field name="final_wavelength_spread" type="NX_FLOAT" units="NX_WAVELENGTH">
+        <doc>Wavelength spread FWHM of beam leaving this component</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <field name="final_beam_divergence" type="NX_FLOAT" units="NX_ANGLE">
+        <doc>Divergence FWHM of beam leaving this component</doc>
+        <dimensions rank="2"><!-- [2,:] -->
+            <dim index="1" value="2"/>
+            <dim index="2" value="j"/>
+        </dimensions>
+    </field>
+    <field name="flux" type="NX_FLOAT" units="NX_FLUX">
+        <doc>flux incident on beam plane area</doc>
+        <dimensions rank="1">
+            <dim index="1" value="i"/>
+        </dimensions>
+    </field>
+    <group type="NXdata">
+        <doc>
+            Distribution of beam with respect to relevant variable e.g. wavelength. This is mainly
+            useful for simulations which need to store plottable information at each beamline
+            component.</doc>
+    </group>
+</definition>

--- a/contributed_definitions/NXptycho.nxdl.xml
+++ b/contributed_definitions/NXptycho.nxdl.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
 <!-- 
   # NeXus - Neutron and X-ray Common Data Format
@@ -21,27 +21,51 @@
   #
   # For further information, see http://www.nexusformat.org 
 -->
-<definition name="NXptycho" extends="NXobject" type="group"
-    category="application"
-    xmlns="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@"
+<definition xmlns="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@ ../nxdl.xsd"
+    name="NXptycho" 
+    category="application"
     version="1.1"
+    type="group"
+    extends="NXobject" 
     >
     <symbols>
-        <doc>These symbols will be used below to coordinate the shapes of the datasets.</doc>
+        <doc>
+            These symbols will be used below to coordinate the shapes of the datasets.
+        </doc>
+
         <symbol name="npts_x">
-        	<doc>The number of points in the x direction</doc></symbol>
+        	<doc>
+                The number of points in the x direction
+            </doc>
+        </symbol>
         
         <symbol name="npts_y">
-        	<doc>Number of points in the y direction. </doc></symbol>
+        	<doc>
+                Number of points in the y direction. 
+            </doc>
+        </symbol>
+
         <symbol name="npts_theta">
-        	<doc>Number of rotation steps</doc></symbol>
+        	<doc>
+                Number of rotation steps
+            </doc>
+        </symbol>
+
         <symbol name="frame_size_x">
-        	<doc>Number of detector pixels in x</doc></symbol>
+        	<doc>
+                Number of detector pixels in x
+            </doc>
+        </symbol>
+
         <symbol name="frame_size_y">
-        	<doc>Number of detector pixels in y</doc>
-        </symbol></symbols>
+        	<doc>
+                Number of detector pixels in y
+            </doc>
+        </symbol>
+    </symbols>
+
     <doc>
           Application definition for a ptychography experiment, which will contain the values 
           for the coherence (NXsource), the energy (NXmonochromator), the focussing optics 
@@ -49,82 +73,98 @@
           (flatfield, mask, detector distance etc..) and the data. THe sample positioners are   
           NXpositioners.
     </doc>
+
     <group type="NXentry" name="entry">
-    	<field name="title" minOccurs=0 maxOccurs=1></field>
-    	<field name="start_time" type="NX_DATE_TIME" minOccurs=0 maxOccurs=1></field>
-    	<field name="end_time" type="NX_DATE_TIME" minOccurs=0 maxOccurs=1></field>
-    	<field name="definition">
-    		<doc>Official NeXus NXDL schema to which this file conforms</doc>
+    	<field name="title" minOccurs="0" maxOccurs="1"/>
+    	<field name="start_time" type="NX_DATE_TIME" minOccurs="0" maxOccurs="1"/>
+    	<field name="end_time" type="NX_DATE_TIME" minOccurs="0" maxOccurs="1"/>
+    	<field name="definition" type="NX_CHAR" minOccurs="1" maxOccurs="1">
+    		<doc>
+                Official NeXus NXDL schema to which this file conforms
+            </doc>
+
     		<enumeration>
-    			<item value="NXptycho"></item>
-    		</enumeration></field>
-    	<group type="NXinstrument" name="instrument">
-    		<group type="NXsource" minOccurs=0 maxOccurs=1
-    			name="coherence">
-    			<field name="sigma_x" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
-    			<field name="sigma_y" type="NX_FLOAT" minOccurs=0 maxOccurs=1"></field>
+    			<item value="NXptycho"/>
+    		</enumeration>
+        </field>
+
+    	<group type="NXinstrument" name="instrument" minOccurs="1" maxOccurs="1">
+    		<group type="NXsource" minOccurs="0" maxOccurs="1" name="coherence">
+    			<field name="sigma_x" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
+    			<field name="sigma_y" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
     		</group>
-    		<group type="NXmonochromator" name="Monochromator">
-    			<field name="energy" type="NX_FLOAT" minOccurs=1 maxOccurs=1><!--We absolutely must have this information!--></field>
-    			<field name="energy_error" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
+    		<group type="NXmonochromator" name="monochromator">
+    			<field name="energy" type="NX_FLOAT" minOccurs="1" maxOccurs="1"/>
+    			<field name="energy_error" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
     		</group>
     		<group type="NXfresnel_zone_plate" name="fresnel_zone_plate">
-    			<field name="outer_diameter" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
-    			<field name="outermost_zone_width" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
-    			<field name="distance_to_sample" type="NX_FLOAT" minOccurs=0 maxOccurs=1><!--This is new and not in the schema!-->
-    			</field>
+    			<field name="outer_diameter" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
+    			<field name="outermost_zone_width" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
+    			<field name="distance_to_sample" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
     		</group>
     		<group type="NXdetector" name="detector">
-    			<field name="data" type="NX_INT" signal=1 minOccurs=1 maxOccurs=1>
+    			<field name="data" type="NX_INT" signal="1" minOccurs="1" maxOccurs="1">
     				<dimensions rank="4">
-    					<dim index="1" value="npts_x" />
-    					<dim index="2" value="npts_x" />
+    					<dim index="1" value="npts_x"/>
+    					<dim index="2" value="npts_x"/>
     					<dim index="3" value="frame_size_x"/>
     					<dim index="4" value="frame_size_y"/>
-    					</dimensions>
-    			</field>
-    			<field name="x_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs=1></field><field name="y_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1"></field>
-    			<field name="distance" type="NX_FLOAT" units="NX_LENGTH" minOccurs=1 maxOccurs=1><!--We must have this!--><doc>The distance between the detector and the sample</doc></field>
-    			<field name="flatfield" type="NX_FLOAT" minOccurs=0 maxOccurs=1>
-    				<dimensions rank="2">
-    					<dim index="1" value="frame_size_x" /><dim
-    						index="2" value="frame_size_y" name="sample"/>
     				</dimensions>
     			</field>
-    			<field name="darkfield" type="NX_float" minOccurs=0 maxOccurs=1>
+    			<field name="x_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1"/>
+                <field name="y_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1"/>
+    			<field name="distance" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
+                    <doc>
+                        The distance between the detector and the sample
+                    </doc>
+                </field>
+    			<field name="flatfield" type="NX_FLOAT" minOccurs="0" maxOccurs="1">
+    				<dimensions rank="2">
+    					<dim index="1" value="frame_size_x"/>
+                        <dim index="2" value="frame_size_y" name="sample"/>
+    				</dimensions>
+    			</field>
+    			<field name="darkfield" type="NX_float" minOccurs="0" maxOccurs="1">
     			    <dimensions rank="2">
-    					<dim index="1" value="frame_size_x" ></dim><dim
-    						index="2" value="frame_size_y" />
-    				</dimensions></field><!--Can be scanned as appropriate in theta,energy etc...-->
-    				<field
-    				name="pixel_mask" type="NX_INT" minOccurs=1 maxOccurs=1>
-	<dimensions rank="2">
-		<dim index="1" value="frame_size_x" />
-		<dim index="2" value="frame_size_y" />
-	</dimensions>
-</field>
+    					<dim index="1" value="frame_size_x"/>
+                        <dim index="2" value="frame_size_y"/>
+    				</dimensions>
+                </field>
+    			<field name="pixel_mask" type="NX_INT" minOccurs="1" maxOccurs="1">
+        	        <dimensions rank="2">
+                		<dim index="1" value="frame_size_x"/>
+                		<dim index="2" value="frame_size_y"/>
+                	</dimensions>
+                </field>
     		</group>
+
     		<group type="NXsample">
-    			<field name="name",type="NX_CHAR"></field>
-    			<field name="description",type="NX_CHAR"></field>
-    			<group type="NXpositioner" name="positions" minOccurs=1 maxOccurs=1>
+    			<field name="name" type="NX_CHAR"/>
+    			<field name="description" type="NX_CHAR"/>
+    			<group type="NXpositioner" name="positions" minOccurs="1" maxOccurs="1">
     				<field name="lab_x" type="NX_FLOAT">
     					<dimensions rank="1">
-    						<dim index="1" value="npts_x" />
-    					</dimensions
-    				</field>
+    						<dim index="1" value="npts_x"/>
+    					</dimensions>
+                    </field>
     				<field name="lab_y" type="NX_FLOAT">
     					<dimensions rank="1">
-    						<dim index="1" value="npts_y" />
-    					</dimensions
+    						<dim index="1" value="npts_y"/>
+    					</dimensions>
     				</field>
     			</group>
     		</group>
-    		<group name="reference" type="NXlog" minOccurs=0 maxOccurs=1></group>
+
+    		<group name="reference" type="NXlog" minOccurs="0" maxOccurs="1">
     			<field name="ion chamber" type="NX_FLOAT">
     				<dimensions rank="2">
-    					<dim index="1" value="npts_x" />
-    					<dim index="2" value="npts_y" />
+    					<dim index="1" value="npts_x"/>
+    					<dim index="2" value="npts_y"/>
     				</dimensions>
-    			</field>
-    	</group></definition>
+                </field>
+    	    </group>
+        </group>
+    </group>
+</definition>
+
+

--- a/contributed_definitions/NXptycho.nxdl.xml
+++ b/contributed_definitions/NXptycho.nxdl.xml
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<!-- 
+  # NeXus - Neutron and X-ray Common Data Format
+  # 
+  # Copyright (C) 2014-2015 NeXus International Advisory Committee (NIAC)
+  # 
+  # This library is free software; you can redistribute it and/or
+  # modify it under the terms of the GNU Lesser General Public
+  # License as published by the Free Software Foundation; either
+  # version 3 of the License, or (at your option) any later version. 
+  # 
+  # This library is distributed in the hope that it will be useful,
+  # but WITHOUT ANY WARRANTY; without even the implied warranty of
+  # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  # Lesser General Public License for more details.
+  #
+  # You should have received a copy of the GNU Lesser General Public
+  # License along with this library; if not, write to the Free Software
+  # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  #
+  # For further information, see http://www.nexusformat.org 
+-->
+<definition name="NXptycho" extends="NXobject" type="group"
+    category="application"
+    xmlns="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@ ../nxdl.xsd"
+    version="1.1"
+    >
+    <symbols>
+        <doc>These symbols will be used below to coordinate the shapes of the datasets.</doc>
+        <symbol name="npts_x">
+        	<doc>The number of points in the x direction</doc></symbol>
+        
+        <symbol name="npts_y">
+        	<doc>Number of points in the y direction. </doc></symbol>
+        <symbol name="npts_theta">
+        	<doc>Number of rotation steps</doc></symbol>
+        <symbol name="frame_size_x">
+        	<doc>Number of detector pixels in x</doc></symbol>
+        <symbol name="frame_size_y">
+        	<doc>Number of detector pixels in y</doc>
+        </symbol></symbols>
+    <doc>
+          Application definition for a ptychography experiment, which will contain the values 
+          for the coherence (NXsource), the energy (NXmonochromator), the focussing optics 
+          (NXfresnel_zone_plate), and their distance relative to the sample. The detector info
+          (flatfield, mask, detector distance etc..) and the data. THe sample positioners are   
+          NXpositioners.
+    </doc>
+    <group type="NXentry" name="entry">
+    	<field name="title" minOccurs=0 maxOccurs=1></field>
+    	<field name="start_time" type="NX_DATE_TIME" minOccurs=0 maxOccurs=1></field>
+    	<field name="end_time" type="NX_DATE_TIME" minOccurs=0 maxOccurs=1></field>
+    	<field name="definition">
+    		<doc>Official NeXus NXDL schema to which this file conforms</doc>
+    		<enumeration>
+    			<item value="NXptycho"></item>
+    		</enumeration></field>
+    	<group type="NXinstrument" name="instrument">
+    		<group type="NXsource" minOccurs=0 maxOccurs=1
+    			name="coherence">
+    			<field name="sigma_x" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
+    			<field name="sigma_y" type="NX_FLOAT" minOccurs=0 maxOccurs=1"></field>
+    		</group>
+    		<group type="NXmonochromator" name="Monochromator">
+    			<field name="energy" type="NX_FLOAT" minOccurs=1 maxOccurs=1><!--We absolutely must have this information!--></field>
+    			<field name="energy_error" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
+    		</group>
+    		<group type="NXfresnel_zone_plate" name="fresnel_zone_plate">
+    			<field name="outer_diameter" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
+    			<field name="outermost_zone_width" type="NX_FLOAT" minOccurs=0 maxOccurs=1></field>
+    			<field name="distance_to_sample" type="NX_FLOAT" minOccurs=0 maxOccurs=1><!--This is new and not in the schema!-->
+    			</field>
+    		</group>
+    		<group type="NXdetector" name="detector">
+    			<field name="data" type="NX_INT" signal=1 minOccurs=1 maxOccurs=1>
+    				<dimensions rank="4">
+    					<dim index="1" value="npts_x" />
+    					<dim index="2" value="npts_x" />
+    					<dim index="3" value="frame_size_x"/>
+    					<dim index="4" value="frame_size_y"/>
+    					</dimensions>
+    			</field>
+    			<field name="x_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs=1></field><field name="y_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1"></field>
+    			<field name="distance" type="NX_FLOAT" units="NX_LENGTH" minOccurs=1 maxOccurs=1><!--We must have this!--><doc>The distance between the detector and the sample</doc></field>
+    			<field name="flatfield" type="NX_FLOAT" minOccurs=0 maxOccurs=1>
+    				<dimensions rank="2">
+    					<dim index="1" value="frame_size_x" /><dim
+    						index="2" value="frame_size_y" name="sample"/>
+    				</dimensions>
+    			</field>
+    			<field name="darkfield" type="NX_float" minOccurs=0 maxOccurs=1>
+    			    <dimensions rank="2">
+    					<dim index="1" value="frame_size_x" ></dim><dim
+    						index="2" value="frame_size_y" />
+    				</dimensions></field><!--Can be scanned as appropriate in theta,energy etc...-->
+    				<field
+    				name="pixel_mask" type="NX_INT" minOccurs=1 maxOccurs=1>
+	<dimensions rank="2">
+		<dim index="1" value="frame_size_x" />
+		<dim index="2" value="frame_size_y" />
+	</dimensions>
+</field>
+    		</group>
+    		<group type="NXsample">
+    			<field name="name",type="NX_CHAR"></field>
+    			<field name="description",type="NX_CHAR"></field>
+    			<group type="NXpositioner" name="positions" minOccurs=1 maxOccurs=1>
+    				<field name="lab_x" type="NX_FLOAT">
+    					<dimensions rank="1">
+    						<dim index="1" value="npts_x" />
+    					</dimensions
+    				</field>
+    				<field name="lab_y" type="NX_FLOAT">
+    					<dimensions rank="1">
+    						<dim index="1" value="npts_y" />
+    					</dimensions
+    				</field>
+    			</group>
+    		</group>
+    		<group name="reference" type="NXlog" minOccurs=0 maxOccurs=1></group>
+    			<field name="ion chamber" type="NX_FLOAT">
+    				<dimensions rank="2">
+    					<dim index="1" value="npts_x" />
+    					<dim index="2" value="npts_y" />
+    				</dimensions>
+    			</field>
+    	</group></definition>

--- a/contributed_definitions/NXptycho.nxdl.xml
+++ b/contributed_definitions/NXptycho.nxdl.xml
@@ -21,13 +21,13 @@
   #
   # For further information, see http://www.nexusformat.org 
 -->
-<definition xmlns="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@"
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/@NXDL_RELEASE@ ../nxdl.xsd"
+    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     name="NXptycho" 
-    category="application"
-    version="1.1"
+    category="contributed"
     type="group"
+    version="0.1"
     extends="NXobject" 
     >
     <symbols>
@@ -46,13 +46,6 @@
                 Number of points in the y direction. 
             </doc>
         </symbol>
-
-        <symbol name="npts_theta">
-        	<doc>
-                Number of rotation steps
-            </doc>
-        </symbol>
-
         <symbol name="frame_size_x">
         	<doc>
                 Number of detector pixels in x
@@ -67,15 +60,17 @@
     </symbols>
 
     <doc>
-          Application definition for a ptychography experiment, which will contain the values 
-          for the coherence (NXsource), the energy (NXmonochromator), the focussing optics 
-          (NXfresnel_zone_plate), and their distance relative to the sample. The detector info
-          (flatfield, mask, detector distance etc..) and the data. THe sample positioners are   
-          NXpositioners.
+          Application definition for a ptychography experiment. This is compatible with CXI from version 1.6 (discussed with Filippe Maia) if this application definition
+          is put at the top "entry" level. Above this a "cxi_version" field should be defined. The CXI format is name based, rather than class based, and so it is important
+          to pay attention to the naming convention to be CXI compatible. There are duplications due to the format merger. These should be achieved by SoftLinks, 
+          with hdf5 Virtual Dataset being used to restructure any data that needs to be remapped. 
+          
+          An example here is that CXI expects the data to always to have shape (npts_x*npts_y, frame_size_x, frame_size_y). For nexus this is only true for arbitrary scan paths
+          with raster format scans taking shape (npts_x, npts_y, frame_size_x, frame_size_y).
     </doc>
 
-    <group type="NXentry" name="entry">
-    	<field name="title" minOccurs="0" maxOccurs="1"/>
+    <group type="NXentry" name="entry_1">
+    	<field name="title" minOccurs="1" maxOccurs="1"/>
     	<field name="start_time" type="NX_DATE_TIME" minOccurs="0" maxOccurs="1"/>
     	<field name="end_time" type="NX_DATE_TIME" minOccurs="0" maxOccurs="1"/>
     	<field name="definition" type="NX_CHAR" minOccurs="1" maxOccurs="1">
@@ -87,84 +82,142 @@
     			<item value="NXptycho"/>
     		</enumeration>
         </field>
-
-    	<group type="NXinstrument" name="instrument" minOccurs="1" maxOccurs="1">
-    		<group type="NXsource" minOccurs="0" maxOccurs="1" name="coherence">
-    			<field name="sigma_x" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
-    			<field name="sigma_y" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
+    	<group type="NXinstrument" name="instrument_1" minOccurs="1" maxOccurs="1">
+    		<group type="NXsource" minOccurs="1" maxOccurs="1" name="source_1">
+    			<field name="name" type="NX_CHAR" minOccurs="1" maxOccurs="1"/>
+    			<field name="energy" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
+    				<doc>
+    					This is the energy of the machine, not the beamline.
+    				</doc>
+    			</field>
+    			<field name="probe" type="NX_FLOAT" minOccurs="1" maxOccurs="1"/>
+    			<field name="type" type="NX_FLOAT" minOccurs="1" maxOccurs="1"/>
     		</group>
-    		<group type="NXmonochromator" name="monochromator">
-    			<field name="energy" type="NX_FLOAT" minOccurs="1" maxOccurs="1"/>
-    			<field name="energy_error" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
+    		<group type="NXbeam" name="beam_1" minOccurs="1" maxOccurs="1">
+    			<field name="energy" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    			</field>
+    			<field name="extent" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    			</field>
+    			<field name="incident_beam_divergence" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    			</field>
+    			<field name="incident_beam_energy" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    			</field>
+    			<field name="incident_energy_spread" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    			</field>
     		</group>
-    		<group type="NXfresnel_zone_plate" name="fresnel_zone_plate">
-    			<field name="outer_diameter" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
-    			<field name="outermost_zone_width" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
-    			<field name="distance_to_sample" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/>
-    		</group>
-    		<group type="NXdetector" name="detector">
+    		<group type="NXdetector" name="detector_1" minOccurs="1" maxOccurs="1">
+    			<attribute name="axes" type="NX_CHAR">
+    				<doc>
+    					should have value "[, data]"
+    				</doc>
+    			</attribute>
+    			<attribute name="signal" type="NX_CHAR">
+    				<doc>
+    					should have value "data"
+    				</doc>
+    			</attribute>
+    			<group type="NXtransformations" name="transformations">
+    				<field name="vector" type="NX_NUMBER" minOccurs="1" maxOccurs="1"/>
+    			</group>
+    			<field name="translation" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
+    				<doc>
+    					This is an array of shape (npts_x*npts_y, 3) and can be a Virtual Dataset of x and y
+    				</doc>
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    				<attribute name="axes" optional="false" type="NX_CHAR">
+    					<doc>
+    						this should take the value "translation:$slowaxisname:$fastaxisname"
+    					</doc>
+    				</attribute>
+    				<attribute name="interpretation" optional="false" type="NX_CHAR">
+    					<doc>
+    						This should be "image"
+    					</doc>
+    				</attribute>
+    			</field>  			
     			<field name="data" type="NX_INT" signal="1" minOccurs="1" maxOccurs="1">
-    				<dimensions rank="4">
+    				<dimensions rank="3 for arbitrary scan, 4 for raster">
     					<dim index="1" value="npts_x"/>
-    					<dim index="2" value="npts_x"/>
+    					<dim index="2" value="npts_y"/>
     					<dim index="3" value="frame_size_x"/>
     					<dim index="4" value="frame_size_y"/>
     				</dimensions>
     			</field>
-    			<field name="x_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1"/>
-                <field name="y_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1"/>
+    			<link name="data_1" target="/NXentry/NXinstrument/NXdetector/data">
+    			 	<doc>
+                		This data must always have shape (npts_x*npts_y, frame_size_x, frame_size_y) regardless 
+                		of the scan pattern. Use hdf5 virtual dataset to achieve this.
+            		</doc>
+    			</link>
+    			<field name="x_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
+    			</field>
+                <field name="y_pixel_size" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
+                	<attribute name="units" type="NX_CHAR" optional="false"/>
+                </field>
     			<field name="distance" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
-                    <doc>
+    			    <doc>
                         The distance between the detector and the sample
                     </doc>
+    				<attribute name="units" type="NX_CHAR" optional="false"/>
                 </field>
-    			<field name="flatfield" type="NX_FLOAT" minOccurs="0" maxOccurs="1">
-    				<dimensions rank="2">
-    					<dim index="1" value="frame_size_x"/>
-                        <dim index="2" value="frame_size_y" name="sample"/>
-    				</dimensions>
-    			</field>
-    			<field name="darkfield" type="NX_float" minOccurs="0" maxOccurs="1">
-    			    <dimensions rank="2">
-    					<dim index="1" value="frame_size_x"/>
-                        <dim index="2" value="frame_size_y"/>
-    				</dimensions>
+                <field name="beam_center_x" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
+                	<attribute name="units" type="NX_CHAR" optional="false"/>
                 </field>
-    			<field name="pixel_mask" type="NX_INT" minOccurs="1" maxOccurs="1">
-        	        <dimensions rank="2">
-                		<dim index="1" value="frame_size_x"/>
-                		<dim index="2" value="frame_size_y"/>
-                	</dimensions>
+                <field name="beam_center_y" type="NX_FLOAT" units="NX_LENGTH" minOccurs="1" maxOccurs="1">
+                	<attribute name="units" type="NX_CHAR" optional="false"/>
                 </field>
     		</group>
-
-    		<group type="NXsample">
-    			<field name="name" type="NX_CHAR"/>
-    			<field name="description" type="NX_CHAR"/>
-    			<group type="NXpositioner" name="positions" minOccurs="1" maxOccurs="1">
-    				<field name="lab_x" type="NX_FLOAT">
-    					<dimensions rank="1">
-    						<dim index="1" value="npts_x"/>
-    					</dimensions>
-                    </field>
-    				<field name="lab_y" type="NX_FLOAT">
-    					<dimensions rank="1">
-    						<dim index="1" value="npts_y"/>
-    					</dimensions>
-    				</field>
-    			</group>
-    		</group>
-
-    		<group name="reference" type="NXlog" minOccurs="0" maxOccurs="1">
-    			<field name="ion chamber" type="NX_FLOAT">
-    				<dimensions rank="2">
+			<group type="NXmonitor" minOccurs="1" maxOccurs="1">
+				<field name="data" type="NX_FLOAT">
+				    <dimensions rank="1 for arbitrary scan, 2 for raster">
     					<dim index="1" value="npts_x"/>
     					<dim index="2" value="npts_y"/>
-    				</dimensions>
-                </field>
-    	    </group>
+    				</dimensions> 
+				</field>
+			</group>
+			</group>
         </group>
-    </group>
+		<group type="NXdata" name="data_1" minOccurs="1" maxOccurs="1">
+			<attribute name="axes" type="NX_CHAR" optional="false">
+				<doc>
+					This should be "[x,.]" for arbitrary scanning patterns, and "[x,.,.]" for raster
+				</doc>
+			</attribute>
+			<attribute name="signal" type="NX_CHAR" optional="false">
+				<doc>
+					This should be "data"
+				</doc>
+			</attribute>
+			<link name="data" target="/NXentry/NXinstrument/NXdetector/data"/>
+			<link name="translation" target="/NXentry/NXinstrument/NXdetector/translation"/>
+			<link name="x" target="/NXentry/NXsample/NXtransformations/x"/>
+			<link name="y" target="/NXentry/NXsample/NXtransformations/y"/>
+			<field name="x_indices" type="NX_CHAR"/>
+			<field name="y_indices" type="NX_CHAR"/>			
+		</group>
+		
+		<group type="NXsample" name="sample_1" minOccurs="1" maxOccurs="1">
+			<field name="name" type="NX_CHAR" minOccurs="0" maxOccurs="1"/>
+			<field name="transformations" type="NXtransformations">
+				<doc>
+					This must contain two fields with the x and y motors that are linked via the 
+					dependency tree according to the real-life motor layout dependency.
+					For raster scans x and y will have shape (npts_x, npts_y)
+					For arbitrary scans x and y will be (npts_x*npts_y,)
+					An attribute with the units for each motor is required.					
+				</doc>
+				<attribute name="vector" optional="false" type="NX_NUMBER"/>
+			</field>
+			<group type="NXgroup" name="geometry_1" minOccurs="1" maxOccurs="1">
+				<link name="translation" target="/NXentry/NXinstrument/NXdetector/translation"/>
+			</group>
+		</group>
 </definition>
 
 


### PR DESCRIPTION
Hi,

This contains a applications definition for NXptycho for ptychography experiments. It's come about after talking to the CXI (another file format for coherent imaging experiments) community and merges the two so that NXptycho is CXI compatible. We are starting to use this at Diamond now on multiple beamlines.

I'll also be adding a PR to nexusformat/exampledata with some example files for you to look through.

Let me know if something wasn't clear in the xml and I can change it, I wasn't sure at which level I needed to specify things, but hopefully the doc makes it clear.

I needed to add an extra field to NXbeam so thats included here too. It's just information about the extent of the beam, which is useful for ptychography.

Aaron
@markbasham 
