### PR TITLE
adjust links for h5toText, now punx tree

### DIFF
--- a/manual/source/examples/code_napi.rst
+++ b/manual/source/examples/code_napi.rst
@@ -106,7 +106,7 @@ NeXus data file validation and view. [#]_
 The *tree* option of this tool [#]_ was developed to show the actual data content of an
 HDF5 file that we create.
 
-.. [#] **punx** : http://punx.readthedocs.io/
+.. [#] **punx** : https://punx.readthedocs.io/
 .. [#] **punx tree** : https://punx.readthedocs.io/en/latest/source_code/h5tree.html#how-to-use-h5tree
 
 NAPI Python Example: ``punx tree simple3D.h5`` output of NeXus HDF5 file

--- a/manual/source/examples/code_napi.rst
+++ b/manual/source/examples/code_napi.rst
@@ -101,12 +101,12 @@ View a NeXus HDF5 file using *punx tree*
 
 The output of ``h5dump`` contains a lot of structural information
 about the HDF5 file that can distract us from the actual content we added to the file.
-Next, we show the output from a custom Python tool (``punx.py tree``) built for
-this NeXus data file validation and view. [#]_
+Next, we show the output from a custom Python tool (``punx tree``) built for
+NeXus data file validation and view. [#]_
 The *tree* option of this tool [#]_ was developed to show the actual data content of an
 HDF5 file that we create.
 
-.. [#] **punx** : http://punx.readthedocs.org
+.. [#] **punx** : http://punx.readthedocs.io/
 .. [#] **punx tree** : https://punx.readthedocs.io/en/latest/source_code/h5tree.html#how-to-use-h5tree
 
 NAPI Python Example: ``punx tree simple3D.h5`` output of NeXus HDF5 file

--- a/manual/source/examples/code_napi.rst
+++ b/manual/source/examples/code_napi.rst
@@ -96,20 +96,21 @@ NAPI Python Example: ``h5dump`` output of NeXus HDF5 file
     :language: text
 
 
-View a NeXus HDF5 file using *h5toText.py*
-##########################################
+View a NeXus HDF5 file using *punx tree*
+########################################
 
 The output of ``h5dump`` contains a lot of structural information
 about the HDF5 file that can distract us from the actual content we added to the file.
-Next, we show the output from a custom Python tool (``h5toText.py``) built for
-this documentation and later moved into the **spec2nexus** package. [#]_
-This tool was developed to show the actual data content of an
+Next, we show the output from a custom Python tool (``punx.py tree``) built for
+this NeXus data file validation and view. [#]_
+The *tree* option of this tool [#]_ was developed to show the actual data content of an
 HDF5 file that we create.
 
-.. [#] **spec2nexus** : http://spec2nexus.readthedocs.org
+.. [#] **punx** : http://punx.readthedocs.org
+.. [#] **punx tree** : https://punx.readthedocs.io/en/latest/source_code/h5tree.html#how-to-use-h5tree
 
-NAPI Python Example: ``h5toText`` output of NeXus HDF5 file
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+NAPI Python Example: ``punx tree simple3D.h5`` output of NeXus HDF5 file
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. literalinclude:: simple3D.xture.txt
     :tab-width: 4

--- a/manual/source/examples/h5py/create_data.sh
+++ b/manual/source/examples/h5py/create_data.sh
@@ -6,24 +6,22 @@
 #python TestReader.py
 #python TestWriter.py
 
-# h5toText comes from the spec2nexus package
-
 python BasicWriter.py
-h5toText prj_test.nexus.hdf5 > prj_test.nexus_structure.txt
+punx tree prj_test.nexus.hdf5 > prj_test.nexus_structure.txt
 h5dump prj_test.nexus.hdf5 > prj_test.nexus_h5dump.txt
 
 python externalExample.py
-h5toText external_angles.hdf5 > external_angles_structure.txt
+punx tree external_angles.hdf5 > external_angles_structure.txt
 h5dump external_angles.hdf5 > external_angles_h5dump.txt
-h5toText external_counts.hdf5 > external_counts_structure.txt
+punx tree external_counts.hdf5 > external_counts_structure.txt
 h5dump external_counts.hdf5 > external_counts_h5dump.txt
-h5toText external_master.hdf5 > external_master_structure.txt
+punx tree external_master.hdf5 > external_master_structure.txt
 h5dump external_master.hdf5 > external_master_h5dump.txt
 
 python writer_1_3.py
-h5toText writer_1_3.hdf5 > writer_1_3_structure.txt
+punx tree writer_1_3.hdf5 > writer_1_3_structure.txt
 h5dump writer_1_3.hdf5 > writer_1_3_h5dump.txt
 
 python writer_2_1.py
-h5toText writer_2_1.hdf5 > writer_2_1_structure.txt
+punx tree writer_2_1.hdf5 > writer_2_1_structure.txt
 h5dump writer_2_1.hdf5 > writer_2_1_h5dump.txt

--- a/manual/source/examples/h5py/index.rst
+++ b/manual/source/examples/h5py/index.rst
@@ -351,15 +351,15 @@ file                                         description
 :download:`BasicWriter.py`                   python code to write example *prj_test.nexus.hdf5*
 :download:`external_angles_h5dump.txt`       *h5dump* analysis of *external_angles.hdf5*
 :download:`external_angles.hdf5`             HDF5 file written by *externalExample*
-:download:`external_angles_structure.txt`    *h5toText* analysis of *external_angles.hdf5*
+:download:`external_angles_structure.txt`    *punx tree* analysis of *external_angles.hdf5*
 :download:`external_counts_h5dump.txt`       *h5dump* analysis of *external_counts.hdf5*
 :download:`external_counts.hdf5`             HDF5 file written by *externalExample*
-:download:`external_counts_structure.txt`    *h5toText* analysis of *external_counts.hdf5*
+:download:`external_counts_structure.txt`    *punx tree* analysis of *external_counts.hdf5*
 :download:`externalExample.py`               python code to write external linking examples
 :download:`external_master_h5dump.txt`       *h5dump* analysis of *external_master.hdf5*
 :download:`external_master.hdf5`             NeXus file written by *externalExample*
-:download:`external_master_structure.txt`    *h5toText* analysis of *external_master.hdf5*
+:download:`external_master_structure.txt`    *punx tree* analysis of *external_master.hdf5*
 :download:`prj_test.nexus_h5dump.txt`        *h5dump* analysis of the NeXus file
 :download:`prj_test.nexus.hdf5`              NeXus file written by *BasicWriter*
-:download:`prj_test.nexus_structure.txt`     *h5toText* analysis of the NeXus file
+:download:`prj_test.nexus_structure.txt`     *punx tree* analysis of the NeXus file
 ===========================================  =============================================

--- a/manual/source/examples/h5py/writer_1_3.rst
+++ b/manual/source/examples/h5py/writer_1_3.rst
@@ -67,7 +67,7 @@ decided by the ``h5py`` support package.
        :language: text
 
 Since the output of ``h5dump`` is verbose (see the *Downloads* section below), 
-the *h5toText* tool [#]_ was used to
+the *punx tree* tool [#]_ was used to
 print out the structure of HDF5 data files.  This tool provides a simplified view
 of the NeXus file.  Here is the output:
 
@@ -77,9 +77,9 @@ of the NeXus file.  Here is the output:
     :language: text
 
 As the data files in these examples become more complex, you will appreciate
-the information density provided by *h5toText*.
+the information density provided by *punx tree*.
 
-.. [#] *h5toText* : http://spec2nexus.readthedocs.org/en/latest/h5toText.html
+.. [#] *punx tree* : https://punx.readthedocs.io/en/latest/source_code/h5tree.html#how-to-use-h5tree
 
 downloads
 *********
@@ -92,5 +92,5 @@ file                                   description
 :download:`writer_1_3.py`              python code to write example *writer_1_3*
 :download:`writer_1_3.hdf5`            NeXus file written by this code
 :download:`writer_1_3_h5dump.txt`      *h5dump* analysis of the NeXus file
-:download:`writer_1_3_structure.txt`   *h5toText* analysis of the NeXus file
+:download:`writer_1_3_structure.txt`   *punx tree* analysis of the NeXus file
 =====================================  =============================================

--- a/manual/source/examples/h5py/writer_2_1.rst
+++ b/manual/source/examples/h5py/writer_2_1.rst
@@ -73,7 +73,7 @@ has been made and shows the HDF5 path to the description.
 NeXus recognizes this behavior of the HDF5 library and adds an additional structure
 when building hard links, the ``target`` attribute,
 to preserve the original location of the data.  Not that it actually matters.
-The ``punx.py tree`` tool knows about the additional NeXus
+The ``punx tree`` tool knows about the additional NeXus
 ``target`` attribute and shows the data to appear in its original
 location, in the ``NXdetector`` group.
 

--- a/manual/source/examples/h5py/writer_2_1.rst
+++ b/manual/source/examples/h5py/writer_2_1.rst
@@ -73,7 +73,7 @@ has been made and shows the HDF5 path to the description.
 NeXus recognizes this behavior of the HDF5 library and adds an additional structure
 when building hard links, the ``target`` attribute,
 to preserve the original location of the data.  Not that it actually matters.
-The ``h5toText.py`` tool knows about the additional NeXus
+The ``punx.py tree`` tool knows about the additional NeXus
 ``target`` attribute and shows the data to appear in its original
 location, in the ``NXdetector`` group.
 
@@ -93,6 +93,6 @@ file                                   description
 :download:`writer_2_1.py`              python code to write example *writer_2_1*
 :download:`writer_2_1.hdf5`            NeXus file written by this code
 :download:`writer_2_1_h5dump.txt`      *h5dump* analysis of the NeXus file
-:download:`writer_2_1_structure.txt`   *h5toText* analysis of the NeXus file
+:download:`writer_2_1_structure.txt`   *punx tree* analysis of the NeXus file
 =====================================  =============================================
     

--- a/manual/source/faq.rst
+++ b/manual/source/faq.rst
@@ -28,7 +28,7 @@ This is a list of commonly asked questions concerning the NeXus data format.
     NeXus data files.  The easiest graphical tool to use is
     *HDFview* which can open any HDF file.  Other tools such as *PyMCA*
     and *NeXPy* provide visualization of scientific data while *h5dump*
-    and *h5toText* provide text renditions of content and structure.
+    and *punx tree* provide text renditions of content and structure.
     If you want to try, for example
     ``nxbrowse``
     is a utility provided by the NeXus community that can be very

--- a/manual/source/utilities.rst
+++ b/manual/source/utilities.rst
@@ -153,7 +153,10 @@ The list is not intended to be a complete list of all available packages.
     
    NOTE: project is under initial construction, 
    not yet released for public use, but is useful in its 
-   present form (version 0.0.9).  
+   present form (version 0.2.3).
+
+   **punx** can show the tree structure of any HDF5 file.
+   The output is more concise than that from *h5dump*.
     
    See the program documentation for more details:
    https://punx.readthedocs.io
@@ -283,7 +286,6 @@ as a data format.  It is not intended to be a complete list of all available pac
 
 **spec2nexus** (http://spec2nexus.readthedocs.io)
     (Python code) Converts SPEC data files and scans into NeXus HDF5 files.
-    Provides *h5toText* utility program to inspect HDF5 file content.
     Provides libraries:
 
     * *spec2nexus.spec*: python binding to read SPEC [#]_ data files

--- a/manual/source/utilities.rst
+++ b/manual/source/utilities.rst
@@ -284,9 +284,13 @@ as a data format.  It is not intended to be a complete list of all available pac
 .. index:: 
 	spec2nexus
 
-**spec2nexus** (http://spec2nexus.readthedocs.io)
+**spec2nexus** (https://spec2nexus.readthedocs.io)
     (Python code) Converts SPEC data files and scans into NeXus HDF5 files.
-    Provides libraries:
+    (Note the *h5toText* tool mentioned here previously is no longer
+    available from the *spec2nexus* project.  The code has been moved
+    into the *punx* project: https://punx.readthedocs.io/.)
+    
+    *spec2nexus* provides libraries:
 
     * *spec2nexus.spec*: python binding to read SPEC [#]_ data files
     * *spec2nexus.eznx*: (Easy NeXus) supports writing NeXus HDF5 files using h5py


### PR DESCRIPTION
*h5toText* (from spec2nexus) has been changed to *punx tree*.  Change the affected manual pages to fix #705