### PR TITLE
NXmx: NXbeam can be on sample or instrument

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -576,7 +576,11 @@
 
 				<field name="temperature" units="NX_TEMPERATURE" minOccurs="0" />
 
-				<group type="NXbeam">
+				<group type="NXbeam" minOccurs="0">
+					<doc>
+						NXbeam is also allowed as a group on NXinstrument but should be
+						specified on one of these two locations.
+					</doc>
 					<field name="incident_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH"
 						minOccurs="0" >
 						<doc>


### PR DESCRIPTION
As part of prepping the SwisFEL Jungfrau 1M detector example, @yayahjb moved the beam group from sample to instrument (see [Zenodo entry](https://zenodo.org/record/3526738#.XrNAABNKipr)).  NXbeam is an allowed group on the [NXsample](https://manual.nexusformat.org/classes/base_classes/NXsample.html) and [NXinstrument](https://manual.nexusformat.org/classes/base_classes/NXinstrument.html) base classes so it makes sense to modify [NXmx](https://manual.nexusformat.org/classes/applications/NXmx.html) to make NXbeam optional on sample but note it should be present on one of sample or instrument.