### PR TITLE
Add per-image dynamic_mask as option for NXdetector. Resolves #651.

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -382,8 +382,9 @@
 					<field name="pixel_mask" type="NX_INT" minOccurs="0">
 						<doc>
 							The 32-bit pixel mask for the detector. Can be either one mask
-							for the whole dataset (rank i, j, k) or each frame can have its own
-							mask (rank np, i, j, k).
+							for the whole dataset (i.e. an array with indices i, j) or
+							each frame can have its own mask (in which case it would be
+							an array with indices np, i, j).
 							Contains a bit field
 							for each pixel to signal dead,
 							blind or high or otherwise unwanted
@@ -423,17 +424,14 @@
 					</field>
 					<field name="dynamic_mask" type="NX_INT" >
 						<doc>
-							32-bit pixel mask for the detector, as defined by pixel_mask, but
-							here each image can have its own mask. Thus the mask shape includes
-							np as its first dimension.
-
-							Bit values are as defined for pixel_mask.
+							Additional 32-bit pixel mask for the detector, useful if a second set
+							of masks needs to be combined with pixel_mask.  Dimensionality and
+							bit values are as defined for pixel_mask.
 						</doc>
-						<dimensions rank="4">
-							<dim index="1" value="np"/>
-							<dim index="2" value="i"/>
-							<dim index="3" value="j"/>
-							<dim index="4" value="k" required="false"/>
+						<dimensions rank="dataRank">
+							<dim index="1" value="i"/>
+							<dim index="2" value="j"/>
+							<dim index="3" value="k" required="false"/>
 						</dimensions>
 					</field>
 					<field name="countrate_correction_applied" type="NX_BOOLEAN"

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -417,12 +417,12 @@
 							mask with fewer bits is permissible.
 
 							If needed, additional pixel masks can be specified by
-							including addtional entries named pixel_mask_N, where
+							including additional entries named pixel_mask_N, where
 							N is an integer. For example, a general bad pixel mask
 							could be specified in pixel_mask that indicates noisy
 							and dead pixels, and an additional pixel mask from
 							experiment-specific shadowing could be specified in
-							pixel_mask_2. The cummulative mask is the bitwise OR
+							pixel_mask_2. The cumulative mask is the bitwise OR
 							of pixel_mask and any pixel_mask_N entries.
 						</doc>
 						<dimensions rank="dataRank">

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -415,22 +415,19 @@
 
 							If the full bit depths is not required, providing a
 							mask with fewer bits is permissible.
+
+							If needed, additional pixel masks can be specified by
+							including addtional entries named pixel_mask_N, where
+							N is an integer. For example, a general bad pixel mask
+							could be specified in pixel_mask that indicates noisy
+							and dead pixels, and an additional pixel mask from
+							experiment-specific shadowing could be specified in
+							pixel_mask_2. The cummulative mask is the bitwise OR
+							of pixel_mask and any pixel_mask_N entries.
 						</doc>
 						<dimensions rank="dataRank">
 							<dim index="1" value="i" />
 							<dim index="2" value="j" />
-							<dim index="3" value="k" required="false"/>
-						</dimensions>
-					</field>
-					<field name="dynamic_mask" type="NX_INT" >
-						<doc>
-							Additional 32-bit pixel mask for the detector, useful if a second set
-							of masks needs to be combined with pixel_mask.  Dimensionality and
-							bit values are as defined for pixel_mask.
-						</doc>
-						<dimensions rank="dataRank">
-							<dim index="1" value="i"/>
-							<dim index="2" value="j"/>
 							<dim index="3" value="k" required="false"/>
 						</dimensions>
 					</field>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -421,7 +421,21 @@
 							<dim index="3" value="k" required="false"/>
 						</dimensions>
 					</field>
+					<field name="dynamic_mask" type="NX_INT" >
+						<doc>
+							32-bit pixel mask for the detector, as defined by pixel_mask, but
+							here each image can have its own mask. Thus the mask shape includes
+							np as its first dimension.
 
