### PR TITLE
Added missing required dim fields

### DIFF
--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -105,15 +105,24 @@
         </field>
         <field name="sensor_size" type="NX_INT">
           <doc>number of raw active elements in fast and slow pixel dimension direction</doc>
-          <dimensions rank="2" />
+          <dimensions rank="2">
+          	<dim index="1" value="1" /> 
+          	<dim index="2" value="2" /> 
+          </dimensions>
         </field>
         <field name="region_origin" type="NX_INT">
           <doc>origin of rectangular region selected for readout</doc>
-          <dimensions rank="2" />
+          <dimensions rank="2">
+          	<dim index="1" value="1" /> 
+          	<dim index="2" value="2" /> 
+          </dimensions>
         </field>
         <field name="region_size" type="NX_INT">
           <doc>size of rectangular region selected for readout</doc>
-          <dimensions rank="2" />
+          <dimensions rank="2" >
+          	<dim index="1" value="1" /> 
+          	<dim index="2" value="2" /> 
+          </dimensions>
         </field>
       </group>
     </group>

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -104,7 +104,7 @@
           </doc>
         </field>
         <field name="sensor_size" type="NX_INT">
-          <doc>number of raw active elements in fast and slow pixel dimension direction</doc>
+          <doc>number of raw active elements in each dimension</doc>
           <dimensions rank="1">
           	<dim index="1" value="2" />
           </dimensions>

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -105,23 +105,20 @@
         </field>
         <field name="sensor_size" type="NX_INT">
           <doc>number of raw active elements in fast and slow pixel dimension direction</doc>
-          <dimensions rank="2">
-          	<dim index="1" value="1" /> 
-          	<dim index="2" value="2" /> 
+          <dimensions rank="1">
+          	<dim index="1" value="2" />
           </dimensions>
         </field>
         <field name="region_origin" type="NX_INT">
           <doc>origin of rectangular region selected for readout</doc>
-          <dimensions rank="2">
-          	<dim index="1" value="1" /> 
-          	<dim index="2" value="2" /> 
+          <dimensions rank="1">
+          	<dim index="1" value="2" />
           </dimensions>
         </field>
         <field name="region_size" type="NX_INT">
           <doc>size of rectangular region selected for readout</doc>
-          <dimensions rank="2" >
-          	<dim index="1" value="1" /> 
-          	<dim index="2" value="2" /> 
+          <dimensions rank="1" >
+          	<dim index="1" value="2" />
           </dimensions>
         </field>
       </group>


### PR DESCRIPTION
3 fields: **_sensor_size, region_origin_** and **_region_size_** all specified a **_rank_** but did not then specify the required **_dim_** fields as well, this pull request adds the missing dim fields so that the nxdl can be auto generated as well as pass **cnxvalidate**.