### PR TITLE
Set minOccurs to zero for unneeded items in NXsource of NXmx

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -643,7 +643,7 @@
 
                         <group type="NXsource">
 				<doc>The neutron or x-ray storage ring/facility.</doc>
-				<field name="distance" type="NX_FLOAT" units="NX_LENGTH">
+				<field name="distance" minOccurs="0" type="NX_FLOAT" units="NX_LENGTH">
 					<doc>
 						Effective distance from sample
 						Distance as seen by radiation from sample. This number should be negative
@@ -656,7 +656,7 @@
 						<doc>short name for source, perhaps the acronym</doc>
 					</attribute>
 				</field>
-				<field name="type">
+				<field name="type" minOccurs="0">
 					<doc>type of radiation source (pick one from the enumerated list and spell exactly)</doc>
 					<enumeration>
 						<item value="Spallation Neutron Source" />
@@ -673,7 +673,7 @@
 						<item value="UV Plasma Source" />
 					</enumeration>
 				</field>
-				<field name="probe">
+				<field name="probe" minOccurs="0">
 					<doc>type of radiation probe (pick one from the enumerated list and spell exactly)</doc>
 					<enumeration>
 						<item value="neutron" />
@@ -686,44 +686,44 @@
 						<item value="proton" />
 					</enumeration>
 				</field>
-				<field name="power" type="NX_FLOAT" units="NX_POWER">
+				<field name="power" minOccurs="0" type="NX_FLOAT" units="NX_POWER">
 					<doc>Source power</doc>
 				</field>
-				<field name="emittance_x" type="NX_FLOAT" units="NX_EMITTANCE">
+				<field name="emittance_x" minOccurs="0" type="NX_FLOAT" units="NX_EMITTANCE">
 					<doc>Source emittance (nm-rad) in X (horizontal) direction.</doc>
 				</field>
-				<field name="emittance_y" type="NX_FLOAT" units="NX_EMITTANCE">
+				<field name="emittance_y" minOccurs="0" type="NX_FLOAT" units="NX_EMITTANCE">
 					<doc>Source emittance (nm-rad) in Y (horizontal) direction.</doc>
 				</field>
-				<field name="sigma_x" type="NX_FLOAT" units="NX_LENGTH">
+				<field name="sigma_x" minOccurs="0" type="NX_FLOAT" units="NX_LENGTH">
 					<doc>particle beam size in x</doc>
 				</field>
-				<field name="sigma_y" type="NX_FLOAT" units="NX_LENGTH">
+				<field name="sigma_y" minOccurs="0" type="NX_FLOAT" units="NX_LENGTH">
 					<doc>particle beam size in y</doc>
 				</field>
-				<field name="flux" type="NX_FLOAT" units="NX_FLUX">
+				<field name="flux" minOccurs="0" type="NX_FLOAT" units="NX_FLUX">
 					<doc>Source intensity/area (example: s-1 cm-2)</doc>
 				</field>
-				<field name="energy" type="NX_FLOAT" units="NX_ENERGY">
+				<field name="energy" minOccurs="0" type="NX_FLOAT" units="NX_ENERGY">
 					<doc>
 						Source energy.
 						For storage rings, this would be the particle beam energy.
 						For X-ray tubes, this would be the excitation voltage.
 					</doc>
 				</field>
-				<field name="current" type="NX_FLOAT" units="NX_CURRENT">
+				<field name="current" minOccurs="0" type="NX_FLOAT" units="NX_CURRENT">
 					<doc>Accelerator, X-ray tube, or storage ring current</doc>
 				</field>
-				<field name="voltage" type="NX_FLOAT" units="NX_VOLTAGE">
+				<field name="voltage" minOccurs="0" type="NX_FLOAT" units="NX_VOLTAGE">
 					<doc>Accelerator voltage</doc>
 				</field>
-				<field name="frequency" type="NX_FLOAT" units="NX_FREQUENCY">
+				<field name="frequency" minOccurs="0" type="NX_FLOAT" units="NX_FREQUENCY">
 					<doc>Frequency of pulsed source</doc>
 				</field>
