### PR TITLE
Add ORCID as a field to NXuser

### DIFF
--- a/base_classes/NXuser.nxdl.xml
+++ b/base_classes/NXuser.nxdl.xml
@@ -68,7 +68,7 @@
 	</field>
 	<field name="ORCID">
 		<doc>
-			an author code, Open Researcher and Contributer ID,
+			an author code, Open Researcher and Contributor ID,
 			defined by https://orcid.org and expressed as a URI
 		</doc>
 	</field>

--- a/base_classes/NXuser.nxdl.xml
+++ b/base_classes/NXuser.nxdl.xml
@@ -66,5 +66,11 @@
 			address/contact database
 		</doc>
 	</field>
+	<field name="ORCID">
+		<doc>
+			an author code, Open Researcher and Contributer ID,
+			defined by https://orcid.org and expressed as a URI
+		</doc>
+	</field>
 </definition>
 


### PR DESCRIPTION
The ORCID system is widely used in scientific literature to identify authors. This adds the URI as an optional field