### PR TITLE
Per shot wavelength

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -570,14 +570,14 @@
 
 							Several other use cases are supported. For each of these,
 							usage of incident_wavelength_axes is recommended and is
-							required if the ray is 2D or higher.
+							required if the array is 2D or higher.
 
 							In the case of a polychromatic beam this is a 2D array
 							of the wavelengths vs. their relative weights.
 
 							In the case of a monochromatic beam with varying
-							wavelength per image, this is a 1D array of length np,
-							listing all the per-image wavelengths.
+							wavelength per shot, this is a 1D array of length np,
+							listing all the per-shot wavelengths.
 
 							In the case of a polychromatic beam that varies per
 							image, this is a 3D array of np vs. wavelengths vs.

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -569,7 +569,8 @@
 							wavelength.
 
 							Several other use cases are supported. For each of these,
-							incident_wavelength_axes must also be specified.
+							usage of incident_wavelength_axes is recommended and is
+							required if the ray is 2D or higher.
 
 							In the case of a polychromatic beam this is a 2D array
 							of the wavelengths vs. their relative weights.
@@ -592,21 +593,25 @@
 						<doc>
 							String array that defines the axes in
 							incident_wavelength. Only the following axes names
-							are supported: "wavelength", "np", "weight",
+							are supported: "wavelength" (required), "np", "weight",
 							"spread". The ordering should be in C order (slow to
 							fast).
 						</doc>
 					</field>
 
 
-					<field name="incident_wavelength_weight" type="NX_FLOAT" minOccurs="0" 
-						deprecated="see: https://github.com/nexusformat/definitions/issues/667">
+					<field name="incident_wavelength_weight" type="NX_FLOAT" minOccurs="0">
 						<doc>
-							(No longer supported)
-
 							In the case of a polychromatic beam this is an array of the
 							relative weights of the corresponding wavelengths in
 							incident_wavelength.
+							
+							Limited to 1D (where incident_wavelength_axes="wavelength"
+							only), and if this specified incident_wavelength must be of
+							the same length.
+							
+							Note, this can instead be specified as an axis in
+							incident_wavelength directly.
 						</doc>
 					</field>
 
@@ -614,18 +619,19 @@
 						minOccurs="0" >
 						<doc>
 							The wavelength spread FWHM for the corresponding
-							wavelength(s) in incident_wavelength. If specified, should
-							have same dimensionality as incident_wavelength. Limited
-							to 1D (where incident_wavelength_axes="wavelength" only).
+							wavelength(s) in incident_wavelength.
 							
-							Note, this can also be specified as an axis in
+							Limited to 1D (where incident_wavelength_axes="wavelength"
+							only), and if this specified incident_wavelength must be of
+							the same length.
+							
+							Note, this can instead be specified as an axis in
 							incident_wavelength directly.
 						</doc>
 					</field>
 
 					<group name="incident_wavelength_spectrum" type="NXdata"
-						minOccurs="0"
-						deprecated="see: https://github.com/nexusformat/definitions/issues/667"/>
+						minOccurs="0"/>
 
 					<field name="flux" type="NX_FLOAT" units="NX_FLUX" minOccurs="0">
 						<doc>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -568,14 +568,35 @@
 							In the case of a monchromatic beam this is the scalar
 							wavelength.
 
-							In the case of a polychromatic beam this is an array of
-							the wavelengths with the relative weights in
-							incident_wavelength_weight.
+							Three other use cases are supported. For each of these,
+							incident_wavelength_axes must also be specified.
+
+							In the case of a polychromatic beam this is a 2D array
+							of the wavelengths vs. their relative weights.
+
+							In the case of a monochromatic beam with varying
+							wavelength per image, this is a 1D array of length np,
+							listing all the per-image wavelengths.
+
+							In the case of a polychromatic beam that varies per
+							image, this is a 3D array of np vs. wavelengths vs.
+							weights.
 						</doc>
 					</field>
 
-					<field name="incident_wavelength_weight" type="NX_FLOAT" minOccurs="0" >
+					<field name="incident_wavelength_axes" type="NX_CHAR" minOccurs="0">
+					        <doc>
+						        String array that defines the axes in
+							incident_wavelength. Only the following axes names
+							are supported: "wavelength", "np", "weight". The
+							ordering should be in C order (slow to fast).
+
+
+					<field name="incident_wavelength_weight" type="NX_FLOAT" minOccurs="0" 
+					        deprecated="see: https://github.com/nexusformat/definitions/issues/667"/>
 						<doc>
+						        (No longer supported)
+
 							In the case of a polychromatic beam this is an array of the
 							relative weights of the corresponding wavelengths in
 							incident_wavelength.
