### PR TITLE
NXroot. Use NX_DATE_TIME and not NX_CHAR

### DIFF
--- a/base_classes/NXroot.nxdl.xml
+++ b/base_classes/NXroot.nxdl.xml
@@ -37,13 +37,13 @@
             <item value="NXroot"></item>
         </enumeration>
     </attribute>
-    <attribute name="file_time">
+    <attribute name="file_time" type="NX_DATE_TIME">
         <doc>Date and time file was originally created</doc>
     </attribute>
     <attribute name="file_name">
         <doc>File name of original NeXus file</doc>
     </attribute>
-    <attribute name="file_update_time">
+    <attribute name="file_update_time" type="NX_DATE_TIME">
         <doc>Date and time of last file change at close</doc>
     </attribute>
     <attribute name="NeXus_version">


### PR DESCRIPTION
Specify NX_DATE_TIME instead of NX_CHAR

closes #783