### PR TITLE
From code camp, Make NXmx/NXdata optional.

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -688,6 +688,6 @@
 					</attribute>
 				</field>
 			</group>
-			<group type="NXdata" />
+			<group type="NXdata" minOccurs="0" />
 		</group>
 </definition>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -171,6 +171,7 @@
 
 					<field name="data" type="NX_NUMBER">
 						<doc>
+							The pixel data recorded, if available.
 							For a dimension-2 detector, the rank of the data array will be 3.
 							For a dimension-3 detector, the rank of the data array will be 4.
 							This allows for the introduction of the frame number as the
@@ -688,6 +689,14 @@
 					</attribute>
 				</field>
 			</group>
-			<group type="NXdata" minOccurs="0" />
+			<group type="NXdata" minOccurs="0">
+				<doc>
+					The pixel data recorded, if available.
+					For a dimension-2 detector, the rank of the data array will be 3.
+					For a dimension-3 detector, the rank of the data array will be 4.
+					This allows for the introduction of the frame number as the
+					first index.
+				</doc>
+			</group>
 		</group>
 </definition>


### PR DESCRIPTION
This is for the NXreflections case where the processed data file could have NXreflections and NXmx sub entries, but the link to the original dataset is gone, therefore there cannot be a NXdata field.

I imagine this one could require a bit more discussion?  Any thoughts on this?  It would be cool to get this into the next milestone too, if possible.

Fixes #746