### PR TITLE
Changes to definitions for NXmx Gold Standard.  Includes changes to NXdl

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -63,15 +63,42 @@
 
 			<doc>
 				Note, it is recommended that ``file_name`` and ``file_time`` are included
-				as attributes at the root of a file that includes :ref:`NXmx`. See
+				as attributes at the root of a file that includes  :ref:`NXmx`. See
 				:ref:`NXroot`.
 			</doc>
 
 			<field name="title" type="NX_CHAR" minOccurs="0" />
 
-			<field name="start_time" type="NX_DATE_TIME" minOccurs="0" />
+			<field name="start_time" type="NX_DATE_TIME" >
+				<doc>
+					ISO 8601 time/date of the first data point collected in UTC,
+					using the Z suffix to avoid confusion with local time.
+					Note that the time zone of the beamline should be provided in
+					NXentry/NXinstrument/time_zone.
+				</doc>
+			</field>
 
-			<field name="end_time" type="NX_DATE_TIME" minOccurs="0" />
+			<field name="end_time" type="NX_DATE_TIME" minOccurs="0" >
+				<doc>
+					ISO 8601 time/date of the last data point collected in UTC,
+					using the Z suffix to avoid confusion with local time.
+					Note that the time zone of the beamline should be provided in
+					NXentry/NXinstrument/time_zone. This field should only be 
+					filled when the value is accurately observed. If the data 
+					collection aborts or otherwise prevents accurate recording of
+					the end_time, this field should be omitted.   
+				</doc>
+			</field>
+
+			<field name="end_time_estimated" type="NX_DATE_TIME" >
+				<doc>
+					ISO 8601 time/date of the last data point collected in UTC,
+					using the Z suffix to avoid confusion with local time.
+					Note that the time zone of the beamline should be provided in
+					NXentry/NXinstrument/time_zone.  This field may be filled
+					with a value estimated before an observed value is available.
+				</doc>
+			</field>
 
 			<field name="definition">
 				<doc> NeXus NXDL schema to which this file conforms </doc>
@@ -80,77 +107,149 @@
 				</enumeration>
 			</field>
 
+			<group type="NXdata">
+
+				<field name="data" type="NX_NUMBER" recommended="true">
+					<doc>
+						For a dimension-2 detector, the rank of the data array will be 3.
+						For a dimension-3 detector, the rank of the data array will be 4.
+						This allows for the introduction of the frame number as the
+						first index.
+					</doc>
+					<dimensions rank="dataRank">
+						<dim index="1" value="np" />
+						<dim index="2" value="i" />
+						<dim index="3" value="j" />
+						<dim index="4" value="k" required="false"/>
+					</dimensions>
+				</field>
+			</group>
+
+			<group type="NXsample">
+				<field name="name" type="NX_CHAR">
+					<doc>Descriptive name of sample</doc>
+				</field>
+
+				<field name="depends_on" type="NX_CHAR">
+					<!-- better type for paths the need to resolve -->
+					<doc>
+						This is a requirement to describe for any scan experiment.
+
+						The axis on which the sample position depends may be stored
+						anywhere, but is normally stored in the NXtransformations
+						group within the NXsample group.
+
+						If there is no goniometer, e.g. with a jet, depends_on
+						should be set to "."				
+					</doc>
+				</field>
+
+				<group type="NXtransformations" minOccurs="0">
+					<doc>
+						This is the recommended location for sample goniometer
+						and other related axes.
+
+						This is a requirement to describe for any scan experiment.
+						The reason it is optional is mainly to accommodate XFEL
+						single shot exposures.
+
+						Use of the depends_on field and the NXtransformations group is
+						strongly recommended.  As noted above this should be an absolute
+						requirement to have for any scan experiment.
+
+						The reason it is optional is mainly to accommodate XFEL
+						single shot exposures.
+					</doc>
+				</group>
+
+				<field name="temperature" units="NX_TEMPERATURE" minOccurs="0" />
+
+			</group>
+
+
 			<group type="NXinstrument">
-			        <field name="name" minOccurs="1">
-                                       <doc>Name of instrument</doc>
-                                       <attribute name="short_name">
-                                               <doc>short name for instrument, perhaps the acronym</doc>
-                                       </attribute>
-                                </field>
+				<field name="name" minOccurs="1">
+					<doc>
+						Name of instrument.  Consistency with the controlled 
+						vocabulary beamline naming in http://mmcif.wwpdb.org
+						/dictionaries/mmcif_pdbx_v50.dic/Items
+						/_diffrn_source.pdbx_synchrotron_beamline.html
+						and http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic
+						/Items/_diffrn_source.type.html} is highly recommended.
+					</doc>
+					<attribute name="short_name">
+						<doc>Short name for instrument, perhaps the acronym.</doc>
+					</attribute>
+				</field>
+
+				<field name="time_zone" type="NX_DATE_TIME" recommended="true">
+					<doc>
+						ISO 8601 time_zone offset from UTC.
+					</doc>
+				</field>
 
 				<group type="NXattenuator" minOccurs="0">
 					<field name="attenuator_transmission" type="NX_NUMBER" units="NX_UNITLESS"
 						minOccurs="0" />
 				</group>
-
-				<group type="NXdetector_group" minOccurs="0">
+	
+				<group type="NXdetector_group" recommended="true">
 					<doc>
-					Optional logical grouping of detector elements.
+						Optional logical grouping of detector elements.
 
-					Each detector element is represented as an NXdetector group
-					with its own detector data array.  Each detector data array
-					may be further decomposed into array sections by use of
-					NXdetector_module groups.  The names are given in the
-					group names field.
+						Each detector element is represented as an NXdetector group
+						with its own detector data array.  Each detector data array
+						may be further decomposed into array sections by use of
+						NXdetector_module groups.  The names are given in the
+						group names field.
 
-					The groups are defined hierarchically, with names given
-					in the group_names field, unique identifiing indices given
-					in the field group_index, and the level in the hierarchy
-					given in the group_parent field.  For example if an x-ray
-					detector, DET, consists of four elements in a rectangular array::
-							
-							 DTL	DTR
-							 DLL	DLR
-							
-					We could have::
+						The groups are defined hierarchically, with names given
+						in the group_names field, unique identifiing indices given
+						in the field group_index, and the level in the hierarchy
+						given in the group_parent field.  For example if an x-ray
+						detector, DET, consists of four elements in a rectangular array::
 						
-						 group_names: ["DET", "DTL", "DTR", "DLL", "DLR"]
-						 group_index: [1, 2, 3, 4, 5]
-						 group_parent:  [-1, 1, 1, 1, 1]
+								 DTL	DTR
+								 DLL	DLR
+						
+						We could have::
+					
+							group_names: ["DET", "DTL", "DTR", "DLL", "DLR"]
+						 	group_index: [1, 2, 3, 4, 5]
+						 	group_parent:  [-1, 1, 1, 1, 1]
 
 					</doc>
 
 					<field name="group_names" type="NX_CHAR">
 						<doc>
-						An array of the names of the detector elements or hierarchical
-						groupings of detector elements.
-						
-						Specified in the base classes as comma separated list of names,
-						but new code should use an array of names as quoted strings.
+							An array of the names of the detector elements or hierarchical
+							groupings of detector elements.
+					
+							Specified in the base classes as comma separated list of names,
+							but new code should use an array of names as quoted strings.
 						</doc>
-						<dimensions><dim index="1" ref="group_index"/></dimensions>
 					</field>
 
 					<field name="group_index" type="NX_INT">
 						<doc>
-						An array of unique indices for detector elements or groupings
-						of detector elements.
+							An array of unique indices for detector elements or groupings
+							of detector elements.
 						
-						Each element is a unique ID for the corresponding group named
-						in the field group_names.  The IDs are positive integers starting
-						with 1.
+							Each element is a unique ID for the corresponding group named
+							in the field group_names.  The IDs are positive integers starting
+							with 1.
 						</doc>
-						<dimensions><dim index="1" value="i"/></dimensions>
+						<dimensions rank="1"><dim index="1" value="i"/></dimensions>
 					</field>
 
 					<field name="group_parent" type="NX_INT">
 						<doc>
-						An array of the hierarchical levels of the parents of detector
-						elements or groupings of detector elements.
+							An array of the hierarchical levels of the parents of detector
+							elements or groupings of detector elements.
 						
-						A top-level element or grouping has parent level -1
+							A top-level element or grouping has parent level -1.
 						</doc>
-						<dimensions><dim index="1" ref="group_index"/></dimensions>
+						<dimensions rank="1"><dim index="1" value="group_index"/></dimensions>
 					</field>
 				</group>
 				<group type="NXdetector">
@@ -159,19 +258,20 @@
 						However, in the case of multiple detector elements, each element
 						needs a uniquely named NXdetector group.
 					</doc>
-					<field name="depends_on" type="NX_CHAR"> <!-- better type for paths needed  -->
+
+					<field name="depends_on" minOccurs="0" type="NX_CHAR">
 						<doc>
-							NeXus path to the detector positioner axis that most directly
-							supports the detector.  In the case of a multi-module detector,
-							this should be the most common axis, or ``.`` if no axes are in
-							common.
+							NeXus path to the detector positioner axis that most directly 
+							supports the detector.  In the case of a single-module
+							detector, the detector axis chain may start here.
 						</doc>
 					</field>
 
 					<group type="NXtransformations" minOccurs="0">
 						<doc>
-							Suggested location for axes (transformations) to do with the
-							detector
+							Location for axes (transformations) to do with the
+							detector.  In the case of a single-module detector, the
+							axes of the detector axis chain may be stored here. 
 						</doc>
 					</group>
 
