### PR TITLE
Clarify how beam_center_x and beam_center_y are used

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -324,6 +324,20 @@
 							detector. This is a length and can be outside of the actual
 							detector. The length can be in physical units or pixels as
 							documented by the units attribute.
+
+							The depends_on field has priority over this field and is
+							designed to fully specify the geometry of an arbitrarily
+							positioned detector. However, if the depends_on attribute is
+							not set, then beam_center_x, beam_center_y, and distance are
+							used to position the detector, given the following
+							conventions (all in the NeXus coordinate system):
+
+							Assume the detector is orthogonal to the beam without any
+							rotation around the beam.  Given the vectors 'fast'
+							(-1,0,0), 'slow'  (0,-1,0), and 'beam' (0, 0, 1), the origin
+							pixel of the detector (the 0th pixel) will be at
+
+							-(beam_center_x * fast) - (beam_center_y * slow) + (distance * beam)
 						</doc>
 					</field>
 
@@ -334,6 +348,8 @@
 							detector. This is a length and can be outside of the actual
 							detector. The length can be in physical units or pixels as
 							documented by the units attribute.
+
+							See beam_center_x.
 						</doc>
 					</field>
 


### PR DESCRIPTION
beam_center_x and beam_center_y are only used if the depends_on field is not present.   Clarify this and provide a definition of the default geometry given no dependency chain.