### PR TITLE
Use consistent terms in manual when names are flexible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build
 impatient-guide/_build
 .DS_Store
 __github_creds__.txt
+
+launch.json

--- a/utils/dev_nxdl2rst.py
+++ b/utils/dev_nxdl2rst.py
@@ -23,11 +23,12 @@ BASEDIR = os.path.dirname(__file__)
 # nxdl = os.path.join(BASEDIR, '..', 'applications', 'NXarchive.nxdl.xml')
 # nxdl = os.path.join(BASEDIR, '..', 'applications', 'NXsas.nxdl.xml')
 # nxdl = os.path.join(BASEDIR, '..', 'base_classes', 'NXcrystal.nxdl.xml')
+nxdl = os.path.join(BASEDIR, '..', 'base_classes', 'NXentry.nxdl.xml')
 # nxdl = os.path.join(BASEDIR, '..', 'base_classes', 'NXobject.nxdl.xml')
 # nxdl = os.path.join(BASEDIR, '..', 'base_classes', 'NXuser.nxdl.xml')
 # nxdl = os.path.join(BASEDIR, '..', 'contributed_definitions', 'NXarpes.nxdl.xml')
 # nxdl = os.path.join(BASEDIR, '..', 'contributed_definitions', 'NXmagnetic_kicker.nxdl.xml')
-nxdl = os.path.join(BASEDIR, '..', 'applications', 'NXcanSAS.nxdl.xml')
+# nxdl = os.path.join(BASEDIR, '..', 'applications', 'NXcanSAS.nxdl.xml')
 
 if len(sys.argv) == 1:
     sys.argv.append(nxdl)

--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -280,7 +280,7 @@ def printFullTree(ns, parent, name, indent):
         optional_text = get_required_or_optional_text(node, use_application_defaults)
         if typ.startswith('NX'):
             if name is '':
-                name = '(%s)' % typ.lstrip('NX')
+                name = typ.lstrip('NX').upper()
             typ = ':ref:`%s`' % typ
         print( '%s**%s**: %s%s\n' % (indent, name, optional_text, typ ) )
 


### PR DESCRIPTION
fixes #562

In some NXDL classes, the name of a field or group is allowed to be flexible at the time the data file is written.  For example, in the definition of `NXdata`, a data field might be allowed any useful name, yet the definition says `data` is its name.  The standard means this is a suggestion.  To be clear when a name is only a suggestion, render it in the manual as upper case; in this case `DATA`.  Names that should be used as shown in the NXDL file will be in lower case.