@@ -183,9 +283,8 @@
 						</doc>
 					</group>
 
-					<field name="data" type="NX_NUMBER">
+					<field name="data" type="NX_NUMBER" recommended="true">
 						<doc>
-							The pixel data recorded, if available.
 							For a dimension-2 detector, the rank of the data array will be 3.
 							For a dimension-3 detector, the rank of the data array will be 4.
 							This allows for the introduction of the frame number as the
@@ -199,14 +298,18 @@
 						</dimensions>
 					</field>
 
-					<field name="description" minOccurs="0">
+					<field name="description" recommended="true">
 						<doc>
-							name/manufacturer/model/etc. information
+							name/manufacturer/model/etc. information.
 						</doc>
 					</field>
 
 					<field name="time_per_channel" units="NX_TIME" minOccurs="0">
-						<doc>todo: define more clearly</doc>
+						<doc>
+							For a time-of-flight detector this is the scaling 
+							factor to convert from the numeric value reported to 
+							the flight time for a given measurement.
+						</doc>
 					</field>
 
 					<group type="NXdetector_module" minOccurs="1" maxOccurs="unbounded">
@@ -238,7 +341,8 @@
 								dataset with indices (np, i, j, k) will be an array with indices
 								(i, j, k).
 
-								The :ref:`order &lt;Design-ArrayStorageOrder&gt;` of indices (i, j or i, j, k) is slow to fast.
+								The :ref:`order &lt;Design-ArrayStorageOrder&gt;` of indices (i, j 
+								or i, j, k) is slow to fast.
 							</doc>
 						</field>
 						<field name="data_size" type="NX_INT">
@@ -257,7 +361,7 @@
 							</doc>
 						</field>
 
-						<field name="module_offset" units="NX_LENGTH" type="NX_NUMBER">
+						<field name="module_offset" units="NX_LENGTH" type="NX_NUMBER" minOccurs="0">
 							<doc>
 								Offset of the module in regards to the origin of the detector in an
 								arbitrary direction.
@@ -267,104 +371,115 @@
 									<item value="translation" />
 								</enumeration>
 							</attribute>
-							<attribute name="vector">
+							<attribute name="vector" type="NX_NUMBER">
 							</attribute>
-							<attribute name="offset">
+							<attribute name="offset" type="NX_NUMBER">
 							</attribute>
 							<attribute name="depends_on">
 							</attribute>
 						</field>
 						<field name="fast_pixel_direction" units="NX_LENGTH" type="NX_NUMBER">
 							<doc>
-								Values along the direction of :ref:`fastest varying &lt;Design-ArrayStorageOrder&gt;` pixel direction.
-								The direction itself is given through the vector attribute
+								Values along the direction of :ref:`fastest varying &lt;Design-ArrayStorageOrder&gt;`
+								pixel direction.  The direction itself is given through the vector
+								attribute.
 							</doc>
 							<attribute name="transformation_type">
 								<enumeration>
 									<item value="translation" />
 								</enumeration>
 							</attribute>
-							<attribute name="vector">
+							<attribute name="vector" type="NX_NUMBER">
 							</attribute>
-							<attribute name="offset">
+							<attribute name="offset" type="NX_NUMBER">
 							</attribute>
 							<attribute name="depends_on">
 							</attribute>
 						</field>
 						<field name="slow_pixel_direction" type="NX_NUMBER" units="NX_LENGTH">
 							<doc>
-								Values along the direction of :ref:`slowest varying &lt;Design-ArrayStorageOrder&gt;` pixel direction. The
-								direction itself is given through the vector attribute
+								Values along the direction of :ref:`slowest varying &lt;Design-ArrayStorageOrder&gt;`
+								pixel direction. The direction itself is given through the vector
+								attribute.
 							</doc>
 							<attribute name="transformation_type">
 								<enumeration>
 									<item value="translation" />
 								</enumeration>
 							</attribute>
-							<attribute name="vector">
+							<attribute name="vector" type="NX_NUMBER">
 							</attribute>
-							<attribute name="offset">
+							<attribute name="offset" type="NX_NUMBER">
 							</attribute>
 							<attribute name="depends_on">
 							</attribute>
 						</field>
 					</group>
 
-					<field name="distance" type="NX_FLOAT" units="NX_LENGTH" minOccurs="0">
+					<field name="distance" type="NX_FLOAT" units="NX_LENGTH" recommended="true">
 						<doc>
 							Distance from the sample to the beam center.
-							This value is a
-							guidance only, the proper geometry can be
-							found following the
-							depends_on axis chain.
+							Normally this value is for guidance only, the proper 
+							geometry can be found following the depends_on axis chain,
+							But in appropriate cases where the dectector distance
+							to the sample is observable independent of the axis
+							chain, that may take precedence over the axis chain
+							calculation.  
+						</doc>
+					</field>
+
+					<field name="distance_derived" type="NX_BOOLEAN" units="NX_LENGTH" recommended="true">
+						<doc>
+							Boolean to indicate if the distance is a derived, rather than
+							a primary observation.  If distance_derived true or is not specified,
+							the distance is assumed to be derived from delector axis
+							specifications.
 						</doc>
 					</field>
 
 					<field name="dead_time" type="NX_FLOAT" units="NX_TIME"	minOccurs="0">
 						<doc>
-							Detector dead time
+							Detector dead time.
 						</doc>
 					</field>
 
-					<field name="count_time" type="NX_NUMBER" units="NX_TIME" minOccurs="0">
+					<field name="count_time" type="NX_NUMBER" units="NX_TIME" recommended="true">
 						<doc>
-							Elapsed actual counting time
+							Elapsed actual counting time.
 						</doc>
 					</field>
+
+					<field name="beam_center_derived" type="NX_BOOLEAN" units="NX_LENGTH" optional="true">
+						<doc>
+							Boolean to indicate if the distance is a derived, rather than
+							a primary observation.  If true or not provided, that value of
+							beam_center_derived is assumed to be true.
+						</doc>
+					</field>
+
+
 
 					<field name="beam_center_x" type="NX_FLOAT" units="NX_LENGTH"
-						minOccurs="0">
+						recommended="true">
 						<doc>
 							This is the x position where the direct beam would hit the
 							detector. This is a length and can be outside of the actual
 							detector. The length can be in physical units or pixels as
-							documented by the units attribute.
-
-							The depends_on field has priority over this field and is
-							designed to fully specify the geometry of an arbitrarily
-							positioned detector. However, if the depends_on attribute is
-							not set, then beam_center_x, beam_center_y, and distance are
-							used to position the detector, given the following
-							conventions (all in the NeXus coordinate system):
-
-							Assume the detector is orthogonal to the beam without any
-							rotation around the beam.  Given the vectors 'fast'
-							(-1,0,0), 'slow'  (0,-1,0), and 'beam' (0, 0, 1), the origin
-							pixel of the detector (the 0th pixel) will be at
-
-							-(beam_center_x * fast) - (beam_center_y * slow) + (distance * beam)
+							documented by the units attribute.  Normally, this should
+							be derived from the axis chain, but the direct specification
+							may take precendence if it is not a derived quantity.
 						</doc>
 					</field>
 
 					<field name="beam_center_y" type="NX_FLOAT" units="NX_LENGTH"
-						minOccurs="0">
+						recommended="true">
 						<doc>
 							This is the y position where the direct beam would hit the
 							detector. This is a length and can be outside of the actual
 							detector. The length can be in physical units or pixels as
-							documented by the units attribute.
-
-							See beam_center_x.
+							documented by the units attribute.  Normally, this should
+							be derived from the axis chain, but the direct specification
+							may take precendence if it is not a derived quantity.
 						</doc>
 					</field>
 
@@ -393,7 +508,10 @@
 					</field>
 
 					<field name="flatfield" type="NX_FLOAT" minOccurs="0">
-						<doc>Flat field correction data.</doc>
+						<doc>
+							Flat field correction data.  If provided, it is recommended
+							that is be compressed.
+						</doc>
 						<dimensions rank="dataRank">
 							<dim index="1" value="i" />
 							<dim index="2" value="j" />
@@ -402,7 +520,10 @@
 					</field>
 
 					<field name="flatfield_error" type="NX_FLOAT" minOccurs="0">
-						<doc>Errors of the flat field correction data.</doc>
+						<doc>
+							Errors of the flat field correction data.  If provided, it is recommended
+							that it be compressed.
+						</doc>
 						<dimensions rank="dataRank">
 							<dim index="1" value="i" />
 							<dim index="2" value="j" />
@@ -413,42 +534,38 @@
 					<field name="pixel_mask_applied" type="NX_BOOLEAN" minOccurs="0">
 						<doc>
 							True when the pixel mask correction has been applied in the
-							electronics, false otherwise.
+							electronics, false otherwise.  
 						</doc>
 					</field>
 
-					<field name="pixel_mask" type="NX_INT" minOccurs="0">
+					<field name="pixel_mask" type="NX_INT" recommended="true">
 						<doc>
 							The 32-bit pixel mask for the detector. Can be either one mask
 							for the whole dataset (i.e. an array with indices i, j) or
 							each frame can have its own mask (in which case it would be
 							an array with indices np, i, j).
-							Contains a bit field
-							for each pixel to signal dead,
-							blind or high or otherwise unwanted
-							or undesirable pixels.
+
+							Contains a bit field for each pixel to signal dead,
+							blind, high or otherwise unwanted or undesirable pixels.
 							They have the following meaning:
 