+							Bit values are as defined for pixel_mask.
+						</doc>
+						<dimensions rank="4">
+							<dim index="1" value="np"/>
+							<dim index="2" value="i"/>
+							<dim index="3" value="j"/>
+							<dim index="4" value="k" required="false"/>
+						</dimensions>
+					</field>
 					<field name="countrate_correction_applied" type="NX_BOOLEAN"
 						minOccurs="0">
 						<doc>

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -624,12 +624,12 @@
       mask with fewer bits is permissible.
 
       If needed, additional pixel masks can be specified by
-      including addtional entries named pixel_mask_N, where
+      including additional entries named pixel_mask_N, where
       N is an integer. For example, a general bad pixel mask
       could be specified in pixel_mask that indicates noisy
       and dead pixels, and an additional pixel mask from
       experiment-specific shadowing could be specified in
-      pixel_mask_2. The cummulative mask is the bitwise OR
+      pixel_mask_2. The cumulative mask is the bitwise OR
       of pixel_mask and any pixel_mask_N entries.
     </doc>
     <dimensions rank="2">

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -623,17 +623,14 @@
       If the full bit depths is not required, providing a
       mask with fewer bits is permissible.
 
-    </doc>
-    <dimensions rank="2">
-      <dim index="1" value="i"/>
-      <dim index="2" value="j"/>
-    </dimensions>
-  </field>
-  <field name="dynamic_mask" type="NX_INT" >
-    <doc>
-      Additional 32-bit pixel mask for the detector, useful if a second set
-      of masks needs to be combined with pixel_mask.  Dimensionality and
-      bit values are as defined for pixel_mask.
+      If needed, additional pixel masks can be specified by
+      including addtional entries named pixel_mask_N, where
+      N is an integer. For example, a general bad pixel mask
+      could be specified in pixel_mask that indicates noisy
+      and dead pixels, and an additional pixel mask from
+      experiment-specific shadowing could be specified in
+      pixel_mask_2. The cummulative mask is the bitwise OR
+      of pixel_mask and any pixel_mask_N entries.
     </doc>
     <dimensions rank="2">
       <dim index="1" value="i"/>

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -588,8 +588,9 @@
   <field name="pixel_mask" type="NX_INT" >
     <doc>
       The 32-bit pixel mask for the detector. Can be either one mask
-      for the whole dataset (rank i, j) or each frame can have its own
-      mask (rank np, i, j).
+      for the whole dataset (i.e. an array with indices i, j) or
+      each frame can have its own mask (in which case it would be
+      an array with indices np, i, j).
 
       Contains a bit field for each pixel to signal dead,
       blind or high or otherwise unwanted or undesirable pixels.
@@ -630,16 +631,13 @@
   </field>
   <field name="dynamic_mask" type="NX_INT" >
     <doc>
-      32-bit pixel mask for the detector, as defined by pixel_mask, but
-      here each image can have its own mask. Thus the mask shape includes
-      np as its first dimension.
-
-      Bit values are as defined for pixel_mask.
+      Additional 32-bit pixel mask for the detector, useful if a second set
+      of masks needs to be combined with pixel_mask.  Dimensionality and
+      bit values are as defined for pixel_mask.
     </doc>
-    <dimensions rank="3">
-      <dim index="1" value="np"/>
-      <dim index="2" value="i"/>
-      <dim index="3" value="j"/>
+    <dimensions rank="2">
+      <dim index="1" value="i"/>
+      <dim index="2" value="j"/>
     </dimensions>
   </field>
   <field name="countrate_correction__applied" type="NX_BOOLEAN" >

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -628,6 +628,20 @@
       <dim index="2" value="j"/>
     </dimensions>
   </field>
+  <field name="dynamic_mask" type="NX_INT" >
+    <doc>
+      32-bit pixel mask for the detector, as defined by pixel_mask, but
+      here each image can have its own mask. Thus the mask shape includes
+      np as its first dimension.
+
+      Bit values are as defined for pixel_mask.
+    </doc>
+    <dimensions rank="3">
+      <dim index="1" value="np"/>
+      <dim index="2" value="i"/>
+      <dim index="3" value="j"/>
+    </dimensions>
+  </field>
   <field name="countrate_correction__applied" type="NX_BOOLEAN" >
     <doc>
       True when a count-rate correction has already been applied in the


### PR DESCRIPTION
Also sync documentation between NXmx and NXdetector.

Alternate solution to #651 than what I did in #654.  Pending discussion.