### PR TITLE
document plot title and axis labels

### DIFF
--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -229,6 +229,25 @@
 		  * The oldest method uses the ``axis`` attribute on each
 		    *dimension scale* to identify
 		    with an integer the axis whose value is the number of the dimension.
+
+		.. index: !plot; axis label
+		   plot, axis units
+		   units
+		   dimension scale
+
+		Each axis of the plot may be labeled with information from the 
+		dimension scale for that axis.  The optional ``@long_name`` attribute
+		is provided as the axis label default.  If ``@long_name`` is not
+		defined, then use the name of the dimension scale.  A ``@units`` attribute,
+		:ref:`if available,<Design-Units>`,  may be added to the axis label
+		for further description.
+
+		.. index: !plot; axis title
+
+		The optional ``title`` field, if available, provides a suggested
+		title for the plot.  If no ``title`` field is found in the :ref:`NXdata`
+		group, look for a ``title`` field in the parent :ref:`NXentry` group,
+		with a fallback to displaying the path to the :ref:`NXdata` group.
 	</doc>
 	<field name="VARIABLE" type="NX_NUMBER" nameType="any">
 		<doc>
@@ -365,6 +384,11 @@
 			An optional offset to apply to the values in data.
 		</doc>
 	</field>
+	<field name="title">
+		<doc>
+			Title for the plot.
+		</doc>
+	</field>
 	<field name="x" type="NX_FLOAT" units="NX_ANY">
 		<doc>
 			This is an array holding the values to use for the x-axis of
@@ -393,4 +417,3 @@
 		</dimensions>
 	</field>
 </definition>
-

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -239,8 +239,8 @@
 		dimension scale for that axis.  The optional ``@long_name`` attribute
 		is provided as the axis label default.  If ``@long_name`` is not
 		defined, then use the name of the dimension scale.  A ``@units`` attribute,
-		:ref:`if available,<Design-Units>`,  may be added to the axis label
-		for further description.
+		if available, may be added to the axis label for further description.
+		See the section :ref:`Design-Units` for more information.
 
 		.. index: !plot; axis title
 


### PR DESCRIPTION
This addition of a`title` field to NXdata and additional documentation fixes #760, where it was asked how to find the plot title in the NeXus data file structure.