-							* bit 0: gap (pixel with no sensor)
-							* bit 1: dead
-							* bit 2: under responding
-							* bit 3: over responding
-							* bit 4: noisy
-							* bit 5: -undefined-
-							* bit 6: pixel is part of a cluster of problematic pixels (bit set in addition to others)
-							* bit 7: -undefined-
-							* bit 8: user defined mask (e.g. around beamstop)
-							* bits 9-30: -undefined-
-							* bit 31: virtual pixel (corner pixel with interpolated value)
+								* bit 0: gap (pixel with no sensor)
+								* bit 1: dead
+								* bit 2: under-responding
+								* bit 3: over-responding
+								* bit 4: noisy
+								* bit 5: -undefined-
+								* bit 6: pixel is part of a cluster of 
+									problematic pixels (bit set in addition to others)
+								* bit 7: -undefined-
+								* bit 8: user defined mask (e.g. around beamstop)
+								* bits 9-30: -undefined-
+								* bit 31: virtual pixel (corner pixel with interpolated value)
 
-							Normal data analysis software would
-							not take pixels into account
-							when a bit in (mask &amp; 0x0000FFFF) is
-							set. Tag bit in the upper
-							two bytes would indicate special pixel
-							properties that normally
-							would not be a sole reason to reject the
-							intensity value (unless
+							Normal data analysis software would not take pixels into account
+							when a bit in (mask &amp; 0x0000FFFF) is set. Tag bit in the upper
+							two bytes would indicate special pixel properties that normally
+							would not be a sole reason to reject the intensity value (unless
 							lower bits are set.
 
 							If the full bit depths is not required, providing a
@@ -462,11 +579,12 @@
 							experiment-specific shadowing could be specified in
 							pixel_mask_2. The cumulative mask is the bitwise OR
 							of pixel_mask and any pixel_mask_N entries.
+
+							If provided, it is recommended that it be compressed.
 						</doc>
-						<dimensions rank="dataRank">
+						<dimensions rank="2">
 							<dim index="1" value="i" />
 							<dim index="2" value="j" />
-							<dim index="3" value="k" required="false"/>
 						</dimensions>
 					</field>
 					<field name="countrate_correction_applied" type="NX_BOOLEAN"
@@ -477,7 +595,7 @@
 						</doc>
 					</field>
 
-					<field name="bit_depth_readout" type="NX_INT" minOccurs="0">
+					<field name="bit_depth_readout" type="NX_INT" recommended="true">
 						<doc>
 							How many bits the electronics record per pixel.
 						</doc>
@@ -508,30 +626,41 @@
 					<field name="saturation_value" type="NX_INT" minOccurs="0">
 						<doc>
 							The value at which the detector goes into saturation.
-							Data
-							above this value is known to be invalid.
+							Data above this value is known to be invalid.
+							
+							For example, given a saturation_value and an underload_value,
+							the valid pixels are those less than or equal to the 
+							saturation_value and greater than or equal to the underload_value.
 						</doc>
 					</field>
 
-					<field name="sensor_material" type="NX_CHAR" minOccurs="0">
+					<field name="underload_value" type="NX_INT" minOccurs="0">
+						<doc>
+							The lowest value at which pixels for this detector
+							would be reasonably be measured.
+
+							For example, given a saturation_value and an underload_value,
+							the valid pixels are those less than or equal to the 
+							saturation_value and greater than or equal to the underload_value.
+						</doc>
+					</field>
+
+					<field name="sensor_material" type="NX_CHAR" minOccurs="1">
 						<doc>
 							At times, radiation is not directly sensed by the detector.
 							Rather, the detector might sense the output from some
-							converter
-							like a scintillator.
+							converter like a scintillator.
 							This is the name of this converter material.
 						</doc>
 					</field>
 
 					<field name="sensor_thickness" type="NX_FLOAT" units="NX_LENGTH"
-						minOccurs="0">
+						minOccurs="1">
 						<doc>
 							At times, radiation is not directly sensed by the detector.
 							Rather, the detector might sense the output from some
-							converter
-							like a scintillator. This is the thickness of this
-							converter
-							material.
+							converter like a scintillator. This is the thickness of this
+							converter material.
 						</doc>
 					</field>
 
@@ -540,7 +669,8 @@
 						<doc>
 							Single photon counter detectors can be adjusted for a certain
 							energy range in which they work optimally. This is the energy
-							setting for this.
+							setting for this.  If the detector supports multiple thresholds,
+							this is an array.
 						</doc>
 					</field>
 
@@ -552,53 +682,9 @@
 						</doc>
 					</field>
 				</group>
-			</group>
-
-			<group type="NXsample">
-				<field name="name" type="NX_CHAR" minOccurs="0">
-					<doc>Descriptive name of sample</doc>
-				</field>
-
-				<field name="depends_on" type="NX_CHAR" minOccurs="0">
-					<!-- better type for paths the need to resolve -->
-					<doc>
-						This is a requirement to describe for any scan experiment.
-						The reason it is optional is mainly to accommodate XFEL
-						single shot exposures.
-
-						The axis on which the sample position depends may be stored
-						anywhere, but is normally stored in the NXtransformations
-						NXtransformations group within the NXsample group.
-					</doc>
-				</field>
-
-				<group type="NXtransformations" minOccurs="0">
-					<doc>
-						This is the recommended location for sample goniometer
-						and other related axes.
-
-						This is a requirement to describe for any scan experiment.
-						The reason it is optional is mainly to accommodate XFEL
-						single shot exposures.
-
-						Use of the depends_on field and the NXtransformations group is
-						strongly recommended.  As noted above this should be an absolute
-						requirement to have for any scan experiment.
-
-						The reason it is optional is mainly to accommodate XFEL
-						single shot exposures.
-					</doc>
-				</group>
-
-				<field name="temperature" units="NX_TEMPERATURE" minOccurs="0" />
-
-				<group type="NXbeam" minOccurs="0">
-					<doc>
-						NXbeam is also allowed as a group on NXinstrument but should be
-						specified on one of these two locations.
-					</doc>
+				<group type="NXbeam" minOccurs="1">
 					<field name="incident_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH"
-						minOccurs="0" >
+						minOccurs="1" >
 						<doc>
 							In the case of a monchromatic beam this is the scalar
 							wavelength.
@@ -625,12 +711,6 @@
 							of dimensions **np** by **m** (slow to fast) with the
 							relative weights in incident_wavelength_weight as a 2D
 							array.
-
-							Note, :ref:`variants &lt;Design-Variants&gt;` are a good way
-							to represent several of these use cases in a single dataset,
-							e.g. if a calibrated, single-value wavelength value is
-							available along with the original spectrum from which it
-							was calibrated.
 						</doc>
 					</field>
 
@@ -652,11 +732,6 @@
 						<doc>
 							The wavelength spread FWHM for the corresponding
 							wavelength(s) in incident_wavelength.
-
-							In the case of shot-to-shot variation in the wavelength
-							spread, this is a 2D array of dimension **np** by
-							**m** (slow to fast) of the spreads of the
-							corresponding wavelengths in incident_wavelength.
 						</doc>
 					</field>
 
@@ -665,35 +740,35 @@
 
 					<field name="flux" type="NX_FLOAT" units="NX_FLUX" minOccurs="0">
 						<doc>
-							flux density incident on beam plane area in photons
-							per second per unit area
+							Flux density incident on beam plane area in photons
+							per second per unit area.
 
 							In the case of a beam that varies in flux shot-to-shot,
 							this is an array of values, one for each recorded shot.
 						</doc>
 					</field>
 
-					<field name="total_flux" type="NX_FLOAT" units="NX_FREQUENCY" minOccurs="0">
+					<field name="total_flux" type="NX_FLOAT" units="NX_FREQUENCY" minOccurs="1">
 						<doc>
-							flux incident on beam plane in photons per second
-
+							Flux incident on beam plane in photons per second.
+						
 							In the case of a beam that varies in total flux shot-to-shot,
 							this is an array of values, one for each recorded shot.
 						</doc>
 					</field>
 
-					<field name="incident_beam_size" type="NX_FLOAT" units="NX_LENGTH"  minOccurs="0">
+					<field name="incident_beam_size" type="NX_FLOAT" units="NX_LENGTH"  recommended="true">
 						<doc>
 							Two-element array of FWHM (if Gaussian or Airy function) or
-							diameters (if top hat) or widths (if rectangular) of beam
+							diameters (if top hat) or widths (if rectangular) of the beam
 							in the order x, y
 						</doc>
-							<dimensions rank="1">
-							    <dim index="1" value="2"/>
-							</dimensions>
+						<dimensions rank="1">
+							<dim index="1" value="2"/>
+						</dimensions>
 					</field>
 
-					<field name="profile" type="NX_CHAR" minOccurs="0">
+					<field name="profile" type="NX_CHAR" recommended="true">
 						<doc>
 							The beam profile, Gaussian, Airy function, top-hat or
 							rectangular.  The profile is given in the plane of
@@ -708,7 +783,7 @@
 					</field>
 
 
-					<field name="incident_polarisation_stokes" minOccurs="0">
+					<field name="incident_polarisation_stokes" recommended="true">
 						<dimensions rank="2">
 							<dim index="1" value="np" />
 							<dim index="2" value="4" />
@@ -717,26 +792,22 @@
 				</group>
 			</group>
 
-                        <group type="NXsource">
+			<group type="NXsource">
 				<doc>
 					The neutron or x-ray storage ring/facility. Note, the NXsource base class
-					as many more fields available, but at present we only require the name.
+					has many more fields available, but at present we only require the name.
 				</doc>
 				<field name="name" minOccurs="1">
-					<doc>Name of source</doc>
-					<attribute name="short_name">
+					<doc>
+						Name of source.  Consistency with the naming in
+						http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items
+						/_diffrn_source.pdbx_synchrotron_site.html controlled 
+						vocabulary is highly recommended.
+					</doc>
+					<attribute name="short_name" optional="true">
 						<doc>short name for source, perhaps the acronym</doc>
 					</attribute>
 				</field>
-			</group>
-			<group type="NXdata" minOccurs="0">
-				<doc>
-					The pixel data recorded, if available.
-					For a dimension-2 detector, the rank of the data array will be 3.
-					For a dimension-3 detector, the rank of the data array will be 4.
-					This allows for the introduction of the frame number as the
-					first index.
-				</doc>
 			</group>
 		</group>
 </definition>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -168,7 +168,7 @@
 
 
 			<group type="NXinstrument">
-				<field name="name" minOccurs="1">
+				<field name="name" type="NXchar" minOccurs="1">
 					<doc>
 						Name of instrument.  Consistency with the controlled 
 						vocabulary beamline naming in http://mmcif.wwpdb.org
@@ -723,6 +723,12 @@
 							of dimensions **np** by **m** (slow to fast) with the
 							relative weights in incident_wavelength_weight as a 2D
 							array.
+							
+							Note, :ref:`variants &lt;Design-Variants&gt;` are a good way
+							to represent several of these use cases in a single dataset,
+							e.g. if a calibrated, single-value wavelength value is
+							available along with the original spectrum from which it
+							was calibrated.
 						</doc>
 					</field>
 
@@ -744,6 +750,11 @@
 						<doc>
 							The wavelength spread FWHM for the corresponding
 							wavelength(s) in incident_wavelength.
+							
+							In the case of shot-to-shot variation in the wavelength
+							spread, this is a 2D array of dimension **np** by
+							**m** (slow to fast) of the spreads of the
+							corresponding wavelengths in incident_wavelength.
 						</doc>
 					</field>
 

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -519,7 +519,19 @@
 						</dimensions>
 					</field>
 
-					<field name="flatfield_error" type="NX_FLOAT" minOccurs="0">
+					<field name="flatfield_error" type="NX_FLOAT" minOccurs="0" maxOccurs="0" >
+						<doc>
+							*** Deprecated form.  Use plural form ***
+							Errors of the flat field correction data.  If provided, it is recommended
+							that it be compressed.
+						</doc>
+						<dimensions rank="dataRank">
+							<dim index="1" value="i" />
+							<dim index="2" value="j" />
+							<dim index="3" value="k" required="false"/>
+						</dimensions>
+					</field>
+					<field name="flatfield_errors" type="NX_FLOAT" minOccurs="0">
 						<doc>
 							Errors of the flat field correction data.  If provided, it is recommended
 							that it be compressed.

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -162,7 +162,7 @@
 					</doc>
 				</group>
 
-				<field name="temperature" units="NX_TEMPERATURE" minOccurs="0" />
+				<field name="temperature" units="NX_TEMPERATURE" type="NX_NUMBER" minOccurs="0" />
 
 			</group>
 
@@ -428,7 +428,7 @@
 						</doc>
 					</field>
 
-					<field name="distance_derived" type="NX_BOOLEAN" units="NX_LENGTH" recommended="true">
+					<field name="distance_derived" type="NX_BOOLEAN" recommended="true">
 						<doc>
 							Boolean to indicate if the distance is a derived, rather than
 							a primary observation.  If distance_derived true or is not specified,
@@ -449,7 +449,7 @@
 						</doc>
 					</field>
 
-					<field name="beam_center_derived" type="NX_BOOLEAN" units="NX_LENGTH" optional="true">
+					<field name="beam_center_derived" type="NX_BOOLEAN" optional="true">
 						<doc>
 							Boolean to indicate if the distance is a derived, rather than
 							a primary observation.  If true or not provided, that value of
@@ -507,10 +507,10 @@
 						</doc>
 					</field>
 
-					<field name="flatfield" type="NX_FLOAT" minOccurs="0">
+					<field name="flatfield" type="NX_NUMBER" minOccurs="0">
 						<doc>
 							Flat field correction data.  If provided, it is recommended
-							that is be compressed.
+							that it be compressed.
 						</doc>
 						<dimensions rank="dataRank">
 							<dim index="1" value="i" />
@@ -519,7 +519,7 @@
 						</dimensions>
 					</field>
 
-					<field name="flatfield_error" type="NX_FLOAT" minOccurs="0" maxOccurs="0" >
+					<field name="flatfield_error" type="NX_NUMBER" minOccurs="0" maxOccurs="0" >
 						<doc>
 							*** Deprecated form.  Use plural form ***
 							Errors of the flat field correction data.  If provided, it is recommended
@@ -531,7 +531,7 @@
 							<dim index="3" value="k" required="false"/>
 						</dimensions>
 					</field>
-					<field name="flatfield_errors" type="NX_FLOAT" minOccurs="0">
+					<field name="flatfield_errors" type="NX_NUMBER" minOccurs="0">
 						<doc>
 							Errors of the flat field correction data.  If provided, it is recommended
 							that it be compressed.

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -108,11 +108,11 @@
 
   </field>
 
-  <field name="data_error" type="NX_NUMBER" units="NX_ANY">
+  <field name="data_errors" type="NX_NUMBER" units="NX_ANY">
     <doc>
       The best estimate of the uncertainty in the data value. Where
       possible, this should be the standard deviation, which has the same units
-      as the data.
+      as the data. The form data_error is deprecated.
     </doc>
 
     <dimensions rank="4">
@@ -122,6 +122,7 @@
       <dim index="4" value="tof" />
     </dimensions>
   </field>
+
 
   <field name="x_pixel_offset" type="NX_FLOAT" units="NX_LENGTH">
     <doc>
@@ -572,8 +573,11 @@
       <dim index="2" value="j"/>
     </dimensions>
   </field>
-  <field name="flatfield_error" type="NX_FLOAT" >
-    <doc>Errors of the flat field correction data.</doc>
+  <field name="flatfield_errors" type="NX_FLOAT" >
+    <doc>
+        Errors of the flat field correction data.
+        The form flatfield_error is deprecated.
+    </doc>
     <dimensions rank="2">
       <dim index="1" value="i"/>
       <dim index="2" value="j"/>

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -637,7 +637,7 @@
       <dim index="2" value="j"/>
     </dimensions>
   </field>
-  <field name="countrate_correction__applied" type="NX_BOOLEAN" >
+  <field name="countrate_correction_applied" type="NX_BOOLEAN" >
     <doc>
       True when a count-rate correction has already been applied in the
       electronics, false otherwise.

--- a/manual/source/datarules.rst
+++ b/manual/source/datarules.rst
@@ -633,7 +633,7 @@ plottable data is as follows:
       naming the field **in this group** to be used as 
       dimension scales of the default plottable data.  
       The number of values given must be equal to the 
-      *rank* of the *signal* data.  These are the *abcissae*
+      *rank* of the *signal* data.  These are the *abscissae*
       of the plottable *signal* data.
       
       *If* no field is available to provide a dimension scale
@@ -657,7 +657,7 @@ plottable data is as follows:
       
       It is possible there may be more than one ``AXISNAME_indices`` attribute
       with the same value or values.  This indicates the possibilty of using
-      alternate abcissae along this (these) dimension(s).  The
+      alternate abscissae along this (these) dimension(s).  The
       field named in the ``axes`` attribute indicates the intention of
       the data file writer as to which field should be used by default.
 

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -623,19 +623,23 @@
 				<xs:sequence>
 					<xs:element name="dimensions" type="nx:dimensionsType" minOccurs="0" maxOccurs="1">
 						<xs:annotation>
-							<xs:documentation>dimensions of a data element 
-							in a NeXus file</xs:documentation>
+							<xs:documentation>
+								dimensions of a data element in a NeXus file
+							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="attribute" type="nx:attributeType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
-							<xs:documentation>attributes to be used with this field</xs:documentation>
+							<xs:documentation>
+								attributes to be used with this field
+							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="enumeration" type="nx:enumerationType" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>A field can specify which 
-							values are to be used</xs:documentation>
+							<xs:documentation>
+								A field can specify which values are to be used
+							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -818,7 +818,7 @@
 				<xs:attribute name="data_offset" use="optional"  default="1" type="nx:nonNegativeUnbounded">
 					<xs:annotation>
 						<!--
-							note: renamed from "offset" due to comflict with CIF usage.
+							note: renamed from "offset" due to conflict with CIF usage.
 							see: https://github.com/nexusformat/definitions/issues/330#issuecomment-232074420
 							-->
 						<xs:documentation>

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -2,7 +2,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	targetNamespace="http://definition.nexusformat.org/nxdl/3.1"
-	xmlns:nx="http://definition.nexusformat.org/nxdl/3.1"
+	xmlns:nx="http://definition.nexusformat.org/nxdl/3.1" 
 	elementFormDefault="qualified">
 
 	<xs:annotation>
@@ -11,7 +11,7 @@
 				NeXus - Neutron and X-ray Common Data Format
 
 				Copyright (C) 2008-2020 NeXus International Advisory Committee (NIAC)
-				
+				 
 				This library is free software; you can redistribute it and/or
 				modify it under the terms of the GNU Lesser General Public
 				License as published by the Free Software Foundation; either
@@ -35,7 +35,7 @@
 	<xs:include schemaLocation="nxdlTypes.xsd">
 		<xs:annotation>
 			<xs:documentation>
-				Definitions of the basic data types and unit types
+				Definitions of the basic data types and unit types 
 				allowed in NXDL instance files.
 			</xs:documentation>
 		</xs:annotation>
@@ -51,7 +51,7 @@
 				is the ``group`` at the
 				root of every NXDL specification.
 				It may *only* appear
-				at the root of an NXDL file and must only appear
+				at the root of an NXDL file and must only appear 
 				**once** for the NXDL to be *well-formed*.
 			</xs:documentation>
 		</xs:annotation>
@@ -62,20 +62,20 @@
 	<xs:simpleType name="validItemName">
 		<xs:annotation>
 			<xs:documentation>
-				Used for allowed names of elements and attributes.
-				Need to be restricted to valid program variable names.
+				Used for allowed names of elements and attributes.  
+				Need to be restricted to valid program variable names.  
 				Note:  This means no "-" or "." characters can be allowed and
 				you cannot start with a number.
-				HDF4 had a 64 character limit on names
-				(possibly including NULL) and NeXus enforces this
-				via the ``NX_MAXNAMELEN`` variable with
+				HDF4 had a 64 character limit on names 
+				(possibly including NULL) and NeXus enforces this 
+				via the ``NX_MAXNAMELEN`` variable with 
 				a **64** character limit (which
 				may be 63 on a practical basis if one considers a NULL
 				terminating byte).
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define a data type.)
-			</xs:documentation>
-		</xs:annotation>
+			</xs:documentation>  
+		</xs:annotation>  
 		<xs:restriction base="xs:token">
 			<xs:pattern value="[A-Za-z_][\w_]*" />
 			<xs:maxLength value="63" />   <!-- enforce via NX_MAXNAMELEN -->
@@ -85,12 +85,12 @@
 	<xs:simpleType name="validNXClassName">
 		<xs:annotation>
 			<xs:documentation>
-				Used for allowed names of NX class types (e.g. NXdetector)
-				not the instance (e.g. bank1) which is covered by validItemName.
-				(This data type is used internally in the NXDL schema
-				to define a data type.)
-			</xs:documentation>
-		</xs:annotation>
+			  Used for allowed names of NX class types (e.g. NXdetector) 
+			  not the instance (e.g. bank1) which is covered by validItemName.  
+			  (This data type is used internally in the NXDL schema 
+			  to define a data type.)
+			</xs:documentation>  
+		</xs:annotation>  
 		<xs:restriction base="nx:validItemName">
 			<xs:pattern value="NX.+"/>
 		</xs:restriction>
@@ -102,7 +102,7 @@
 				This is a valid link target - currently it must be an absolute path
 				made up of valid names with the ``/`` character delimiter.  But we may
 				want to consider allowing "``..``" (parent of directory) at some point.
-				If the ``name`` attribute is helpful, then use it in the path
+				If the ``name`` attribute is helpful, then use it in the path 
 				with the syntax of *name:type* as in these examples::
 				
 					/NXentry/NXinstrument/analyzer:NXcrystal/ef
@@ -110,19 +110,19 @@
 					/NX_other
 				
 				Must also consider use of ``name`` attribute in resolving ``link`` targets.
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define a data type.)
-			</xs:documentation>
-		</xs:annotation>
+			</xs:documentation>  
+		</xs:annotation>  
 		<xs:restriction base="xs:token">
 			<xs:annotation>
 				<xs:documentation>
 					From the HDF5 documentation:
 					