-				<field name="period" type="NX_FLOAT" units="NX_PERIOD">
+				<field name="period" minOccurs="0" type="NX_FLOAT" units="NX_PERIOD">
 					<doc>Period of pulsed source</doc>
 				</field>
-				<field name="target_material">
+				<field name="target_material" minOccurs="0">
 					<doc>Pulsed source target material</doc>
 					<enumeration>
 						<item value="Ta" />
@@ -735,35 +735,35 @@
 						<item value="C" />
 					</enumeration>
 				</field>
-				<group name="notes" type="NXnote">
+				<group name="notes" minOccurs="0" type="NXnote">
 					<doc>
 						any source/facility related messages/events that
 						occurred during the experiment
 					</doc>
 				</group>
-				<group name="bunch_pattern" type="NXdata">
+				<group name="bunch_pattern" minOccurs="0" type="NXdata">
 					<doc>
 						For storage rings, description of the bunch pattern.
 						This is useful to describe irregular bunch patterns.
 					</doc>
 					<field name="title"><doc>name of the bunch pattern</doc></field>
 				</group>
-				<field name="number_of_bunches" type="NX_INT">
+				<field name="number_of_bunches" minOccurs="0" type="NX_INT">
 					<doc>For storage rings, the number of bunches in use.</doc>
 				</field>
-				<field name="bunch_length" type="NX_FLOAT" units="NX_TIME">
+				<field name="bunch_length" minOccurs="0" type="NX_FLOAT" units="NX_TIME">
 					<doc>For storage rings, temporal length of the bunch</doc>
 				</field>
-				<field name="bunch_distance" type="NX_FLOAT" units="NX_TIME">
+				<field name="bunch_distance" minOccurs="0" type="NX_FLOAT" units="NX_TIME">
 					<doc>For storage rings, time between bunches</doc>
 				</field>
-				<field name="pulse_width" type="NX_FLOAT" units="NX_TIME">
+				<field name="pulse_width" minOccurs="0" type="NX_FLOAT" units="NX_TIME">
 					<doc>temporal width of source pulse</doc><!-- pulsed sources or storage rings could use this -->
 				</field>
-				<group name="pulse_shape" type="NXdata">
+				<group name="pulse_shape" minOccurs="0" type="NXdata">
 					<doc>source pulse shape</doc><!-- pulsed sources or storage rings could use this -->
 				</group>
-				<field name="mode">
+				<field name="mode" minOccurs="0">
 					<doc>source operating mode</doc>
 					<enumeration>
 						<item value="Single Bunch"><doc>for storage rings</doc></item>
@@ -771,17 +771,17 @@
 						<!-- other sources could add to this -->
 					</enumeration>
 				</field>
-				<field name="top_up" type="NX_BOOLEAN">
+				<field name="top_up" minOccurs="0" type="NX_BOOLEAN">
 					<doc>Is the synchrotron operating in top_up mode?</doc>
 				</field>
-				<field name="last_fill" type="NX_NUMBER" units="NX_CURRENT">
+				<field name="last_fill" minOccurs="0" type="NX_NUMBER" units="NX_CURRENT">
 					<doc>For storage rings, the current at the end of the most recent injection.</doc>
 					<attribute name="time" type="NX_DATE_TIME"><doc>date and time of the most recent injection.</doc></attribute>
 				</field>
-				<group name="geometry" type="NXgeometry">
+				<group name="geometry" minOccurs="0" type="NXgeometry">
 					<doc>"Engineering" location of source</doc>
 				</group>
-				<group type="NXdata" name="distribution">
+				<group type="NXdata" minOccurs="0" name="distribution">
 				  <doc>The wavelength or energy distribution of the source</doc>
 				</group>
                         </group>


### PR DESCRIPTION
Fix #696 as documentation for application definitions adds items
as required if they do not set minOccurs as zero