### PR TITLE
Fix NXtransformation example

### DIFF
--- a/manual/source/examples/euler-cif.txt
+++ b/manual/source/examples/euler-cif.txt
@@ -1,18 +1,19 @@
   sample:NXsample
-    rotation_angle
-      @transformation_type=rotation
-      @vector=0,1,0
-      @offset=0,0,0
-      @depends_on=.
-    chi
-      @transformation_type=rotation
-      @vector=0,0,1
-      @offset=0,0,0
-      @depends_on=rotation_angle
-    phi
-      @transformation_type=rotation
-      @vector=0,1,0
-      @offset=0,0,0
-      @depends_on=chi
-    depends_on 
+    transforms:NXtransformation
+      rotation_angle
+        @transformation_type=rotation
+        @vector=0,1,0
+        @offset=0,0,0
+        @depends_on=.
+      chi
+        @transformation_type=rotation
+        @vector=0,0,1
+        @offset=0,0,0
+        @depends_on=rotation_angle
       phi
+        @transformation_type=rotation
+        @vector=0,1,0
+        @offset=0,0,0
+        @depends_on=chi
+      depends_on 
+        phi

--- a/manual/source/examples/euler-cif.txt
+++ b/manual/source/examples/euler-cif.txt
@@ -1,5 +1,5 @@
   sample:NXsample
-    transforms:NXtransformation
+    transforms:NXtransformations
       rotation_angle
         @transformation_type=rotation
         @vector=0,1,0

--- a/manual/source/examples/euler-cif.txt
+++ b/manual/source/examples/euler-cif.txt
@@ -16,4 +16,4 @@
         @offset=0,0,0
         @depends_on=chi
     depends_on 
-      phi
+      transforms/phi

--- a/manual/source/examples/euler-cif.txt
+++ b/manual/source/examples/euler-cif.txt
@@ -15,5 +15,5 @@
         @vector=0,1,0
         @offset=0,0,0
         @depends_on=chi
-      depends_on 
-        phi
+    depends_on 
+      phi


### PR DESCRIPTION
Fixes #643 

According to http://download.nexusformat.org/sphinx/classes/base_classes/NXtransformations.html transformation axes should be fields of an NXtransformations group, not direct fields of the component to which the transformations apply. This fixes the example shown on the design page of the manual.

I think the `depends_on` field (not attribute) should be in the parent component rather than the `NXtransformations` group, as this results in one fewer operation required when parsing, but this should also be clarified in the documentation.