-						*Note that relative path names in HDF5 do not employ the ``../`` notation,
+						*Note that relative path names in HDF5 do not employ the ``../`` notation, 
 						the UNIX notation indicating a parent directory, to indicate a parent group.*
 					
-					Thus, if we only consider the case of
+					Thus, if we only consider the case of 
 					``[name:]type``, the matching regular expression syntax
 					is written: ``/[a-zA-Z_][\w_]*(:[a-zA-Z_][\w_]*)?)+``.
 					Note that HDF5 also permits relative path names, such as:
@@ -140,10 +140,10 @@
 		<xs:attribute name="deprecated" use="optional">
 			<xs:annotation>
 				<xs:documentation>
-					The presence of the ``deprecated`` attribute
+					The presence of the ``deprecated`` attribute 
 					indicates to the data file validation process that
 					an advisory message (specified as the content of the
-					``deprecated`` attribute) will be reported.
+					``deprecated`` attribute) will be reported.  
 					Future versions of the NXDL file might
 					not define (or even re-use) the component marked with this attribute.
 					
@@ -153,8 +153,8 @@
 					
 					  deprecated="as of release MAJOR.MINOR"
 					
-					Note: because ``deprecated`` is an attribute,
-					the XML rules do not permit it to have any
+					Note: because ``deprecated`` is an attribute, 
+					the XML rules do not permit it to have any 
 					element content.
 				</xs:documentation>
 			</xs:annotation>