@@ -586,12 +607,14 @@
 						minOccurs="0" >
 						<doc>
 							The wavelength spread FWHM for the corresponding
-							wavelength(s) in incident_wavelength.
+							wavelength(s) in incident_wavelength. If specified, should
+							have same dimensionality as incident_wavelength.
 						</doc>
 					</field>
 
 					<group name="incident_wavelength_spectrum" type="NXdata"
-						minOccurs="0" />
+						minOccurs="0"
+						deprecated="see: https://github.com/nexusformat/definitions/issues/667"/>
 
 					<field name="flux" type="NX_FLOAT" units="NX_FLUX" minOccurs="0">
 						<doc>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -589,18 +589,20 @@
 					</field>
 
 					<field name="incident_wavelength_axes" type="NX_CHAR" minOccurs="0">
-					        <doc>
-						        String array that defines the axes in
+						<doc>
+							String array that defines the axes in
 							incident_wavelength. Only the following axes names
 							are supported: "wavelength", "np", "weight",
 							"spread". The ordering should be in C order (slow to
 							fast).
+						</doc>
+					</field>
 
 
 					<field name="incident_wavelength_weight" type="NX_FLOAT" minOccurs="0" 
-					        deprecated="see: https://github.com/nexusformat/definitions/issues/667"/>
+						deprecated="see: https://github.com/nexusformat/definitions/issues/667">
 						<doc>
-						        (No longer supported)
+							(No longer supported)
 
 							In the case of a polychromatic beam this is an array of the
 							relative weights of the corresponding wavelengths in

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -568,7 +568,7 @@
 							In the case of a monchromatic beam this is the scalar
 							wavelength.
 
-							Three other use cases are supported. For each of these,
+							Several other use cases are supported. For each of these,
 							incident_wavelength_axes must also be specified.
 
 							In the case of a polychromatic beam this is a 2D array
@@ -581,6 +581,10 @@
 							In the case of a polychromatic beam that varies per
 							image, this is a 3D array of np vs. wavelengths vs.
 							weights.
+							
+							Finally, the incident wavelength spread can also be
+							specified as axis (this can also be specified in the
+							incident_wavelength_spread field)
 						</doc>
 					</field>
 
@@ -588,8 +592,9 @@
 					        <doc>
 						        String array that defines the axes in
 							incident_wavelength. Only the following axes names
-							are supported: "wavelength", "np", "weight". The
-							ordering should be in C order (slow to fast).
+							are supported: "wavelength", "np", "weight",
+							"spread". The ordering should be in C order (slow to
+							fast).
 
 
 					<field name="incident_wavelength_weight" type="NX_FLOAT" minOccurs="0" 
@@ -608,7 +613,11 @@
 						<doc>
 							The wavelength spread FWHM for the corresponding
 							wavelength(s) in incident_wavelength. If specified, should
-							have same dimensionality as incident_wavelength.
+							have same dimensionality as incident_wavelength. Limited
+							to 1D (where incident_wavelength_axes="wavelength" only).
+							
+							Note, this can also be specified as an axis in
+							incident_wavelength directly.
 						</doc>
 					</field>
 

--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -27,6 +27,14 @@
     name="NXbeam"
     type="group" extends="NXobject">
 
+    <symbols>
+        <symbol name="i">
+            <doc>Number of beamline components, or incident wavelengths, etc., depending on application</doc>
+        </symbol>
+        <symbol name="j">
+            <doc>Number of beamline components, or incident wavelengths, etc., depending on application</doc>
+        </symbol>
+    </symbols>
     <doc>
         Properties of the neutron or X-ray beam at a given location. 
         

--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -62,7 +62,7 @@ def getDocBlocks( ns, node ):
     try:		# see #661
         import html
         text = html.unescape(text)
-    except ImportError:
+    except (ImportError, AttributeError):
         text = htmlparser.unescape(text)
 
     # Blocks are separated by whitelines


### PR DESCRIPTION
Fixes #667 

Detail:
- Allow incident_wavelength to be up to 4D, supporting per-shot spectra.  Several use cases are directly supported now, including 1 wavelength for the whole dataset, a constant polychromatic beam, a varying per-shot wavelength, per-shot individual spectra, and a spread for each wavelength.
- Add incident_wavelength_axes, used to specify which axes are present in incident_wavelength
- Deprecate incident_wavelength_weight. This field is where one of the dimensions of the spectrum of a polychromatic beam was specified. This is now folded into a dimension of incident_wavelength.
- Deprecate incident_wavelength_spectrum. This group was undocumented.
- Clarify incident_wavelength_spread should have same dimensionality as incident_wavelength if specified