### PR TITLE
Using HTTPS instead of HTTP for google search request

### DIFF
--- a/manual/source/_templates/google_search.html
+++ b/manual/source/_templates/google_search.html
@@ -11,7 +11,7 @@
 <div id="google_search" style="display: none">
 	<hr />
 	<h3>{{ _('Google search') }}</h3>
-	<form method="get" action="http://www.google.com/search">
+	<form method="get" action="https://www.google.com/search">
 		<table border="0" align="center" cellpadding="0">
 			<tr>
 				<td>


### PR DESCRIPTION
Closes #753 

Causing warnings in the NeXus-Constructor (and browser console) as JS is complaining that there is a raw HTTP request that targets an insecure endpoint. 