@@ -170,10 +170,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				A ``definition`` is the root element of every NXDL definition.
-				It may *only* appear at the root of an NXDL file and must only
+				It may *only* appear at the root of an NXDL file and must only 
 				appear **once** for the NXDL to be *well-formed*.
 
-				The ``definitionType`` defines the documentation,
+				The ``definitionType`` defines the documentation, 
 				attributes, fields, and groups that will be used
 				as children of the ``definition`` element.
 				Could contain these elements:
@@ -184,9 +184,9 @@
 				* ``group``
 				* ``link``
 
-				Note that a ``definition`` element also includes the definitions of the
+				Note that a ``definition`` element also includes the definitions of the 
 				``basicComponent`` data type.
-				(The ``definitionType`` data type is used internally in the NXDL schema
+				(The ``definitionType`` data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 				
 				Note that the first line of text in a ``doc`` element in a ``definition``
@@ -198,7 +198,7 @@
 			<xs:element name="symbols" type="nx:symbolsType" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
-						Use a ``symbols`` list
+						Use a ``symbols`` list  
 						to define each of the mnemonics that
 						represent the length of each dimension in a vector or array.
 					</xs:documentation>
@@ -264,17 +264,17 @@
 		<xs:attribute name="category" use="required">
 			<xs:annotation>
 				<xs:documentation>
-					NXDL ``base`` definitions define the dictionary
-					of terms to use for these components.
+					NXDL ``base`` definitions define the dictionary 
+					of terms to use for these components.  
 					All terms in a ``base`` definition are optional.
-					NXDL ``application`` definitions define what is
-					required for a scientific interest.
-					All terms in an ``application`` definition
+					NXDL ``application`` definitions define what is 
+					required for a scientific interest.  
+					All terms in an ``application`` definition 
 					are required.
-					NXDL ``contributed`` definitions may be
+					NXDL ``contributed`` definitions may be 
 					considered either base or applications.
-					Contributed definitions <emphasis>must</emphasis> indicate
-					their intended use, either as a base class or
+					Contributed definitions <emphasis>must</emphasis> indicate 
+					their intended use, either as a base class or 
 					as an application definition.
 				</xs:documentation>
 			</xs:annotation>
@@ -290,12 +290,12 @@
 			<xs:annotation>
 				<xs:documentation>
 					Only validate known groups; do not not warn about unknowns.
-					The ``ignoreExtraGroups`` attribute is a flag to the process of
-					validating NeXus data files.  By setting ``ignoreExtraGroups="true"``,
-					presence of any undefined groups in this class will not generate warnings
-					during validation.  Normally, validation will check all the groups against
-					their definition in the NeXus base classes and
-					application definitions.  Any items found that do not match the definition
+					The ``ignoreExtraGroups`` attribute is a flag to the process of 
+					validating NeXus data files.  By setting ``ignoreExtraGroups="true"``, 
+					presence of any undefined groups in this class will not generate warnings 
+					during validation.  Normally, validation will check all the groups against 
+					their definition in the NeXus base classes and 
+					application definitions.  Any items found that do not match the definition 
 					in the NXDL will generate a warning message.
 					
 					The ``ignoreExtraGroups`` attribute should be used sparingly!
@@ -306,12 +306,12 @@
 			<xs:annotation>
 				<xs:documentation>
 					Only validate known fields; do not not warn about unknowns.
-					The ``ignoreExtraFields`` attribute is a flag to the process of
-					validating NeXus data files.  By setting ``ignoreExtraFields="true"``,
-					presence of any undefined fields in this class will not generate warnings
-					during validation.  Normally, validation will check all the fields against
-					their definition in the NeXus base classes and
-					application definitions.  Any items found that do not match the definition
+					The ``ignoreExtraFields`` attribute is a flag to the process of 
+					validating NeXus data files.  By setting ``ignoreExtraFields="true"``, 
+					presence of any undefined fields in this class will not generate warnings 
+					during validation.  Normally, validation will check all the fields against 
+					their definition in the NeXus base classes and 
+					application definitions.  Any items found that do not match the definition 
 					in the NXDL will generate a warning message.
 					
 					The ``ignoreExtraFields`` attribute should be used sparingly!
@@ -322,12 +322,12 @@
 			<xs:annotation>
 				<xs:documentation>
 					Only validate known attributes; do not not warn about unknowns.
-					The ``ignoreExtraAttributes`` attribute is a flag to the process of
-					validating NeXus data files.  By setting ``ignoreExtraAttributes="true"``,
-					presence of any undefined attributes in this class will not generate warnings
-					during validation.  Normally, validation will check all the attributes
-					against their definition in the NeXus base classes and
-					application definitions.  Any items found that do not match the definition
+					The ``ignoreExtraAttributes`` attribute is a flag to the process of 
+					validating NeXus data files.  By setting ``ignoreExtraAttributes="true"``, 
+					presence of any undefined attributes in this class will not generate warnings 
+					during validation.  Normally, validation will check all the attributes 
+					against their definition in the NeXus base classes and 
+					application definitions.  Any items found that do not match the definition 
 					in the NXDL will generate a warning message.
 					
 					The ``ignoreExtraAttributes`` attribute should be used sparingly!
@@ -341,7 +341,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				Prescribes the allowed values for ``definition`` ``type`` attribute.
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define a data type.)
 			</xs:documentation>
 		</xs:annotation>
@@ -362,24 +362,24 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="group" type="nx:groupType" minOccurs="2" maxOccurs="unbounded">
-				<xs:annotation>
-					<xs:documentation>
-						NeXus base class that could be used here.
-						The group will take the ``@name`` attribute
-						defined by the parent ``choice`` element
-						so do not specify the ``@name`` attribute of
-						the group here.
-					</xs:documentation>
-					<!-- TODO: How to enforce the name rule in the schema? -->
-				</xs:annotation>
-			</xs:element>
+		  <xs:element name="group" type="nx:groupType" minOccurs="2" maxOccurs="unbounded">
+		  	<xs:annotation>
+		  		<xs:documentation>
+		  			NeXus base class that could be used here.
+		  			The group will take the ``@name`` attribute 
+		  			defined by the parent ``choice`` element
+		  			so do not specify the ``@name`` attribute of
+		  			the group here.
+		  		</xs:documentation>
+		  		<!-- TODO: How to enforce the name rule in the schema? -->
+		  	</xs:annotation>
+		  </xs:element>
 		</xs:sequence>
 		<xs:attribute name="name" use="required" type="nx:validItemName">
 			<xs:annotation>
 				<xs:documentation>
-					The name to be applied to the selected child group.
-					None of the child groups should define a
+					The name to be applied to the selected child group.  
+					None of the child groups should define a 
 					``@name`` attribute.
 				</xs:documentation>
 			</xs:annotation>
@@ -391,7 +391,7 @@
 	<xs:complexType name="groupType">
 		<xs:annotation>
 			<xs:documentation>
-				A group element refers to the definition of
+				A group element refers to the definition of 
 				an existing NX object or a locally-defined component.
 				Could contain these elements:
 				
@@ -401,9 +401,9 @@
 				* ``group``
 				* ``link``
 				
-				Note that a ``group`` element also includes the definitions of the
+				Note that a ``group`` element also includes the definitions of the 
 				``basicComponent`` data type.
-				(The ``groupType`` data type is used internally in the NXDL schema
+				(The ``groupType`` data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 			</xs:documentation>
 		</xs:annotation>
@@ -417,8 +417,8 @@
 		<xs:attribute name="type" use="required" type="nx:validNXClassName">
 			<xs:annotation>
 				<xs:documentation>
-					The ``type`` attribute *must*
-					contain the name of a
+					The ``type`` attribute *must* 
+					contain the name of a 
 					NeXus base class, application definition, or contributed definition.
 				</xs:documentation>
 			</xs:annotation>
@@ -431,16 +431,16 @@
 					required to specify the ``name``
 					attribute in the NXDL file.
 					It is suggested to always specify a ``name``
-					to avoid ambiguity.  It is also suggested to
-					derive the ``name`` from the
+					to avoid ambiguity.  It is also suggested to 
+					derive the ``name`` from the 
 					type, using an additional number suffix as necessary.
-					For example, consider a data file with only one
-					``NXentry``.  The suggested default
+					For example, consider a data file with only one 
+					``NXentry``.  The suggested default 
 					``name`` would
 					be ``entry``.  For a data file with two or more
 					``NXentry`` groups, the suggested names would be
 					``entry1``, ``entry2``, ...
-					Alternatively, a scientific application such as small-angle
+					Alternatively, a scientific application such as small-angle 
 					scattering might require
 					a different naming procedure; two different ``NXaperture`` groups
 					might be given the names ``beam-defining slit``
@@ -455,6 +455,21 @@
 					parent group.  Note each ``group`` must have a ``name`` attribute
 					that is unique among all ``group`` and ``field``
 					declarations within a common parent group.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="recommended" use="optional" type="nx:NX_BOOLEAN" default="false" >
+			<xs:annotation>
+				<xs:documentation>
+					A synomym for optional, but with the recommendation that this
+					``group'' be specificied.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="optional" use="optional" type="nx:NX_BOOLEAN" default="false" >
+			<xs:annotation>
+				<xs:documentation>
+					A synomym for minOccurs=0..
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -474,7 +489,7 @@
 	<xs:group name="groupGroup">
 		<xs:annotation>
 			<xs:documentation>
-				A ``groupGroup`` defines the allowed children of a
+				A ``groupGroup`` defines the allowed children of a 
 				``group`` specification.
 			</xs:documentation>
 		</xs:annotation>
@@ -482,7 +497,7 @@
 			<xs:element name="doc" type="nx:docType" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
-						Describe the purpose of this ``group``.
+						Describe the purpose of this ``group``. 
 						This documentation will go into the manual.
 					</xs:documentation>
 				</xs:annotation>
@@ -490,7 +505,7 @@
 			<xs:element name="attribute" type="nx:attributeType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-						Use an ``attribute`` if additional information
+						Use an ``attribute`` if additional information 
 						needs to be associated with a ``group``.
 					</xs:documentation>
 				</xs:annotation>
@@ -520,15 +535,15 @@
 			<xs:element name="link" type="nx:linkType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-						Use a ``link`` to refer locally to
-						information placed elsewhere else in the data storage hierarchy.
-						The ``name`` attribute uniquely identifies
+						Use a ``link`` to refer locally to 
+						information placed elsewhere else in the data storage hierarchy.  
+						The ``name`` attribute uniquely identifies 
 						the element in this ``group``.
-						The ``target`` attribute
+						The ``target`` attribute 
 						(added automatically in a data file by the NAPI)
 						identifies the original location of this data in the
 						data storage hierarchy.
-						In an NXDL specification, the ``target`` attribute
+						In an NXDL specification, the ``target`` attribute 
 						indicates a link to be made by the software that writes the data file.
 						The value, as written in the NXDL file, will be a suggestion of
 						the path to the source of the link.
@@ -550,10 +565,10 @@
 	<xs:complexType name="basicComponent">
 			<xs:annotation>
 				<xs:documentation>
-					A ``basicComponent`` defines the allowed name
-					format and attributes common to all ``field``
+					A ``basicComponent`` defines the allowed name 
+					format and attributes common to all ``field`` 
 					and ``group`` specifications.
-					(This data type is used internally in the NXDL schema
+					(This data type is used internally in the NXDL schema 
 					to define elements and attributes to be used by users in NXDL specifications.)
 				</xs:documentation>
 			</xs:annotation>
@@ -570,11 +585,11 @@
 		<xs:attribute name="name" use="required" type="nx:validItemName">
 			<xs:annotation>
 				<xs:documentation>
-					The ``name`` attribute is the
+					The ``name`` attribute is the 
 					identifier string for this entity.
-					It is required that ``name`` must be unique
+					It is required that ``name`` must be unique 
 					within the enclosing ``group``.
-					The rule (``validItemName``) is defined to only
+					The rule (``validItemName``) is defined to only 
 					allow names that can be represented as valid variable names
 					in most computer languages.
 				</xs:documentation>
@@ -588,8 +603,8 @@
 	<xs:complexType name="fieldType">
 		<xs:annotation>
 			<xs:documentation>
-				A ``field`` declares a new element in the component being defined.
-				A ``field`` is synonymous with the HDF4 SDS (Scientific Data Set) and
+				A ``field`` declares a new element in the component being defined. 
+				A ``field`` is synonymous with the HDF4 SDS (Scientific Data Set) and 
 				the HDF5 *dataset* terms.   Could contain these elements:
 				
 				* ``attribute``
@@ -597,9 +612,9 @@
 				* ``doc``
 				* ``enumeration``
 				
-				Note that a ``field`` element also includes the definitions of the
+				Note that a ``field`` element also includes the definitions of the 
 				``basicComponent`` data type.
-				(The ``fieldType`` data type is used internally in the NXDL schema
+				(The ``fieldType`` data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 			</xs:documentation>
 		</xs:annotation>
@@ -608,23 +623,19 @@
 				<xs:sequence>
 					<xs:element name="dimensions" type="nx:dimensionsType" minOccurs="0" maxOccurs="1">
 						<xs:annotation>
-							<xs:documentation>
-								dimensions of a data element in a NeXus file
-							</xs:documentation>
+							<xs:documentation>dimensions of a data element 
+							in a NeXus file</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="attribute" type="nx:attributeType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
-							<xs:documentation>
-								attributes to be used with this field
-							</xs:documentation>
+							<xs:documentation>attributes to be used with this field</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="enumeration" type="nx:enumerationType" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>
-								A field can specify which values are to be used
-							</xs:documentation>
+							<xs:documentation>A field can specify which 
+							values are to be used</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>
@@ -679,7 +690,7 @@
 							The regular expression for this rule is::
 							
 								[A-Za-z_][\w_]*([ :][A-Za-z_][\w_]*)*
-							
+								
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -693,24 +704,24 @@
 							
 							The attribute value is an integer indicating this
 							field as an axis that is part of the data set.
-							The data set is a field with the attribute
+							The data set is a field with the attribute 
 							``signal=1`` in the same group.
-							The value can range from 1 up to the number of
-							independent axes (abscissae) in the data set.
+							The value can range from 1 up to the number of 
+							independent axes (abscissae) in the data set.  
 							
-							A value of ``axis=1``" indicates that this field
-							contains the data for the first independent axis.
+							A value of ``axis=1``" indicates that this field 
+							contains the data for the first independent axis.  
 							For example, the X axis in an XY data set.
 							
-							A value of ``axis=2`` indicates that this field
+							A value of ``axis=2`` indicates that this field 
 							contains the data for the second independent axis.
 							For example, the Y axis in a 2-D data set.
 							
-							A value of ``axis=3`` indicates that this field
+							A value of ``axis=3`` indicates that this field 
 							contains the data for the third independent axis.
 							For example, the Z axis in a 3-D data set.
 							
-							A field with an ``axis`` attribute should
+							A field with an ``axis`` attribute should 
 							not have a ``signal`` attribute.
 						</xs:documentation>
 					</xs:annotation>
@@ -721,7 +732,7 @@
 							Integer indicating the priority of selection
 							of this field for plotting (or visualization) as an axis.
 							
-							Presence of the ``primary`` attribute means this
+							Presence of the ``primary`` attribute means this 
 							field is an abscissa.
 						</xs:documentation>
 					</xs:annotation>
@@ -738,16 +749,31 @@
 				<xs:attribute name="minOccurs" use="optional" default="0" type="nx:nonNegativeUnbounded">
 					<xs:annotation>
 						<xs:documentation>
-							Defines the minimum number of times this ``field`` may be used.  Its
+							Defines the minimum number of times this ``field`` may be used.  Its 
 							value is confined to zero or greater.  Must be less than or equal to
 							the value for the "maxOccurs" attribute.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="recommended" use="optional" type="nx:NX_BOOLEAN" default="false" >
+					<xs:annotation>
+						<xs:documentation>
+							A synomym for optional, but with the recommendation that this
+							``field'' be specificied.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="optional" use="optional" type="nx:NX_BOOLEAN" default="false" >
+					<xs:annotation>
+						<xs:documentation>
+							A synomym for minOccurs=0..
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="maxOccurs" use="optional"  default="1" type="nx:nonNegativeUnbounded">
 					<xs:annotation>
 						<xs:documentation>
-							Defines the maximum number of times this element may be used.  Its
+							Defines the maximum number of times this element may be used.  Its 
 							value is confined to zero or greater.  Must be greater than or equal to
 							the value for the "minOccurs" attribute.
 							A value of "unbounded" is allowed.
@@ -758,18 +784,18 @@
 					<xs:annotation>
 						<xs:documentation>
 							The ``stride`` and ``data_offset`` attributes
-							are used together to index the array of data items in a
+							are used together to index the array of data items in a 
 							multi-dimensional array.  They may be used as an alternative
 							method to address a data array that is not stored in the standard NeXus
 							method of "C" order.
 							
-							The ``stride`` list chooses array locations from the
-							data array  with each value in the ``stride`` list
-							determining how many elements to move in each dimension.
-							Setting a value in the ``stride`` array to 1 moves
-							to each element in that dimension of the data array, while
-							setting a value of 2 in a location in the ``stride``
-							array moves to every other element in that dimension of the
+							The ``stride`` list chooses array locations from the 
+							data array  with each value in the ``stride`` list 
+							determining how many elements to move in each dimension. 
+							Setting a value in the ``stride`` array to 1 moves 
+							to each element in that dimension of the data array, while 
+							setting a value of 2 in a location in the ``stride`` 
+							array moves to every other element in that dimension of the 
 							data array.  A value in the ``stride`` list may be
 							positive to move forward or negative to step backward.
 							A value of zero will not step (and is of no particular use).
@@ -779,9 +805,9 @@
 							https://portal.hdfgroup.org/display/HDF5/Dataspaces
 							
 
-							The ``stride`` attribute contains a
-							comma-separated list of integers.
-							(In addition to the required comma delimiter,
+							The ``stride`` attribute contains a 
+							comma-separated list of integers. 
+							(In addition to the required comma delimiter, 
 							whitespace is also allowed to improve readability.)
 							The number of items in the list
 							is equal to the rank of the data being stored.  The value of each
@@ -792,12 +818,12 @@
 				<xs:attribute name="data_offset" use="optional"  default="1" type="nx:nonNegativeUnbounded">
 					<xs:annotation>
 						<!--
-							note: renamed from "offset" due to conflict with CIF usage.
+							note: renamed from "offset" due to comflict with CIF usage.
 							see: https://github.com/nexusformat/definitions/issues/330#issuecomment-232074420
 							-->
 						<xs:documentation>
 							The ``stride`` and ``data_offset`` attributes
-							are used together to index the array of data items in a
+							are used together to index the array of data items in a 
 							multi-dimensional array.  They may be used as an alternative
 							method to address a data array that is not stored in the standard NeXus
 							method of "C" order.
@@ -810,13 +836,13 @@
 							or *4. Dataspace Selection Operations* in
 							https://portal.hdfgroup.org/display/HDF5/Dataspaces
 							
-							The ``data_offset`` attribute contains a
-							comma-separated list of integers.
-							(In addition to the required comma delimiter,
+							The ``data_offset`` attribute contains a 
+							comma-separated list of integers. 
+							(In addition to the required comma delimiter, 
 							whitespace is also allowed to improve readability.)
 							The number of items in the list
 							is equal to the rank of the data being stored.  The value of each
-							item is the offset in the array of the first data item of that
+							item is the offset in the array of the first data item of that 
 							subscript of the array.
 						</xs:documentation>
 					</xs:annotation>
@@ -824,16 +850,16 @@
 				<xs:attribute name="interpretation" use="optional">
 					<xs:annotation>
 						<xs:documentation>
-							This instructs the consumer of the data what the last dimensions
-							of the data are. It allows plotting software to work
+							This instructs the consumer of the data what the last dimensions 
+							of the data are. It allows plotting software to work 
 							out the natural way of displaying the data.
 							
 							For example a single-element, energy-resolving, fluorescence detector
-							with 512 bins should have ``interpretation="spectrum"``. If the
-							detector is scanned over a 512 x 512 spatial grid, the data reported
+							with 512 bins should have ``interpretation="spectrum"``. If the 
+							detector is scanned over a 512 x 512 spatial grid, the data reported 
 							will be of dimensions: 512 x 512 x 512.
-							In this example, the initial plotting representation should default to
-							data of the same dimensions of a 512 x 512 pixel ``image``
+							In this example, the initial plotting representation should default to 
+							data of the same dimensions of a 512 x 512 pixel ``image`` 
 							detector where the images where taken at 512 different pressure values.
 							
 							In simple terms, the allowed values mean:
@@ -846,12 +872,12 @@
 						</xs:documentation>
 					</xs:annotation>
 					<xs:simpleType>
-						<xs:restriction base="nx:NX_CHAR">
-							<xs:enumeration value="scalar"/>
-							<xs:enumeration value="spectrum"/>
-							<xs:enumeration value="image"/>
-							<xs:enumeration value="vertex"/>
-						</xs:restriction>
+                        <xs:restriction base="nx:NX_CHAR">
+                        	<xs:enumeration value="scalar"/>
+                        	<xs:enumeration value="spectrum"/>
+                        	<xs:enumeration value="image"/>
+                        	<xs:enumeration value="vertex"/>
+                        </xs:restriction>
 					</xs:simpleType>
 				</xs:attribute>
 				<xs:attribute name="nameType" use="optional" default="specified">
@@ -863,10 +889,10 @@
 						</xs:documentation>
 					</xs:annotation>
 					<xs:simpleType>
-						<xs:restriction base="nx:NX_CHAR">
-							<xs:enumeration value="specified"/>
-							<xs:enumeration value="any"/>
-						</xs:restriction>
+                        <xs:restriction base="nx:NX_CHAR">
+                        	<xs:enumeration value="specified"/>
+                        	<xs:enumeration value="any"/>
+                        </xs:restriction>
 					</xs:simpleType>
 				</xs:attribute>
 			</xs:extension>
@@ -884,7 +910,7 @@
 					* ``doc``
 					* ``enumeration``
 				
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 			</xs:documentation>
 		</xs:annotation>
@@ -925,7 +951,7 @@
 				<xs:documentation>
 					Type of the attribute.
 					For ``group`` specifications, the class name.
-					For ``field`` or ``attribute`` specifications,
+					For ``field`` or ``attribute`` specifications, 
 					the NXDL field type.
 				</xs:documentation>
 			</xs:annotation>
@@ -944,9 +970,9 @@
 	<xs:simpleType name="nonNegativeUnbounded">
 		<xs:annotation>
 			<xs:documentation>
-				A ``nonNegativeUnbounded`` allows values including
+				A ``nonNegativeUnbounded`` allows values including 
 				all positive integers, zero, and the string ``unbounded``.
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define a data type.)
 			</xs:documentation>
 		</xs:annotation>
@@ -969,7 +995,7 @@
 			<xs:documentation>
 				A link to another item.  Use a link to avoid
 				needless repetition of information.
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 			</xs:documentation>
 		</xs:annotation>
@@ -980,7 +1006,7 @@
 						<xs:documentation>
 							Declares the absolute HDF5 address of an existing field or group.
 							
-							The target attribute is added for NeXus to distinguish the
+							The target attribute is added for NeXus to distinguish the 
 							HDF5 path to the original dataset.
 							
 							Could contain these elements:
@@ -990,7 +1016,7 @@
 							Matching regular expression::
 							
 								(/[a-zA-Z_][\w_]*(:[a-zA-Z_][\w_]*)?)+
-							
+								
 							For example, given a
 							``/entry/instrument/detector/polar_angle`` field,
 							link it into the ``NXdata`` group
@@ -1006,14 +1032,14 @@
 											/detector:NXdetector
 												/polar_angle:NX_NUMBER
 													@target="/entry/instrument/detector/polar_angle"
-							
+											
 						</xs:documentation>
-					</xs:annotation>
+					</xs:annotation>					
 				</xs:attribute>
 				<xs:attribute name="napimount" use="optional" type="xs:string">
 					<xs:annotation>
 						<xs:documentation>
-							Group attribute that provides a URL to a group in another file.
+							Group attribute that provides a URL to a group in another file.  
 							More information is described in the *NeXus Programmers Reference*.
 							
 							http://manual.nexusformat.org/pdf/NeXusIntern.pdf
@@ -1029,7 +1055,7 @@
 			<xs:documentation>
 				NXDL allows for documentation on most elements using the ``doc``
 				element. The documentation is useful in several contexts. The documentation will be
-				rendered in the manual. Documentation, is provided as tooltips
+				rendered in the manual. Documentation, is provided as tooltips 
 				by some XML editors when editing NXDL files.
 				Simple documentation can be typed directly in the NXDL::
 
@@ -1046,13 +1072,13 @@
 				
 				* *any*
 				
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 
 				Note:
 				For documentation of ``definition`` elements,
 				the first line of text in a ``doc``
-				is used as a summary in the manual.
+				is used as a summary in the manual.  
 				Follow the pattern as shown
 				in the base class NXDL files.
 			</xs:documentation>
@@ -1080,7 +1106,7 @@
 			<xs:element name="doc" type="nx:docType" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
-						Describe the purpose of this list of ``symbols``.
+						Describe the purpose of this list of ``symbols``. 
 						This documentation will go into the manual.
 					</xs:documentation>
 				</xs:annotation>
@@ -1090,7 +1116,7 @@
 					<xs:documentation>
 						When multiple ``field`` elements share the same dimensions, such as the dimension scales
 						associated with plottable data in an ``NXdata`` group, the length of each
-						dimension written in a NeXus data file should be something that can be tested by the
+						dimension written in a NeXus data file should be something that can be tested by the 
 						data file validation process.
 					</xs:documentation>
 				</xs:annotation>
@@ -1099,7 +1125,7 @@
 						<xs:element name="doc" type="nx:docType" minOccurs="0" maxOccurs="1">
 							<xs:annotation>
 								<xs:documentation>
-									Describe the purpose of the parent ``symbol``.
+									Describe the purpose of the parent ``symbol``. 
 									This documentation will go into the manual.
 								</xs:documentation>
 							</xs:annotation>
@@ -1128,7 +1154,7 @@
 				* ``doc``
 				* ``item``
 				
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 				
 				::
@@ -1153,14 +1179,14 @@
 						Defines the value of one selection for an ``enumeration`` list.
 						Each enumerated item must have a value (it cannot have an empty text node).
 					</xs:documentation>
-				</xs:annotation>
+				</xs:annotation>				
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="doc" type="nx:docType" minOccurs="0" maxOccurs="1">
 							<xs:annotation>
 								<xs:documentation>
-									Individual items can be documented
-									but this documentation might not be printed in the
+									Individual items can be documented 
+									but this documentation might not be printed in the 
 									*NeXus Reference Guide*.
 								</xs:documentation>
 							</xs:annotation>
@@ -1180,13 +1206,13 @@
 	</xs:complexType>
 	
 	<xs:complexType name="dimensionsType">
-		<!--
-			see issue #32: https://github.com/nexusformat/definitions/issues/32
+		<!-- 
+			see issue #32: https://github.com/nexusformat/definitions/issues/32 
 		-->
 		<xs:annotation>
 			<xs:documentation>
 				dimensions of a data element in a NeXus file
-				(This data type is used internally in the NXDL schema
+				(This data type is used internally in the NXDL schema 
 				to define elements and attributes to be used by users in NXDL specifications.)
 			</xs:documentation>
 		</xs:annotation>
@@ -1204,9 +1230,9 @@
 					<xs:documentation>
 						Specify the parameters for each index of the ``dimensions``
 						element with a ``dim`` element.
-						The number of ``dim`` entries should be equal to
+						The number of ``dim`` entries should be equal to 
 						the ``rank`` of the array.
-						For example, these terms
+						For example, these terms 
 						describe a 2-D array with lengths (``nsurf``, ``nwl``):
 						
 						.. code-block:: xml
@@ -1218,7 +1244,7 @@
 							</dimensions>
 
 						The ``value`` attribute is used by NXDL and also by
-						the NeXus data file validation tools to associate and coordinate the
+						the NeXus data file validation tools to associate and coordinate the 
 						same array length across multiple fields in a group.
 					</xs:documentation>
 				</xs:annotation>
@@ -1226,12 +1252,12 @@
 					<xs:attribute name="index" use="required">
 						<xs:annotation>
 							<xs:documentation>
-								Number or symbol indicating which axis (subscript) is
-								being described, ranging from 1 up to
-								``rank`` (rank of the
-								data structure).  For example, given an array
-								``A[i,j,k]``,
-								``index="1"`` would refer to the
+								Number or symbol indicating which axis (subscript) is 
+								being described, ranging from 1 up to 
+								``rank`` (rank of the 
+								data structure).  For example, given an array 
+								``A[i,j,k]``, 
+								``index="1"`` would refer to the 
 								``i`` axis (subscript).
 								(``NXdata`` uses ``index="0"``
 								to indicate a situation when the specific index is not
@@ -1242,7 +1268,7 @@
 					<xs:attribute name="value" type="nx:NX_CHAR">
 						<xs:annotation>
 							<xs:documentation>
-								Integer length (number of values), or mnemonic symbol
+								Integer length (number of values), or mnemonic symbol 
 								representing the length of this axis.
 							</xs:documentation>
 						</xs:annotation>
@@ -1250,11 +1276,11 @@
 					<xs:attribute name="ref" type="nx:NX_CHAR">
 						<xs:annotation>
 							<xs:documentation>
-								Deprecated: 2016-11-23 telco
+								Deprecated: 2016-11-23 telco 
 								(https://github.com/nexusformat/definitions/issues/330)
 								
-								The dimension specification is the same as
-								that in the ``ref`` field, specified either by a relative path,
+								The dimension specification is the same as 
+								that in the ``ref`` field, specified either by a relative path, 
 								such as ``polar_angle`` or ``../Qvec`` or absolute path, such as
 								``/entry/path/to/follow/to/ref/field``.
 							</xs:documentation>
@@ -1263,10 +1289,10 @@
 					<xs:attribute name="refindex" type="nx:NX_CHAR">
 						<xs:annotation>
 							<xs:documentation>
-								Deprecated: 2016-11-23 telco
+								Deprecated: 2016-11-23 telco 
 								(https://github.com/nexusformat/definitions/issues/330)
 								
-								The dimension specification is the same as
+								The dimension specification is the same as 
 								the ``refindex`` axis within the ``ref`` field.
 								Requires ``ref`` attribute to be present.
 							</xs:documentation>
@@ -1276,7 +1302,7 @@
 						<xs:annotation>
 							<xs:documentation>
 								The dimension specification is related to
-								the ``refindex`` axis within the ``ref`` field by an
+								the ``refindex`` axis within the ``ref`` field by an 
 								offset of ``incr``.  Requires ``ref`` and ``refindex``
 								attributes to be present.
 							</xs:documentation>
@@ -1287,11 +1313,11 @@
 							<xs:documentation>
 								This dimension is required (true: default) or not required (false).
 								
-								The default value is ``true``.
+								The default value is ``true``.  
 								
 								When ``required="false"`` is
-								specified, all subsequent ``&lt;dim`` nodes
-								(with higher ``index`` value)
+								specified, all subsequent ``&lt;dim`` nodes 
+								(with higher ``index`` value) 
 								**must** also have ``required="false"``.
 							</xs:documentation>
 						</xs:annotation>
@@ -1307,8 +1333,8 @@
 					Value could be either an unsigned integer or a symbol
 					as defined in the *symbol* table of the NXDL file.
 					
-					For example: ``a[5]`` has ``rank="1"`` while
-					``b[8,5,6,4]`` has ``rank="4"``.
+					For example: ``a[5]`` has ``rank="1"`` while 
+					``b[8,5,6,4]`` has ``rank="4"``.  
 					See https://en.wikipedia.org/wiki/Rank_%28computer_programming%29 for more details.
 				</xs:documentation>
 			</xs:annotation>

--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -132,9 +132,14 @@ def get_required_or_optional_text(node, use_application_defaults):
     tag = node.tag.split('}')[-1]
     nm = node.get('name')
     if tag in ('field', 'group'):
+        optional_default = not use_application_defaults
+        optional = node.get('optional', optional_default) in (True, 'true', '1', 1)
+        recommended = node.get('recommended', None) in (True, 'true', '1', 1)
         minOccurs = get_minOccurs(node, use_application_defaults)
-        if minOccurs in ('0', 0):
+        if minOccurs in ('0', 0) or optional:
             optional_text = '(optional) '
+        elif recommended:
+            optional_text = '(recommended) '
         elif minOccurs in ('1', 1):
             optional_text = '(required) '
         else:
@@ -144,7 +149,10 @@ def get_required_or_optional_text(node, use_application_defaults):
     elif tag in ('attribute',):
         optional_default = not use_application_defaults
         optional = node.get('optional', optional_default) in (True, 'true', '1', 1)
+        recommended = node.get('recommended', None) in (True, 'true', '1', 1)
         optional_text = {True: '(optional) ', False: '(required) '}[optional]
+        if recommended:
+            optional_text = '(recommended) '
     else:
         optional_text = '(unknown tag: ' + str(tag) + ') '
     return optional_text


### PR DESCRIPTION
This is the new NXmx Gold Standard as discussed at the raw data e-workshop, 22 August 2020 for
consideration by NIAC.  There is a companion branch for cnxvalidate -- HJB

Includes a fix for #782