### PR TITLE
Clarify note on IUCr coordinate system.

### DIFF
--- a/manual/source/design.rst
+++ b/manual/source/design.rst
@@ -672,8 +672,7 @@ any prior knowledge of the chosen coordinate system.
 
 .. note:: The NeXus definition of *+z* is opposite to that
           in the :index:`IUCr <coordinate systems; IUCr>`
-          International Tables for Crystallography, volume G,
-          and consequently, *+x* is also reversed.
+          International Tables for Crystallography, volume G.
 
 .. _CoordinateTransformations:
 


### PR DESCRIPTION
The comment on Z is correct, but in ImageCIF, the X axis is defined based on the goniometer orientation. It is common for goniometers to be mounted in different orientations, which will flip X and Y depending on the beamline. Therefore, the second part of the note has been removed.

Fixes #703