### PR TITLE
Symbol tables were added to def's that did not have them

### DIFF
--- a/applications/NXfluo.nxdl.xml
+++ b/applications/NXfluo.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
       <doc>
-        The symbol(s) listed here will be used below to coordinate datasets
-        with the same shape.  
+        The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="nE">
         <doc>Number of energies</doc>

--- a/applications/NXfluo.nxdl.xml
+++ b/applications/NXfluo.nxdl.xml
@@ -28,14 +28,14 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd "
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nE">
-				<doc>number of energies</doc>
-			</symbol>
-		</symbols>
+      <doc>
+        The symbol(s) listed here will be used below to coordinate datasets
+        with the same shape.  
+      </doc>
+      <symbol name="nE">
+        <doc>number of energies</doc>
+      </symbol>
+    </symbols>
     <doc>
       This is an application definition for raw data from an X-ray fluorescence experiment
     </doc>

--- a/applications/NXfluo.nxdl.xml
+++ b/applications/NXfluo.nxdl.xml
@@ -33,7 +33,7 @@
         with the same shape.  
       </doc>
       <symbol name="nE">
-        <doc>number of energies</doc>
+        <doc>Number of energies</doc>
       </symbol>
     </symbols>
     <doc>

--- a/applications/NXfluo.nxdl.xml
+++ b/applications/NXfluo.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd "
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nE">
+				<doc>number of energies</doc>
+			</symbol>
+		</symbols>
     <doc>
       This is an application definition for raw data from an X-ray fluorescence experiment
     </doc>
@@ -57,12 +66,12 @@
         <group type="NXdetector" name="fluorescence">
           <field name="data" type="NX_INT" axes="energy" signal="1">
             <dimensions rank="1">
-              <dim index="1" value="nenergy" />
+              <dim index="1" value="nE" />
             </dimensions>
           </field>
           <field name="energy" type="NX_FLOAT">
             <dimensions rank="1">
-              <dim index="1" value="nenergy" />
+              <dim index="1" value="nE" />
             </dimensions>
           </field>
         </group>

--- a/applications/NXindirecttof.nxdl.xml
+++ b/applications/NXindirecttof.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nDet">
+				<doc>number of detectors</doc>
+			</symbol>
+		</symbols>
     <doc>This is a application definition for raw data from a direct geometry TOF spectrometer</doc>
     <group type="NXentry" name="entry">
       <field name="title" />
@@ -47,12 +56,12 @@
         <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
           <doc>polar angle towards sample</doc>
           <dimensions rank="1">
-            <dim index="1" value="ndet" /></dimensions>
+            <dim index="1" value="nDet" /></dimensions>
         </field>  
         <field name="distance" type="NX_FLOAT" units="NX_LENGTH">
           <doc>distance from sample</doc>
           <dimensions rank="1">
-            <dim index="1" value="ndet" /></dimensions>
+            <dim index="1" value="nDet" /></dimensions>
         </field>  
         </group>
      </group>

--- a/applications/NXindirecttof.nxdl.xml
+++ b/applications/NXindirecttof.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
         <doc>
-            The symbol(s) listed here will be used below to coordinate datasets
-            with the same shape.
+            The symbol(s) listed here will be used below to coordinate datasets with the same shape.
         </doc>
         <symbol name="nDet">
             <doc>Number of detectors</doc>

--- a/applications/NXindirecttof.nxdl.xml
+++ b/applications/NXindirecttof.nxdl.xml
@@ -28,14 +28,14 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nDet">
-				<doc>number of detectors</doc>
-			</symbol>
-		</symbols>
+        <doc>
+            The symbol(s) listed here will be used below to coordinate datasets
+            with the same shape.
+        </doc>
+        <symbol name="nDet">
+            <doc>Number of detectors</doc>
+        </symbol>
+    </symbols>
     <doc>This is a application definition for raw data from a direct geometry TOF spectrometer</doc>
     <group type="NXentry" name="entry">
       <field name="title" />

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -33,7 +33,7 @@
             with the same shape.  
         </doc>
         <symbol name="nVars">
-            <doc>The number of values taken by the the variable</doc>
+            <doc>The number of values taken by the varied variable</doc>
         </symbol>
         <symbol name="nQX">
             <doc>Number of values for the first dimension of Q</doc>
@@ -94,14 +94,14 @@
               </doc>
               <dimensions rank="3">
 
-                <dim index="1" value="nE" />
+                <dim index="1" value="nVars" />
                 <dim index="2" value="nQX" />
                 <dim index="3" value="nQY" />
               </dimensions>
             </field>
             <field name="variable" axis="1">
               <dimensions rank="1">
-                <dim index="1" value="nE" /></dimensions>
+                <dim index="1" value="nVars" /></dimensions>
               <attribute name="varied_variable">
                 <doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc></attribute></field>
             <field name="qx" axis="2">

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -28,20 +28,20 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nE">
-				<doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc>
-			</symbol>
-			<symbol name="nQX">
-				<doc>Values for the first dimension of Q</doc>
-			</symbol>
-			<symbol name="nQY">
-				<doc>Values for the second dimension of Q</doc>
-			</symbol>
-		</symbols>
+        <doc>
+            The symbol(s) listed here will be used below to coordinate datasets
+            with the same shape.  
+        </doc>
+        <symbol name="nE">
+            <doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc>
+        </symbol>
+        <symbol name="nQX">
+            <doc>Values for the first dimension of Q</doc>
+        </symbol>
+        <symbol name="nQY">
+            <doc>Values for the second dimension of Q</doc>
+        </symbol>
+    </symbols>
     <doc>Application definition for any :math:`I(Q)` data.</doc>
     <group type="NXentry">
         <attribute name="entry">

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -27,6 +27,21 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nE">
+				<doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc>
+			</symbol>
+			<symbol name="nQX">
+				<doc>Values for the first dimension of Q</doc>
+			</symbol>
+			<symbol name="nQY">
+				<doc>Values for the second dimension of Q</doc>
+			</symbol>
+		</symbols>
     <doc>Application definition for any :math:`I(Q)` data.</doc>
     <group type="NXentry">
         <attribute name="entry">
@@ -79,24 +94,24 @@
               </doc>
               <dimensions rank="3">
 
-                <dim index="1" value="NE" />
-                <dim index="2" value="NQX" />
-                <dim index="3" value="NQY" />
+                <dim index="1" value="nE" />
+                <dim index="2" value="nQX" />
+                <dim index="3" value="nQY" />
               </dimensions>
             </field>
             <field name="variable" axis="1">
               <dimensions rank="1">
-                <dim index="1" value="NE" /></dimensions>
+                <dim index="1" value="nE" /></dimensions>
               <attribute name="varied_variable">
                 <doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc></attribute></field>
             <field name="qx" axis="2">
               <doc>Values for the first dimension of Q</doc>
               <dimensions rank="1">
-                <dim index="1" value="NQX" /></dimensions></field>
+                <dim index="1" value="nQX" /></dimensions></field>
             <field name="qy" axis="3">
               <doc>Values for the second dimension of Q</doc>
               <dimensions rank="1">
-                <dim index="1" value="NQY" /></dimensions></field>
+                <dim index="1" value="nQY" /></dimensions></field>
          </group>
      </group>
 </definition>

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -36,10 +36,10 @@
             <doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc>
         </symbol>
         <symbol name="nQX">
-            <doc>Values for the first dimension of Q</doc>
+            <doc>Number of values for the first dimension of Q</doc>
         </symbol>
         <symbol name="nQY">
-            <doc>Values for the second dimension of Q</doc>
+            <doc>Number of values for the second dimension of Q</doc>
         </symbol>
     </symbols>
     <doc>Application definition for any :math:`I(Q)` data.</doc>

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -32,8 +32,8 @@
             The symbol(s) listed here will be used below to coordinate datasets
             with the same shape.  
         </doc>
-        <symbol name="nE">
-            <doc>The real name of the varied variable in the first dim of data, temperature, P, MF etc...</doc>
+        <symbol name="nVars">
+            <doc>The number of values taken by the the variable</doc>
         </symbol>
         <symbol name="nQX">
             <doc>Number of values for the first dimension of Q</doc>

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
         <doc>
-            The symbol(s) listed here will be used below to coordinate datasets
-            with the same shape.  
+            The symbol(s) listed here will be used below to coordinate datasets with the same shape.
         </doc>
         <symbol name="nVars">
             <doc>The number of values taken by the varied variable</doc>

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
       <doc>
-        The symbol(s) listed here will be used below to coordinate datasets
-        with the same shape.
+        The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="nXPixels">
         <doc>Number of x pixels</doc>
@@ -43,7 +42,7 @@
       </symbol>
   </symbols>
   <doc>
-    This is the application definition for a TOF laue diffractometer 
+    This is the application definition for a TOF laue diffractometer
   </doc>
   <group type="NXentry" name="entry">
     <field name="definition">
@@ -55,8 +54,8 @@
     <group type="NXinstrument" name="instrument">
       <group type="NXdetector" name="detector">
          <doc>
-           This assumes a planar 2D detector. All angles and distances refer to the center of the 
-           detector. 
+           This assumes a planar 2D detector. All angles and distances refer to the center of the
+           detector.
         </doc>
          <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
           <doc>The polar_angle (two theta) where the detector is placed.</doc>
@@ -92,10 +91,10 @@
       </field>
         <field name="orientation_matrix" type="NX_FLOAT">
           <doc>
-            The orientation matrix according to Busing and 
-            Levy conventions. This is not strictly necessary as 
-            the UB can always be derived from the data.  But 
-            let us bow to common usage which includes thie 
+            The orientation matrix according to Busing and
+            Levy conventions. This is not strictly necessary as
+            the UB can always be derived from the data.  But
+            let us bow to common usage which includes thie
             UB nearly always.
 	  </doc>
           <dimensions rank="2">
@@ -105,7 +104,7 @@
         </field>
         <field name="unit_cell" type="NX_FLOAT">
           <doc>
-            The unit cell, a, b, c, alpha, beta, gamma. 
+            The unit cell, a, b, c, alpha, beta, gamma.
             Again, not strictly necessary, but normally written.
           </doc>
           <dimensions rank="1">

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -27,6 +27,21 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nXPixels">
+				<doc>number of x pixels</doc>
+			</symbol>
+			<symbol name="nYPixels">
+				<doc>number of y pixels</doc>
+			</symbol>
+			<symbol name="nTOF">
+				<doc>Time of flight</doc>
+			</symbol>
+		</symbols>
   <doc>
     This is the application definition for a TOF laue diffractometer 
   </doc>
@@ -51,8 +66,8 @@
         </field>
          <field name="data" type="NX_INT" signal="1">
             <dimensions rank="3">
-              <dim index="1" value="number of x pixels" />
-              <dim index="2" value="number of y pixels" />
+              <dim index="1" value="nXPixels" />
+              <dim index="2" value="nYPixels" />
               <dim index="3" value="nTOF" />
             </dimensions>
            <attribute name="signal" type="NX_POSINT">

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -31,16 +31,16 @@
       <doc>
         The symbol(s) listed here will be used below to coordinate datasets
         with the same shape.
-    </doc>
-    <symbol name="nXPixels">
+      </doc>
+      <symbol name="nXPixels">
         <doc>Number of x pixels</doc>
-    </symbol>
-    <symbol name="nYPixels">
+      </symbol>
+      <symbol name="nYPixels">
         <doc>Number of y pixels</doc>
-    </symbol>
-    <symbol name="nTOF">
+      </symbol>
+      <symbol name="nTOF">
         <doc>Time of flight</doc>
-    </symbol>
+      </symbol>
   </symbols>
   <doc>
     This is the application definition for a TOF laue diffractometer 

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -28,20 +28,20 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nXPixels">
-				<doc>number of x pixels</doc>
-			</symbol>
-			<symbol name="nYPixels">
-				<doc>number of y pixels</doc>
-			</symbol>
-			<symbol name="nTOF">
-				<doc>Time of flight</doc>
-			</symbol>
-		</symbols>
+      <doc>
+        The symbol(s) listed here will be used below to coordinate datasets
+        with the same shape.
+    </doc>
+    <symbol name="nXPixels">
+        <doc>Number of x pixels</doc>
+    </symbol>
+    <symbol name="nYPixels">
+        <doc>Number of y pixels</doc>
+    </symbol>
+    <symbol name="nTOF">
+        <doc>Time of flight</doc>
+    </symbol>
+  </symbols>
   <doc>
     This is the application definition for a TOF laue diffractometer 
   </doc>

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -32,10 +32,10 @@
         The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="nXPixels">
-        <doc>Number of x pixels</doc>
+        <doc>Number of X pixels</doc>
       </symbol>
       <symbol name="nYPixels">
-        <doc>Number of y pixels</doc>
+        <doc>Number of Y pixels</doc>
       </symbol>
       <symbol name="nTOF">
         <doc>Time of flight</doc>

--- a/applications/NXmonopd.nxdl.xml
+++ b/applications/NXmonopd.nxdl.xml
@@ -28,17 +28,17 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="i">
-				<doc>Optimum diffracted wavelength</doc>
-			</symbol>
-			<symbol name="nDet">
-				<doc>number of detectors</doc>
-			</symbol>
-		</symbols>
+        <doc>
+            The symbol(s) listed here will be used below to coordinate datasets
+            with the same shape.
+        </doc>
+        <symbol name="i">
+            <doc>Optimum diffracted wavelength</doc>
+        </symbol>
+        <symbol name="nDet">
+            <doc>Number of detectors</doc>
+        </symbol>
+    </symbols>
     <doc>
         Monochromatic Neutron and X-Ray Powder diffractometer 
         

--- a/applications/NXmonopd.nxdl.xml
+++ b/applications/NXmonopd.nxdl.xml
@@ -32,7 +32,7 @@
             The symbol(s) listed here will be used below to coordinate datasets with the same shape.
         </doc>
         <symbol name="i">
-            <doc>Optimum diffracted wavelength</doc>
+            <doc>i is the number of wavelengths</doc>
         </symbol>
         <symbol name="nDet">
             <doc>Number of detectors</doc>
@@ -78,7 +78,6 @@
             </group>
             <group type="NXdetector">
                 <field name="polar_angle" type="NX_FLOAT" axis="1">
-                  <doc>where ndet = number of detectors</doc>
                   <dimensions rank="1">
                     <dim index="1" value="nDet" />
                   </dimensions>

--- a/applications/NXmonopd.nxdl.xml
+++ b/applications/NXmonopd.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
         <doc>
-            The symbol(s) listed here will be used below to coordinate datasets
-            with the same shape.
+            The symbol(s) listed here will be used below to coordinate datasets with the same shape.
         </doc>
         <symbol name="i">
             <doc>Optimum diffracted wavelength</doc>

--- a/applications/NXmonopd.nxdl.xml
+++ b/applications/NXmonopd.nxdl.xml
@@ -27,6 +27,18 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="i">
+				<doc>Optimum diffracted wavelength</doc>
+			</symbol>
+			<symbol name="nDet">
+				<doc>number of detectors</doc>
+			</symbol>
+		</symbols>
     <doc>
         Monochromatic Neutron and X-Ray Powder diffractometer 
         
@@ -69,7 +81,7 @@
                 <field name="polar_angle" type="NX_FLOAT" axis="1">
                   <doc>where ndet = number of detectors</doc>
                   <dimensions rank="1">
-                    <dim index="1" value="ndet" />
+                    <dim index="1" value="nDet" />
                   </dimensions>
                 </field>
                 <field name="data" type="NX_INT" signal="1">
@@ -78,7 +90,7 @@
                     corrected for detector efficiency
                   </doc>
                   <dimensions rank="1">
-                    <dim index="1" value="ndet" />
+                    <dim index="1" value="nDet" />
                   </dimensions>
                 </field>
             </group>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -36,22 +36,22 @@
 				images, using one of the indices to select a detector module.
 			</doc>
 			<symbol name="dataRank">
-				<doc>rank of the ``data`` field</doc>
+				<doc>Rank of the ``data`` field</doc>
 			</symbol>
 			<symbol name="nP">
-				<doc>number of scan points</doc>
+				<doc>Number of scan points</doc>
 			</symbol>
 			<symbol name="i">
-				<doc>number of detector pixels in the slowest direction</doc>
+				<doc>Number of detector pixels in the slowest direction</doc>
 			</symbol>
 			<symbol name="j">
-				<doc>number of detector pixels in the second slowest direction</doc>
+				<doc>Number of detector pixels in the second slowest direction</doc>
 			</symbol>
 			<symbol name="k">
-				<doc>number of detector pixels in the third slowest direction</doc>
+				<doc>Number of detector pixels in the third slowest direction</doc>
 			</symbol>
 			<symbol name="m">
-				<doc>number of channels in the incident beam spectrum, if known</doc>
+				<doc>Number of channels in the incident beam spectrum, if known</doc>
 			</symbol>
 			<symbol name="groupIndex">
 				<doc>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -57,7 +57,6 @@
 				<doc>
 					An array of the hierarchical levels of the parents of detector
 					elements or groupings of detector elements.
-						
 					A top-level element or grouping has parent level -1.
 				</doc>
 			</symbol>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -38,7 +38,7 @@
 			<symbol name="dataRank">
 				<doc>rank of the ``data`` field</doc>
 			</symbol>
-			<symbol name="np">
+			<symbol name="nP">
 				<doc>number of scan points</doc>
 			</symbol>
 			<symbol name="i">
@@ -52,6 +52,12 @@
 			</symbol>
 			<symbol name="m">
 				<doc>number of channels in the incident beam spectrum, if known</doc>
+			</symbol>
+			<symbol name="groupIndex">
+				<doc>An array of the hierarchical levels of the parents of detector
+							elements or groupings of detector elements.
+						
+							A top-level element or grouping has parent level -1.</doc>
 			</symbol>
 		</symbols>
 
@@ -117,7 +123,7 @@
 						first index.
 					</doc>
 					<dimensions rank="dataRank">
-						<dim index="1" value="np" />
+						<dim index="1" value="nP" />
 						<dim index="2" value="i" />
 						<dim index="3" value="j" />
 						<dim index="4" value="k" required="false"/>
@@ -249,7 +255,7 @@
 						
 							A top-level element or grouping has parent level -1.
 						</doc>
-						<dimensions rank="1"><dim index="1" value="group_index"/></dimensions>
+						<dimensions rank="1"><dim index="1" value="groupIndex"/></dimensions>
 					</field>
 				</group>
 				<group type="NXdetector">
@@ -291,7 +297,7 @@
 							first index.
 						</doc>
 						<dimensions rank="dataRank">
-							<dim index="1" value="np" />
+							<dim index="1" value="nP" />
 							<dim index="2" value="i" />
 							<dim index="3" value="j" />
 							<dim index="4" value="k" required="false"/>
@@ -335,10 +341,10 @@
 
 								The data_origin is 0-based.
 
-								The frame number dimension (np) is omitted.  Thus the
-								data_origin field for a dimension-2 dataset with indices (np, i, j)
+								The frame number dimension (nP) is omitted.  Thus the
+								data_origin field for a dimension-2 dataset with indices (nP, i, j)
 								will be an array with indices (i, j), and for a dimension-3
-								dataset with indices (np, i, j, k) will be an array with indices
+								dataset with indices (nP, i, j, k) will be an array with indices
 								(i, j, k).
 
 								The :ref:`order &lt;Design-ArrayStorageOrder&gt;` of indices (i, j 
@@ -557,7 +563,7 @@
 							The 32-bit pixel mask for the detector. Can be either one mask
 							for the whole dataset (i.e. an array with indices i, j) or
 							each frame can have its own mask (in which case it would be
-							an array with indices np, i, j).
+							an array with indices nP, i, j).
 
 							Contains a bit field for each pixel to signal dead,
 							blind, high or otherwise unwanted or undesirable pixels.
@@ -722,7 +728,7 @@
 
 							In the case of a polychromatic beam that varies shot-to-
 							shot and where the channels also vary, this is a 2D array
-							of dimensions **np** by **m** (slow to fast) with the
+							of dimensions **nP** by **m** (slow to fast) with the
 							relative weights in incident_wavelength_weight as a 2D
 							array.
 							
@@ -741,7 +747,7 @@
 							wavelengths in incident_wavelength.
 
 							In the case of a polychromatic beam that varies shot-to-
-							shot, this is a 2D array of dimensions **np** by **m** 
+							shot, this is a 2D array of dimensions **nP** by **m** 
 							(slow to fast) of the relative weights of the
 							corresponding wavelengths in incident_wavelength.
 						</doc>
@@ -754,7 +760,7 @@
 							wavelength(s) in incident_wavelength.
 							
 							In the case of shot-to-shot variation in the wavelength
-							spread, this is a 2D array of dimension **np** by
+							spread, this is a 2D array of dimension **nP** by
 							**m** (slow to fast) of the spreads of the
 							corresponding wavelengths in incident_wavelength.
 						</doc>
@@ -810,7 +816,7 @@
 
 					<field name="incident_polarisation_stokes" recommended="true">
 						<dimensions rank="2">
-							<dim index="1" value="np" />
+							<dim index="1" value="nP" />
 							<dim index="2" value="4" />
 						</dimensions>
 					</field>

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -54,10 +54,12 @@
 				<doc>number of channels in the incident beam spectrum, if known</doc>
 			</symbol>
 			<symbol name="groupIndex">
-				<doc>An array of the hierarchical levels of the parents of detector
-							elements or groupings of detector elements.
+				<doc>
+					An array of the hierarchical levels of the parents of detector
+					elements or groupings of detector elements.
 						
-							A top-level element or grouping has parent level -1.</doc>
+					A top-level element or grouping has parent level -1.
+				</doc>
 			</symbol>
 		</symbols>
 

--- a/applications/NXrefscan.nxdl.xml
+++ b/applications/NXrefscan.nxdl.xml
@@ -32,7 +32,7 @@
 	  The symbol(s) listed here will be used below to coordinate datasets with the same shape.
 	</doc>
 	<symbol name="nP">
-		<doc>Number of Points</doc>
+		<doc>Number of points</doc>
 	</symbol>
   </symbols>
   <doc>

--- a/applications/NXrefscan.nxdl.xml
+++ b/applications/NXrefscan.nxdl.xml
@@ -28,14 +28,14 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of Points</doc>
-			</symbol>
-		</symbols>
+    <doc>
+	  The symbol(s) listed here will be used below to coordinate datasets
+      with the same shape.
+	</doc>
+	<symbol name="nP">
+		<doc>Number of Points</doc>
+	</symbol>
+  </symbols>
   <doc>
     This is an application definition for a monochromatic scanning reflectometer.
 

--- a/applications/NXrefscan.nxdl.xml
+++ b/applications/NXrefscan.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of Points</doc>
+			</symbol>
+		</symbols>
   <doc>
     This is an application definition for a monochromatic scanning reflectometer.
 
@@ -61,13 +70,13 @@
         <group type="NXdetector">
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="1">
-              <dim index="1" value="NP" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
           <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE"
             axis="1">
             <dimensions rank="1">
-              <dim index="1" value="NP" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
         </group>
@@ -78,7 +87,7 @@
         </field>
         <field name="rotation_angle" type="NX_FLOAT" units="NX_ANGLE">
           <dimensions rank="1">
-            <dim index="1" value="NP" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
       </group>
@@ -99,7 +108,7 @@
         <field name="data" type="NX_FLOAT" units="NX_ANY">
           <doc>Monitor counts for each step</doc>
           <dimensions rank="1">
-            <dim index="1" value="NP" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
       </group>

--- a/applications/NXrefscan.nxdl.xml
+++ b/applications/NXrefscan.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-	  The symbol(s) listed here will be used below to coordinate datasets
-      with the same shape.
+	  The symbol(s) listed here will be used below to coordinate datasets with the same shape.
 	</doc>
 	<symbol name="nP">
 		<doc>Number of Points</doc>

--- a/applications/NXreftof.nxdl.xml
+++ b/applications/NXreftof.nxdl.xml
@@ -28,20 +28,20 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   	<symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="xSize">
-				<doc>xsize description</doc>
-			</symbol>
-			<symbol name="ySize">
-				<doc>ysize description</doc>
-			</symbol>
-			<symbol name="nTOF">
-				<doc>nTOF description</doc>
-			</symbol>
-		</symbols>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+      <symbol name="xSize">
+	    <doc>xSize description</doc>
+      </symbol>
+	  <symbol name="ySize">
+	    <doc>ySize description</doc>
+	  </symbol>
+	  <symbol name="nTOF">
+	    <doc>nTOF description</doc>
+	  </symbol>
+    </symbols>
     <doc>This is an application definition for raw data from a TOF reflectometer. </doc>
     <group type="NXentry" name="entry">
       <field name="title" />

--- a/applications/NXreftof.nxdl.xml
+++ b/applications/NXreftof.nxdl.xml
@@ -32,10 +32,10 @@
         The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="xSize">
-	    <doc>X Size description</doc>
+	    <doc>xSize description</doc>
       </symbol>
 	  <symbol name="ySize">
-	    <doc>Y Size description</doc>
+	    <doc>ySize description</doc>
 	  </symbol>
 	  <symbol name="nTOF">
 	    <doc>nTOF description</doc>

--- a/applications/NXreftof.nxdl.xml
+++ b/applications/NXreftof.nxdl.xml
@@ -27,6 +27,21 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  	<symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="xSize">
+				<doc>xsize description</doc>
+			</symbol>
+			<symbol name="ySize">
+				<doc>ysize description</doc>
+			</symbol>
+			<symbol name="nTOF">
+				<doc>nTOF description</doc>
+			</symbol>
+		</symbols>
     <doc>This is an application definition for raw data from a TOF reflectometer. </doc>
     <group type="NXentry" name="entry">
       <field name="title" />
@@ -48,8 +63,8 @@
         <group type="NXdetector" name="detector">
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="3">
-              <dim index="1" value="xsize" />
-              <dim index="2" value="ysize" />
+              <dim index="1" value="xSize" />
+              <dim index="2" value="ySize" />
               <dim index="3" value="nTOF" />
             </dimensions>
           </field>

--- a/applications/NXreftof.nxdl.xml
+++ b/applications/NXreftof.nxdl.xml
@@ -32,10 +32,10 @@
         The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="xSize">
-	    <doc>xSize description</doc>
+	    <doc>X Size description</doc>
       </symbol>
 	  <symbol name="ySize">
-	    <doc>ySize description</doc>
+	    <doc>Y Size description</doc>
 	  </symbol>
 	  <symbol name="nTOF">
 	    <doc>nTOF description</doc>

--- a/applications/NXreftof.nxdl.xml
+++ b/applications/NXreftof.nxdl.xml
@@ -29,8 +29,7 @@
   >
   	<symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+        The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="xSize">
 	    <doc>xSize description</doc>

--- a/applications/NXsas.nxdl.xml
+++ b/applications/NXsas.nxdl.xml
@@ -28,17 +28,17 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nXPixel">
-				<doc>nXPixel description</doc>
-			</symbol>
-			<symbol name="nYPixel">
-				<doc>nYPixel description</doc>
-			</symbol>
-	</symbols>
+    <doc>
+	  The symbol(s) listed here will be used below to coordinate datasets
+	  with the same shape.
+	</doc>
+	<symbol name="nXPixel">
+	  <doc>nXPixel description</doc>
+	</symbol>
+	<symbol name="nYPixel">
+	  <doc>nYPixel description</doc>
+	</symbol>
+  </symbols>
   <doc>
     raw, monochromatic 2-D SAS data with an area detector
 

--- a/applications/NXsas.nxdl.xml
+++ b/applications/NXsas.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-	  The symbol(s) listed here will be used below to coordinate datasets
-	  with the same shape.
+	  The symbol(s) listed here will be used below to coordinate datasets with the same shape.
 	</doc>
 	<symbol name="nXPixel">
 	  <doc>nXPixel description</doc>

--- a/applications/NXsas.nxdl.xml
+++ b/applications/NXsas.nxdl.xml
@@ -27,6 +27,18 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nXPixel">
+				<doc>nXPixel description</doc>
+			</symbol>
+			<symbol name="nYPixel">
+				<doc>nYPixel description</doc>
+			</symbol>
+	</symbols>
   <doc>
     raw, monochromatic 2-D SAS data with an area detector
 

--- a/applications/NXsastof.nxdl.xml
+++ b/applications/NXsastof.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-	  The symbol(s) listed here will be used below to coordinate datasets
-	  with the same shape.
+	  The symbol(s) listed here will be used below to coordinate datasets with the same shape.
 	</doc>
 	<symbol name="nXPixel">
 	  <doc>nXPixel description</doc>

--- a/applications/NXsastof.nxdl.xml
+++ b/applications/NXsastof.nxdl.xml
@@ -27,6 +27,22 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nXPixel">
+				<doc>nXPixel description</doc>
+			</symbol>
+			<symbol name="nYPixel">
+				<doc>nYPixel description</doc>
+			</symbol>
+			<symbol name="nTOF">
+				<doc>nTOF description</doc>
+			</symbol>
+			
+	</symbols>
   <doc>
     raw, 2-D SAS data with an area detector with a time-of-flight source
     

--- a/applications/NXsastof.nxdl.xml
+++ b/applications/NXsastof.nxdl.xml
@@ -28,21 +28,20 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nXPixel">
-				<doc>nXPixel description</doc>
-			</symbol>
-			<symbol name="nYPixel">
-				<doc>nYPixel description</doc>
-			</symbol>
-			<symbol name="nTOF">
-				<doc>nTOF description</doc>
-			</symbol>
-			
-	</symbols>
+    <doc>
+	  The symbol(s) listed here will be used below to coordinate datasets
+	  with the same shape.
+	</doc>
+	<symbol name="nXPixel">
+	  <doc>nXPixel description</doc>
+    </symbol>
+    <symbol name="nYPixel">
+	  <doc>nYPixel description</doc>
+	</symbol>
+	<symbol name="nTOF">
+	  <doc>nTOF description</doc>
+	</symbol>
+  </symbols>
   <doc>
     raw, 2-D SAS data with an area detector with a time-of-flight source
     

--- a/applications/NXscan.nxdl.xml
+++ b/applications/NXscan.nxdl.xml
@@ -22,25 +22,25 @@
 # For further information, see http://www.nexusformat.org
 -->
 <definition name="NXscan" extends="NXobject" type="group"
-	    category="application"
-	    xmlns="http://definition.nexusformat.org/nxdl/3.1"
-	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-	    >
+    category="application"
+	xmlns="http://definition.nexusformat.org/nxdl/3.1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
+	>
     <symbols>
-        <doc>
-		    The symbol(s) listed here will be used below to coordinate datasets
-			with the same shape.
-        </doc>
-		<symbol name="nP">
-		    <doc>Number of points</doc>
-        </symbol>
-		<symbol name="xDim">
-		    <doc>xDim description</doc>
-        </symbol>
-		<symbol name="yDim">
-			<doc>yDim description</doc>
-		</symbol>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+      <symbol name="nP">
+	    <doc>Number of points</doc>
+      </symbol>
+	  <symbol name="xDim">
+	    <doc>xDim description</doc>
+      </symbol>
+	  <symbol name="yDim">
+	    <doc>yDim description</doc>
+	  </symbol>
     </symbols>
   <doc>
     Application definition for a generic scan instrument. 

--- a/applications/NXscan.nxdl.xml
+++ b/applications/NXscan.nxdl.xml
@@ -27,21 +27,21 @@
 	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	    >
-	<symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
-			<symbol name="xDim">
-				<doc>xdim description</doc>
-			</symbol>
-			<symbol name="yDim">
-				<doc>ydim description</doc>
-			</symbol>
-	</symbols>
+    <symbols>
+        <doc>
+		    The symbol(s) listed here will be used below to coordinate datasets
+			with the same shape.
+        </doc>
+		<symbol name="nP">
+		    <doc>Number of points</doc>
+        </symbol>
+		<symbol name="xDim">
+		    <doc>xDim description</doc>
+        </symbol>
+		<symbol name="yDim">
+			<doc>yDim description</doc>
+		</symbol>
+    </symbols>
   <doc>
     Application definition for a generic scan instrument. 
     

--- a/applications/NXscan.nxdl.xml
+++ b/applications/NXscan.nxdl.xml
@@ -27,6 +27,21 @@
 	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	    >
+	<symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+			<symbol name="xDim">
+				<doc>xdim description</doc>
+			</symbol>
+			<symbol name="yDim">
+				<doc>ydim description</doc>
+			</symbol>
+	</symbols>
   <doc>
     Application definition for a generic scan instrument. 
     
@@ -67,9 +82,9 @@
       <group type="NXdetector">
         <field name="data" type="NX_INT" signal="1">
           <dimensions rank="3">
-            <dim index="1" value="NP" />
-            <dim index="2" value="xdim" />
-            <dim index="3" value="ydim" />
+            <dim index="1" value="nP" />
+            <dim index="2" value="xDim" />
+            <dim index="3" value="yDim" />
           </dimensions>
         </field>
       </group>
@@ -77,14 +92,14 @@
     <group type="NXsample">
       <field name="rotation_angle" type="NX_FLOAT" axis="1">
         <dimensions rank="1">
-          <dim index="1" value="NP" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
     </group> 
     <group type="NXmonitor">
       <field name="data" type="NX_INT">
         <dimensions rank="1">
-          <dim index="1" value="NP"/>
+          <dim index="1" value="nP"/>
         </dimensions>
       </field>
     </group> 

--- a/applications/NXscan.nxdl.xml
+++ b/applications/NXscan.nxdl.xml
@@ -29,8 +29,7 @@
 	>
     <symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+	    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="nP">
 	    <doc>Number of points</doc>

--- a/applications/NXsqom.nxdl.xml
+++ b/applications/NXsqom.nxdl.xml
@@ -27,13 +27,13 @@
 	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	    >
 	<symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+	  <symbol name="nP">
+	    <doc>Number of points</doc>
+      </symbol>
 	</symbols>
   <doc>
     This is the application definition for S(Q,OM) processed data. 

--- a/applications/NXsqom.nxdl.xml
+++ b/applications/NXsqom.nxdl.xml
@@ -26,6 +26,15 @@
 	    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	    >
+	<symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
   <doc>
     This is the application definition for S(Q,OM) processed data. 
     
@@ -81,31 +90,31 @@
       <field name="data" type="NX_INT" signal="1">
         <doc> This is the intensity for each point in QE </doc>
         <dimensions rank="1">
-          <dim index="1" value="NP"/>
+          <dim index="1" value="nP"/>
         </dimensions>
       </field>
       <field name="qx" axis="1" units="NX_WAVENUMBER">
         <doc>Positions for the first dimension of Q</doc>
         <dimensions rank="1">
-          <dim index="1" value="NP"/>
+          <dim index="1" value="nP"/>
         </dimensions>
       </field>
       <field name="qy" axis="1" units="NX_WAVENUMBER">
         <doc>Positions for the the second dimension of Q</doc>
         <dimensions rank="1">
-          <dim index="1" value="NP"/>
+          <dim index="1" value="nP"/>
         </dimensions>
       </field>
       <field name="qz" axis="1" units="NX_WAVENUMBER">
         <doc>Positions for the the third dimension of Q</doc>
         <dimensions rank="1">
-          <dim index="1" value="NP"/>
+          <dim index="1" value="nP"/>
         </dimensions>
       </field>
       <field name="en" axis="1" type="NX_FLOAT" units="NX_ENERGY">
         <doc>Values for the energy transfer for each point</doc>
         <dimensions rank="1">
-          <dim index="1" value="NP"/>
+          <dim index="1" value="nP"/>
         </dimensions>
       </field>
     </group>

--- a/applications/NXsqom.nxdl.xml
+++ b/applications/NXsqom.nxdl.xml
@@ -28,8 +28,7 @@
 	    >
 	<symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+	    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
 	  <symbol name="nP">
 	    <doc>Number of points</doc>

--- a/applications/NXstxm.nxdl.xml
+++ b/applications/NXstxm.nxdl.xml
@@ -28,7 +28,9 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-        <doc>These symbols will be used below to coordinate the shapes of the datasets.</doc>
+        <doc>
+            These symbols will be used below to coordinate the shapes of the datasets.
+        </doc>
         <symbol name="nP">
             <doc>Total number of scan points</doc>
         </symbol>

--- a/applications/NXstxm.nxdl.xml
+++ b/applications/NXstxm.nxdl.xml
@@ -29,10 +29,10 @@
     >
     <symbols>
         <doc>These symbols will be used below to coordinate the shapes of the datasets.</doc>
-        <symbol name="numP"><doc>total number of scan points</doc></symbol>
-        <symbol name="numE"><doc>number of photon energies scanned</doc></symbol>
-        <symbol name="numY"><doc>number of pixels in Y direction</doc></symbol>
-        <symbol name="numX"><doc>number of pixels in X direction</doc></symbol>
+        <symbol name="nP"><doc>total number of scan points</doc></symbol>
+        <symbol name="nE"><doc>number of photon energies scanned</doc></symbol>
+        <symbol name="nY"><doc>number of pixels in Y direction</doc></symbol>
+        <symbol name="nX"><doc>number of pixels in X direction</doc></symbol>
     </symbols>
     <doc>
           Application definition for a STXM instrument. 
@@ -91,7 +91,7 @@
                 <doc> Measurements of the sample position from the x-axis interferometer.</doc>
                 <field name="data" type="NX_FLOAT">
                   <dimensions rank="1">
-                    <dim index="1" value="NumP" />
+                    <dim index="1" value="nP" />
                   </dimensions>
                 </field>
             </group>
@@ -99,7 +99,7 @@
                 <doc> Measurements of the sample position from the y-axis interferometer.</doc>
                 <field name="data" type="NX_FLOAT">
                   <dimensions rank="1">
-                    <dim index="1" value="NumP" />
+                    <dim index="1" value="nP" />
                   </dimensions>
                 </field>
             </group>
@@ -107,7 +107,7 @@
                 <doc> Measurements of the sample position from the z-axis interferometer.</doc>
                 <field name="data" type="NX_FLOAT">
                   <dimensions rank="1">
-                    <dim index="1" value="NumP" />
+                    <dim index="1" value="nP" />
                   </dimensions>
                 </field>
             </group>
@@ -159,21 +159,21 @@
               <doc> List of photon energies of the X-ray beam. If scanned through multiple values,
               then an 'axis' attribute will be required to link the field to the appropriate data array dimension.</doc>
               <dimensions rank="1">
-                <dim index="1" value="NumE" />
+                <dim index="1" value="nE" />
               </dimensions>
             </field>
             <field name="sample_y" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
               <doc> List of Y positions on the sample. If scanned through multiple values,
               then an 'axis' attribute will be required to link the field to the appropriate data array dimension.</doc>
               <dimensions rank="1">
-                <dim index="1" value="NumY" />
+                <dim index="1" value="nY" />
               </dimensions>
             </field>
             <field name="sample_x" type="NX_FLOAT" minOccurs="1" maxOccurs="1">
               <doc> List of X positions on the sample. If scanned through multiple values,
               then an 'axis' attribute will be required to link the field to the appropriate data array dimension.</doc>
               <dimensions rank="1">
-                <dim index="1" value="NumX" />
+                <dim index="1" value="nX" />
               </dimensions>
             </field>
         </group>

--- a/applications/NXstxm.nxdl.xml
+++ b/applications/NXstxm.nxdl.xml
@@ -29,11 +29,21 @@
     >
     <symbols>
         <doc>These symbols will be used below to coordinate the shapes of the datasets.</doc>
-        <symbol name="nP"><doc>Total number of scan points</doc></symbol>
-        <symbol name="nE"><doc>Number of photon energies scanned</doc></symbol>
-        <symbol name="nY"><doc>Number of pixels in Y direction</doc></symbol>
-        <symbol name="nX"><doc>Number of pixels in X direction</doc></symbol>
-        <symbol name="detectorRank"><doc>Rank of data array provided by the detector for a single measurement</doc></symbol>
+        <symbol name="nP">
+            <doc>Total number of scan points</doc>
+        </symbol>
+        <symbol name="nE">
+            <doc>Number of photon energies scanned</doc>
+        </symbol>
+        <symbol name="nX">
+            <doc>Number of pixels in X direction</doc>
+        </symbol>
+        <symbol name="nY">
+            <doc>Number of pixels in Y direction</doc>
+        </symbol>
+        <symbol name="detectorRank">
+            <doc>Rank of data array provided by the detector for a single measurement</doc>
+        </symbol>
     </symbols>
     <doc>
           Application definition for a STXM instrument. 

--- a/applications/NXstxm.nxdl.xml
+++ b/applications/NXstxm.nxdl.xml
@@ -29,11 +29,11 @@
     >
     <symbols>
         <doc>These symbols will be used below to coordinate the shapes of the datasets.</doc>
-        <symbol name="nP"><doc>total number of scan points</doc></symbol>
-        <symbol name="nE"><doc>number of photon energies scanned</doc></symbol>
-        <symbol name="nY"><doc>number of pixels in Y direction</doc></symbol>
-        <symbol name="nX"><doc>number of pixels in X direction</doc></symbol>
-        <symbol name="detectorRank"><doc>rank of data array provided by the detector for a single measurement</doc></symbol>
+        <symbol name="nP"><doc>Total number of scan points</doc></symbol>
+        <symbol name="nE"><doc>Number of photon energies scanned</doc></symbol>
+        <symbol name="nY"><doc>Number of pixels in Y direction</doc></symbol>
+        <symbol name="nX"><doc>Number of pixels in X direction</doc></symbol>
+        <symbol name="detectorRank"><doc>Rank of data array provided by the detector for a single measurement</doc></symbol>
     </symbols>
     <doc>
           Application definition for a STXM instrument. 

--- a/applications/NXstxm.nxdl.xml
+++ b/applications/NXstxm.nxdl.xml
@@ -33,6 +33,7 @@
         <symbol name="nE"><doc>number of photon energies scanned</doc></symbol>
         <symbol name="nY"><doc>number of pixels in Y direction</doc></symbol>
         <symbol name="nX"><doc>number of pixels in X direction</doc></symbol>
+        <symbol name="detectorRank"><doc>rank of data array provided by the detector for a single measurement</doc></symbol>
     </symbols>
     <doc>
           Application definition for a STXM instrument. 
@@ -43,7 +44,7 @@
           within the NXinstrument group as lists of values stored in 
           chronological order. The NXdata group then holds another version
           of the data in a regular 3D array (NumE by NumY by NumX, for a
-          total of NumP points in a sample image stack type scan). The former
+          total of nP points in a sample image stack type scan). The former
           data values should be stored with a minimum loss of precision, while
           the latter values can be simplified and/or approximated in order to
           fit the constraints of a regular 3D array. 'Line scans' and 'point spectra'
@@ -69,21 +70,23 @@
             <group type="NXmonochromator" name="monochromator" minOccurs="1" maxOccurs="1">
               <field name="energy" minOccurs="1" maxOccurs="1" type="NX_FLOAT">
                 <dimensions rank="1">
-                  <dim index="1" value="NumP" />
+                  <dim index="1" value="nP" />
                 </dimensions>
               </field>
             </group>
             <group type="NXdetector" minOccurs="1">
                 <field name="data" type="NX_NUMBER">
-                  <dimensions>
+                  <dimensions rank="1+detectorRank">
                     <doc> Detector data should be presented with the first dimension corresponding to the
                     scan point and subsequent dimensions corresponding to the output of the detector.
                     Detectors that provide more than one value per scan point should have
                     a data array of rank 1+d, where d is the dimensions of the array provided per
                     scan point. For example, an area detector should have an NXdetector data array
                     of 3 dimensions, with the first being the set of scan points and the latter 
-                    two being the x- and y- extent of the detector </doc>
-                    <dim index="1" value="NumP" />
+                    two being the x- and y- extent of the detector.
+                        NOTE: For each dimension > 1 there must exist a dim section such as:
+                            <dim index="(dimension index value)" value="(size of dimension)" /></doc>
+                    <dim index="1" value="nP" />
                   </dimensions>
                 </field>
             </group>

--- a/applications/NXtas.nxdl.xml
+++ b/applications/NXtas.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
   <doc>
     This is an application definition for a triple axis spectrometer. 
     
@@ -55,41 +64,41 @@
         <group type="NXcrystal" name="monochromator">
           <field name="ei" type="NX_FLOAT" units="NX_ENERGY" axis="1">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
           <field name="rotation_angle" type="NX_FLOAT" units="NX_ANGLE">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
         </group>
         <group type="NXcrystal" name="analyser">
           <field name="ef" type="NX_FLOAT" units="NX_ENERGY" axis="1">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
           <field name="rotation_angle" type="NX_FLOAT" units="NX_ANGLE">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
           <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
         </group>
         <group type="NXdetector">
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
           <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
         </group>
@@ -100,42 +109,42 @@
         </field>
         <field name="qh" type="NX_FLOAT" units="NX_DIMENSIONLESS" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="qk" type="NX_FLOAT" units="NX_DIMENSIONLESS" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="ql" type="NX_FLOAT" units="NX_DIMENSIONLESS" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="en" type="NX_FLOAT" units="NX_ENERGY" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="rotation_angle" type="NX_FLOAT" units="NX_ANGLE">
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
            <dimensions rank="1">
-             <dim index="1" value="np" />
+             <dim index="1" value="nP" />
            </dimensions>
         </field>
         <field name="sgu" type="NX_FLOAT" units="NX_ANGLE">
            <dimensions rank="1">
-             <dim index="1" value="np" />
+             <dim index="1" value="nP" />
            </dimensions>
         </field>
         <field name="sgl" type="NX_FLOAT" units="NX_ANGLE">
            <dimensions rank="1">
-             <dim index="1" value="np" />
+             <dim index="1" value="nP" />
            </dimensions>
         </field>
         <field name="unit_cell" type="NX_FLOAT" units="NX_LENGTH">
@@ -166,7 +175,7 @@
         <field name="data" type="NX_FLOAT" units="NX_ANY">
           <doc>Total integral monitor counts</doc>
           <dimensions rank="1">
-            <dim index="1" value="np"></dim></dimensions>
+            <dim index="1" value="nP"></dim></dimensions>
         </field>
       </group>
       <group type="NXdata">

--- a/applications/NXtas.nxdl.xml
+++ b/applications/NXtas.nxdl.xml
@@ -28,13 +28,13 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+	  <symbol name="nP">
+	    <doc>Number of points</doc>
+      </symbol>
 	</symbols>
   <doc>
     This is an application definition for a triple axis spectrometer. 

--- a/applications/NXtas.nxdl.xml
+++ b/applications/NXtas.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+	    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
 	  <symbol name="nP">
 	    <doc>Number of points</doc>

--- a/applications/NXtofnpd.nxdl.xml
+++ b/applications/NXtofnpd.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+	    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
 	  <symbol name="nDet">
 	    <doc>Number of detectors</doc>

--- a/applications/NXtofnpd.nxdl.xml
+++ b/applications/NXtofnpd.nxdl.xml
@@ -35,7 +35,7 @@
 	    <doc>Number of detectors</doc>
       </symbol>
 	  <symbol name="nTimeChan">
-	    <doc>ntimechan description to be provided by contributor</doc>
+	    <doc>nTimeChan description</doc>
       </symbol>
 	</symbols>
     <doc>This is a application definition for raw data from a TOF neutron powder diffractometer</doc>

--- a/applications/NXtofnpd.nxdl.xml
+++ b/applications/NXtofnpd.nxdl.xml
@@ -27,6 +27,18 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nDet">
+				<doc>Number of detectors</doc>
+			</symbol>
+			<symbol name="nTimeChan">
+				<doc>ntimechan description to be provided by contributor</doc>
+			</symbol>
+	</symbols>
     <doc>This is a application definition for raw data from a TOF neutron powder diffractometer</doc>
     <group type="NXentry" name="entry">
       <field name="title" />
@@ -52,32 +64,32 @@
         <group type="NXdetector" name="detector">
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="2">
-              <dim index="1" value="ndet" /><dim index="2" value="ntimechan" />
+              <dim index="1" value="nDet" /><dim index="2" value="nTimeChan" />
             </dimensions>
           </field>
           <field name="detector_number" type="NX_INT" axis="2">
             <dimensions rank="1">
-              <dim index="1" value="ndet" /></dimensions></field>
+              <dim index="1" value="nDet" /></dimensions></field>
           <field name="distance" type="NX_FLOAT" units="NX_LENGTH">
             <doc>distance to sample for each detector</doc>
             <dimensions rank="1">
-              <dim index="1" value="ndet" /></dimensions></field>
+              <dim index="1" value="nDet" /></dimensions></field>
             <field name="time_of_flight" type="NX_FLOAT"
           units="NX_TIME_OF_FLIGHT" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions>
+            <dim index="1" value="nTimeChan" /></dimensions>
         </field>
             <field name="polar_angle" type="NX_FLOAT"
               units="NX_ANGLE">
               <doc>polar angle for each detector element</doc>
               <dimensions rank="1">
-                <dim index="1" value="ndet"></dim></dimensions>
+                <dim index="1" value="nDet"></dim></dimensions>
             </field>
             <field name="azimuthal_angle" type="NX_FLOAT"
               units="NX_ANGLE">
               <doc>azimuthal angle for each detector element</doc>
               <dimensions rank="1">
-                <dim index="1" value="ndet"></dim></dimensions>
+                <dim index="1" value="nDet"></dim></dimensions>
             </field>
          </group>
       </group>
@@ -103,11 +115,11 @@
         <field name="distance" type="NX_FLOAT" units="NX_LENGTH"></field>
         <field name="data" type="NX_INT" signal="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions></field>
+            <dim index="1" value="nTimeChan" /></dimensions></field>
         <field name="time_of_flight" type="NX_FLOAT"
           units="NX_TIME_OF_FLIGHT" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions>
+            <dim index="1" value="nTimeChan" /></dimensions>
         </field>
       </group>
       <group type="NXdata" name="data">

--- a/applications/NXtofnpd.nxdl.xml
+++ b/applications/NXtofnpd.nxdl.xml
@@ -28,16 +28,16 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nDet">
-				<doc>Number of detectors</doc>
-			</symbol>
-			<symbol name="nTimeChan">
-				<doc>ntimechan description to be provided by contributor</doc>
-			</symbol>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+	  <symbol name="nDet">
+	    <doc>Number of detectors</doc>
+      </symbol>
+	  <symbol name="nTimeChan">
+	    <doc>ntimechan description to be provided by contributor</doc>
+      </symbol>
 	</symbols>
     <doc>This is a application definition for raw data from a TOF neutron powder diffractometer</doc>
     <group type="NXentry" name="entry">

--- a/applications/NXtofraw.nxdl.xml
+++ b/applications/NXtofraw.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+	    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
 	  <symbol name="nDet">
 	    <doc>Number of detectors</doc>

--- a/applications/NXtofraw.nxdl.xml
+++ b/applications/NXtofraw.nxdl.xml
@@ -28,16 +28,16 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nDet">
-				<doc>Number of detectors</doc>
-			</symbol>
-			<symbol name="nTimeChan">
-				<doc>ntimechan description</doc>
-			</symbol>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+	  <symbol name="nDet">
+	    <doc>Number of detectors</doc>
+      </symbol>
+	  <symbol name="nTimeChan">
+	    <doc>ntimechan description</doc>
+      </symbol>
 	</symbols>
     <doc>This is an application definition for raw data from a generic TOF instrument</doc>
     <group type="NXentry" name="entry">

--- a/applications/NXtofraw.nxdl.xml
+++ b/applications/NXtofraw.nxdl.xml
@@ -27,6 +27,18 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nDet">
+				<doc>Number of detectors</doc>
+			</symbol>
+			<symbol name="nTimeChan">
+				<doc>ntimechan description</doc>
+			</symbol>
+	</symbols>
     <doc>This is an application definition for raw data from a generic TOF instrument</doc>
     <group type="NXentry" name="entry">
       <field name="title" />
@@ -54,38 +66,38 @@
         <group type="NXdetector" name="detector">
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="2">
-              <dim index="1" value="ndet" />
-              <dim index="2" value="ntimechan" />
+              <dim index="1" value="nDet" />
+              <dim index="2" value="nTimeChan" />
             </dimensions>
           </field>
           <field name="detector_number" type="NX_INT" axis="2">
             <dimensions rank="1">
-              <dim index="1" value="ndet" />
+              <dim index="1" value="nDet" />
             </dimensions>
           </field>
           <field name="distance" type="NX_FLOAT" units="NX_LENGTH">
             <doc>distance to sample for each detector</doc>
             <dimensions rank="1">
-              <dim index="1" value="ndet" />
+              <dim index="1" value="nDet" />
             </dimensions>
           </field>
           <field name="time_of_flight" type="NX_FLOAT"
             units="NX_TIME_OF_FLIGHT" axis="1">
             <dimensions rank="1">
-              <dim index="1" value="ntimechan" />
+              <dim index="1" value="nTimeChan" />
             </dimensions>
           </field>
           <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
             <doc>polar angle for each detector element</doc>
             <dimensions rank="1">
-              <dim index="1" value="ndet"></dim>
+              <dim index="1" value="nDet"></dim>
             </dimensions>
           </field>
           <field name="azimuthal_angle" type="NX_FLOAT"
             units="NX_ANGLE">
             <doc>polar angle for each detector element</doc>
             <dimensions rank="1">
-              <dim index="1" value="ndet"></dim>
+              <dim index="1" value="nDet"></dim>
             </dimensions>
           </field>
         </group>
@@ -118,11 +130,11 @@
         <field name="distance" type="NX_FLOAT" units="NX_LENGTH"></field>
         <field name="data" type="NX_INT" signal="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions></field>
+            <dim index="1" value="nTimeChan" /></dimensions></field>
         <field name="time_of_flight" type="NX_FLOAT"
           units="NX_TIME_OF_FLIGHT" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions>
+            <dim index="1" value="nTimeChan" /></dimensions>
         </field>
         <field name="integral_counts" type="NX_INT" units="NX_UNITLESS"></field>
       </group>

--- a/applications/NXtofraw.nxdl.xml
+++ b/applications/NXtofraw.nxdl.xml
@@ -35,7 +35,7 @@
 	    <doc>Number of detectors</doc>
       </symbol>
 	  <symbol name="nTimeChan">
-	    <doc>ntimechan description</doc>
+	    <doc>nTimeChan description</doc>
       </symbol>
 	</symbols>
     <doc>This is an application definition for raw data from a generic TOF instrument</doc>

--- a/applications/NXtofsingle.nxdl.xml
+++ b/applications/NXtofsingle.nxdl.xml
@@ -28,22 +28,22 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="xSize">
-				<doc>xsize description</doc>
-			</symbol>
-			<symbol name="ySize">
-				<doc>ysize description</doc>
-			</symbol>
-			<symbol name="nDet">
-				<doc>Number of detectors</doc>
-			</symbol>
-			<symbol name="nTimeChan">
-				<doc>ntimechan description</doc>
-			</symbol>
+      <doc>
+	    The symbol(s) listed here will be used below to coordinate datasets
+		with the same shape.
+      </doc>
+	  <symbol name="xSize">
+	    <doc>xSize description</doc>
+      </symbol>
+      <symbol name="ySize">
+	    <doc>ySize description</doc>
+      </symbol>
+      <symbol name="nDet">
+	    <doc>Number of detectors</doc>
+      </symbol>
+	  <symbol name="nTimeChan">
+	    <doc>nTimeChan description</doc>
+      </symbol>
 	</symbols>
     <doc>This is a application definition for raw data from a generic TOF instrument</doc>
     <group type="NXentry" name="entry">

--- a/applications/NXtofsingle.nxdl.xml
+++ b/applications/NXtofsingle.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
       <doc>
-	    The symbol(s) listed here will be used below to coordinate datasets
-		with the same shape.
+	    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
 	  <symbol name="xSize">
 	    <doc>xSize description</doc>

--- a/applications/NXtofsingle.nxdl.xml
+++ b/applications/NXtofsingle.nxdl.xml
@@ -27,6 +27,24 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="xSize">
+				<doc>xsize description</doc>
+			</symbol>
+			<symbol name="ySize">
+				<doc>ysize description</doc>
+			</symbol>
+			<symbol name="nDet">
+				<doc>Number of detectors</doc>
+			</symbol>
+			<symbol name="nTimeChan">
+				<doc>ntimechan description</doc>
+			</symbol>
+	</symbols>
     <doc>This is a application definition for raw data from a generic TOF instrument</doc>
     <group type="NXentry" name="entry">
       <field name="title" />
@@ -53,9 +71,9 @@
         <group type="NXdetector" name="detector">
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="3">
-              <dim index="1" value="xsize" />
-              <dim index="2" value="ysize" />
-              <dim index="3" value="ntimechan" />
+              <dim index="1" value="xSize" />
+              <dim index="2" value="ySize" />
+              <dim index="3" value="nTimeChan" />
             </dimensions>
           </field>
           <field name="distance" type="NX_FLOAT" units="NX_LENGTH">
@@ -65,19 +83,19 @@
             <field name="time_of_flight" type="NX_FLOAT"
           units="NX_TIME_OF_FLIGHT" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions>
+            <dim index="1" value="nTimeChan" /></dimensions>
         </field>
             <field name="polar_angle" type="NX_FLOAT"
               units="NX_ANGLE">
               <doc>polar angle for each detector element</doc>
               <dimensions rank="1">
-                <dim index="1" value="ndet"></dim></dimensions>
+                <dim index="1" value="nDet"></dim></dimensions>
             </field>
             <field name="azimuthal_angle" type="NX_FLOAT"
               units="NX_ANGLE">
               <doc>azimuthal angle for each detector element</doc>
               <dimensions rank="1">
-                <dim index="1" value="ndet"></dim></dimensions>
+                <dim index="1" value="nDet"></dim></dimensions>
             </field>
         </group>
       </group>
@@ -109,11 +127,11 @@
         <field name="distance" type="NX_FLOAT" units="NX_LENGTH"></field>
         <field name="data" type="NX_INT" signal="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions></field>
+            <dim index="1" value="nTimeChan" /></dimensions></field>
         <field name="time_of_flight" type="NX_FLOAT"
           units="NX_TIME_OF_FLIGHT" axis="1">
           <dimensions rank="1">
-            <dim index="1" value="ntimechan" /></dimensions>
+            <dim index="1" value="nTimeChan" /></dimensions>
         </field>
       </group>
       <group type="NXdata" name="data">

--- a/applications/NXtomo.nxdl.xml
+++ b/applications/NXtomo.nxdl.xml
@@ -30,9 +30,9 @@
 
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nFrames"><doc>number of frames</doc></symbol>
-		<symbol name="xSize"><doc>number of pixels in X direction</doc></symbol>
-		<symbol name="ySize"><doc>number of pixels in Y direction</doc></symbol>
+		<symbol name="nFrames"><doc>Number of frames</doc></symbol>
+		<symbol name="xSize"><doc>Number of pixels in X direction</doc></symbol>
+		<symbol name="ySize"><doc>Number of pixels in Y direction</doc></symbol>
 	</symbols>
 
     <doc>

--- a/applications/NXtomo.nxdl.xml
+++ b/applications/NXtomo.nxdl.xml
@@ -27,14 +27,20 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
-
 	<symbols>
-		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nFrames"><doc>Number of frames</doc></symbol>
-		<symbol name="xSize"><doc>Number of pixels in X direction</doc></symbol>
-		<symbol name="ySize"><doc>Number of pixels in Y direction</doc></symbol>
+		<doc>
+          These symbols will be used below to coordinate datasets with the same shape.
+        </doc>
+		<symbol name="nFrames">
+          <doc>Number of frames</doc>
+        </symbol>
+		<symbol name="xSize">
+          <doc>Number of pixels in X direction</doc>
+        </symbol>
+		<symbol name="ySize">
+          <doc>Number of pixels in Y direction</doc>
+        </symbol>
 	</symbols>
-
     <doc>
           This is the application definition for x-ray or neutron tomography raw data. 
           

--- a/applications/NXtomo.nxdl.xml
+++ b/applications/NXtomo.nxdl.xml
@@ -31,8 +31,8 @@
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
 		<symbol name="nFrames"><doc>number of frames</doc></symbol>
-		<symbol name="xsize"><doc>number of pixels in X direction</doc></symbol>
-		<symbol name="ysize"><doc>number of pixels in Y direction</doc></symbol>
+		<symbol name="xSize"><doc>number of pixels in X direction</doc></symbol>
+		<symbol name="ySize"><doc>number of pixels in Y direction</doc></symbol>
 	</symbols>
 
     <doc>
@@ -68,8 +68,8 @@
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="3">
               <dim index="1" value="nFrames" />
-              <dim index="2" value="xsize" />
-              <dim index="3" value="ysize" />
+              <dim index="2" value="xSize" />
+              <dim index="3" value="ySize" />
             </dimensions>
           </field>
           <field name="image_key" type="NX_INT" >

--- a/applications/NXtomophase.nxdl.xml
+++ b/applications/NXtomophase.nxdl.xml
@@ -34,8 +34,8 @@
 		<symbol name="nDarkFrames"><doc>number of dark frames</doc></symbol>
 		<symbol name="nSampleFrames"><doc>number of image (sample) frames</doc></symbol>
 		<symbol name="nPhase"><doc>number of phase settings</doc></symbol>
-		<symbol name="xsize"><doc>number of pixels in X direction</doc></symbol>
-		<symbol name="ysize"><doc>number of pixels in Y direction</doc></symbol>
+		<symbol name="xSize"><doc>number of pixels in X direction</doc></symbol>
+		<symbol name="ySize"><doc>number of pixels in Y direction</doc></symbol>
 	</symbols>
 
     <doc>
@@ -71,8 +71,8 @@
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="3">
               <dim index="1" value="nBrightFrames" />
-              <dim index="2" value="xsize" />
-              <dim index="3" value="ysize" />
+              <dim index="2" value="xSize" />
+              <dim index="3" value="ySize" />
             </dimensions>
           </field>
           <field name="sequence_number" type="NX_INT">
@@ -85,8 +85,8 @@
           <field name="data" type="NX_INT" signal="1">
             <dimensions rank="3">
               <dim index="1" value="nDarkFrames" />
-              <dim index="2" value="xsize" />
-              <dim index="3" value="ysize" />
+              <dim index="2" value="xSize" />
+              <dim index="3" value="ySize" />
             </dimensions>
           </field>
           <field name="sequence_number" type="NX_INT">
@@ -100,8 +100,8 @@
             <dimensions rank="4">
               <dim index="1" value="nSampleFrames" />
               <dim index="2" value="nPhase" />
-              <dim index="3" value="xsize" />
-              <dim index="4" value="ysize" />
+              <dim index="3" value="xSize" />
+              <dim index="4" value="ySize" />
             </dimensions>
           </field>
           <field name="sequence_number" type="NX_INT">

--- a/applications/NXtomophase.nxdl.xml
+++ b/applications/NXtomophase.nxdl.xml
@@ -30,12 +30,12 @@
 
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nBrightFrames"><doc>number of bright frames</doc></symbol>
-		<symbol name="nDarkFrames"><doc>number of dark frames</doc></symbol>
-		<symbol name="nSampleFrames"><doc>number of image (sample) frames</doc></symbol>
-		<symbol name="nPhase"><doc>number of phase settings</doc></symbol>
-		<symbol name="xSize"><doc>number of pixels in X direction</doc></symbol>
-		<symbol name="ySize"><doc>number of pixels in Y direction</doc></symbol>
+		<symbol name="nBrightFrames"><doc>Number of bright frames</doc></symbol>
+		<symbol name="nDarkFrames"><doc>Number of dark frames</doc></symbol>
+		<symbol name="nSampleFrames"><doc>Number of image (sample) frames</doc></symbol>
+		<symbol name="nPhase"><doc>Number of phase settings</doc></symbol>
+		<symbol name="xSize"><doc>Number of pixels in X direction</doc></symbol>
+		<symbol name="ySize"><doc>Number of pixels in Y direction</doc></symbol>
 	</symbols>
 
     <doc>

--- a/applications/NXtomophase.nxdl.xml
+++ b/applications/NXtomophase.nxdl.xml
@@ -27,17 +27,27 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
-
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nBrightFrames"><doc>Number of bright frames</doc></symbol>
-		<symbol name="nDarkFrames"><doc>Number of dark frames</doc></symbol>
-		<symbol name="nSampleFrames"><doc>Number of image (sample) frames</doc></symbol>
-		<symbol name="nPhase"><doc>Number of phase settings</doc></symbol>
-		<symbol name="xSize"><doc>Number of pixels in X direction</doc></symbol>
-		<symbol name="ySize"><doc>Number of pixels in Y direction</doc></symbol>
+		<symbol name="nBrightFrames">
+          <doc>Number of bright frames</doc>
+        </symbol>
+		<symbol name="nDarkFrames">
+          <doc>Number of dark frames</doc>
+        </symbol>
+		<symbol name="nSampleFrames">
+          <doc>Number of image (sample) frames</doc>
+        </symbol>
+		<symbol name="nPhase">
+          <doc>Number of phase settings</doc>
+        </symbol>
+		<symbol name="xSize">
+          <doc>Number of pixels in X direction</doc>
+        </symbol>
+		<symbol name="ySize">
+          <doc>Number of pixels in Y direction</doc>
+        </symbol>
 	</symbols>
-
     <doc>
       This is the application definition for x-ray or neutron tomography raw data with phase contrast variation at each point. 
       

--- a/applications/NXtomoproc.nxdl.xml
+++ b/applications/NXtomoproc.nxdl.xml
@@ -27,14 +27,18 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
-
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nX"><doc>Number of voxels in X direction</doc></symbol>
-		<symbol name="nY"><doc>Number of voxels in Y direction</doc></symbol>
-		<symbol name="nZ"><doc>Number of voxels in Z direction</doc></symbol>
+		<symbol name="nX">
+          <doc>Number of voxels in X direction</doc>
+        </symbol>
+		<symbol name="nY">
+          <doc>Number of voxels in Y direction</doc>
+        </symbol>
+		<symbol name="nZ">
+          <doc>Number of voxels in Z direction</doc>
+        </symbol>
 	</symbols>
-  
     <doc>This is an application definition for the final result of a tomography experiment: a 3D construction of some volume of physical properties.</doc>
     <group type="NXentry" name="entry">
       <field name="title" />

--- a/applications/NXtomoproc.nxdl.xml
+++ b/applications/NXtomoproc.nxdl.xml
@@ -30,9 +30,9 @@
 
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nX"><doc>number of voxels in X direction</doc></symbol>
-		<symbol name="nY"><doc>number of voxels in Y direction</doc></symbol>
-		<symbol name="nZ"><doc>number of voxels in Z direction</doc></symbol>
+		<symbol name="nX"><doc>Number of voxels in X direction</doc></symbol>
+		<symbol name="nY"><doc>Number of voxels in Y direction</doc></symbol>
+		<symbol name="nZ"><doc>Number of voxels in Z direction</doc></symbol>
 	</symbols>
   
     <doc>This is an application definition for the final result of a tomography experiment: a 3D construction of some volume of physical properties.</doc>

--- a/applications/NXtomoproc.nxdl.xml
+++ b/applications/NXtomoproc.nxdl.xml
@@ -30,9 +30,9 @@
 
 	<symbols>
 		<doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
-		<symbol name="nx"><doc>number of voxels in X direction</doc></symbol>
-		<symbol name="ny"><doc>number of voxels in Y direction</doc></symbol>
-		<symbol name="nz"><doc>number of voxels in Z direction</doc></symbol>
+		<symbol name="nX"><doc>number of voxels in X direction</doc></symbol>
+		<symbol name="nY"><doc>number of voxels in Y direction</doc></symbol>
+		<symbol name="nZ"><doc>number of voxels in Z direction</doc></symbol>
 	</symbols>
   
     <doc>This is an application definition for the final result of a tomography experiment: a 3D construction of some volume of physical properties.</doc>
@@ -86,9 +86,9 @@
             quantity this really is.
           </doc>
           <dimensions rank="3">
-            <dim index="1" value="nx" />
-            <dim index="2" value="nx" />
-            <dim index="3" value="nz" />
+            <dim index="1" value="nX" />
+            <dim index="2" value="nX" />
+            <dim index="3" value="nZ" />
           </dimensions>
           <attribute name="transform"></attribute>
           <attribute name="offset"></attribute>
@@ -100,7 +100,7 @@
             data. The units must be appropriate for the measurement.
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="nx" />
+            <dim index="1" value="nX" />
           </dimensions>
         </field>
         <field name="y" type="NX_FLOAT" units="NX_ANY" axis="2">
@@ -109,7 +109,7 @@
             data. The units must be appropriate for the measurement.
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="ny" />
+            <dim index="1" value="nY" />
           </dimensions>
         </field>
         <field name="z" type="NX_FLOAT" units="NX_ANY" axis="3">
@@ -118,7 +118,7 @@
             data. The units must be appropriate for the measurement.
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="nz" />
+            <dim index="1" value="nZ" />
           </dimensions>
         </field>
       </group>

--- a/applications/NXxas.nxdl.xml
+++ b/applications/NXxas.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
         <doc>
-		    The symbol(s) listed here will be used below to coordinate datasets
-			with the same shape.
+		    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
         </doc>
 		<symbol name="nP">
 		    <doc>Number of points</doc>

--- a/applications/NXxas.nxdl.xml
+++ b/applications/NXxas.nxdl.xml
@@ -28,13 +28,13 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd "
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
+        <doc>
+		    The symbol(s) listed here will be used below to coordinate datasets
+			with the same shape.
+        </doc>
+		<symbol name="nP">
+		    <doc>Number of points</doc>
+        </symbol>
 	</symbols>
     <doc>
       This is an application definition for raw data from an X-ray absorption spectroscopy experiment. 

--- a/applications/NXxas.nxdl.xml
+++ b/applications/NXxas.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd "
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
     <doc>
       This is an application definition for raw data from an X-ray absorption spectroscopy experiment. 
       
@@ -61,14 +70,14 @@
             <group type="NXmonochromator" name="monochromator">
               <field name="energy" axis="1" type="NX_FLOAT">
                 <dimensions rank="1">
-                  <dim index="1" value="np" />
+                  <dim index="1" value="nP" />
                 </dimensions>
               </field>
             </group>
             <group type="NXdetector" name="incoming_beam">
               <field name="data" type="NX_INT">
                 <dimensions rank="1">
-                  <dim index="1" value="np" />
+                  <dim index="1" value="nP" />
                 </dimensions>
               </field>
             </group>
@@ -76,7 +85,7 @@
               <field name="data" type="NX_INT">
                   <doc>mark this field with attribute  ``signal=1``</doc>
                 <dimensions rank="1">
-                  <dim index="1" value="np" />
+                  <dim index="1" value="nP" />
                 </dimensions>
               </field>
             </group>
@@ -102,7 +111,7 @@
             </field>
             <field name="data" type="NX_INT">
               <dimensions rank="1">
-                <dim index="1" value="np" /></dimensions></field>
+                <dim index="1" value="nP" /></dimensions></field>
         </group>
         <group type="NXdata">
           <link name="energy" target="/entry/instrument/monochromator/energy"></link>

--- a/applications/NXxas.nxdl.xml
+++ b/applications/NXxas.nxdl.xml
@@ -111,7 +111,9 @@
             </field>
             <field name="data" type="NX_INT">
               <dimensions rank="1">
-                <dim index="1" value="nP" /></dimensions></field>
+                <dim index="1" value="nP" />
+              </dimensions>
+            </field>
         </group>
         <group type="NXdata">
           <link name="energy" target="/entry/instrument/monochromator/energy"></link>

--- a/applications/NXxasproc.nxdl.xml
+++ b/applications/NXxasproc.nxdl.xml
@@ -29,8 +29,7 @@
     >
     <symbols>
         <doc>
-		    The symbol(s) listed here will be used below to coordinate datasets
-			with the same shape.
+		    The symbol(s) listed here will be used below to coordinate datasets with the same shape.
         </doc>
 		<symbol name="nP">
 			<doc>Number of points</doc>

--- a/applications/NXxasproc.nxdl.xml
+++ b/applications/NXxasproc.nxdl.xml
@@ -28,13 +28,13 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd "
     >
     <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
+        <doc>
+		    The symbol(s) listed here will be used below to coordinate datasets
+			with the same shape.
+        </doc>
+		<symbol name="nP">
+			<doc>Number of points</doc>
+		</symbol>
 	</symbols>
     <doc>
        Processed data from XAS. This is energy versus I(incoming)/I(absorbed).

--- a/applications/NXxasproc.nxdl.xml
+++ b/applications/NXxasproc.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd "
     >
+    <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
     <doc>
        Processed data from XAS. This is energy versus I(incoming)/I(absorbed).
     </doc>
@@ -68,7 +77,7 @@
         <group type="NXdata">
               <field name="energy" axis="1">
                 <dimensions rank="1">
-                  <dim index="1" value="np" />
+                  <dim index="1" value="nP" />
                 </dimensions>
               </field>
               <field name="data" type="NX_FLOAT">
@@ -77,7 +86,7 @@
                    Expect attribute  ``signal=1``
                 </doc>
                 <dimensions rank="1">
-                  <dim index="1" value="np" />
+                  <dim index="1" value="nP" />
                 </dimensions>
               </field>
         </group>

--- a/applications/NXxbase.nxdl.xml
+++ b/applications/NXxbase.nxdl.xml
@@ -35,10 +35,10 @@
         <doc>Number of points</doc>
       </symbol>
       <symbol name="nXPixels">
-        <doc>Number of x pixels</doc>
+        <doc>Number of X pixels</doc>
       </symbol>
       <symbol name="nYPixels">
-        <doc>Number of y pixels</doc>
+        <doc>Number of Y pixels</doc>
       </symbol>
 	</symbols>
     <doc>

--- a/applications/NXxbase.nxdl.xml
+++ b/applications/NXxbase.nxdl.xml
@@ -27,20 +27,20 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
-  <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
-			<symbol name="nXPixels">
-				<doc>number of x pixels</doc>
-			</symbol>
-			<symbol name="nYPixels">
-				<doc>number of y pixels</doc>
-			</symbol>
+    <symbols>
+      <doc>
+        The symbol(s) listed here will be used below to coordinate datasets
+        with the same shape.
+      </doc>
+      <symbol name="nP">
+        <doc>Number of points</doc>
+      </symbol>
+      <symbol name="nXPixels">
+        <doc>Number of x pixels</doc>
+      </symbol>
+      <symbol name="nYPixels">
+        <doc>Number of y pixels</doc>
+      </symbol>
 	</symbols>
     <doc>
       This definition covers the common parts of all monochromatic single crystal raw data application definitions.

--- a/applications/NXxbase.nxdl.xml
+++ b/applications/NXxbase.nxdl.xml
@@ -27,6 +27,21 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+			<symbol name="nXPixels">
+				<doc>number of x pixels</doc>
+			</symbol>
+			<symbol name="nYPixels">
+				<doc>number of y pixels</doc>
+			</symbol>
+	</symbols>
     <doc>
       This definition covers the common parts of all monochromatic single crystal raw data application definitions.
     </doc>
@@ -64,9 +79,9 @@
               the number of detectors on your instrument.
             </doc>
             <dimensions rank="3">
-              <dim index="1" value="np" />
-              <dim index="2" value="number of x pixels" />
-              <dim index="3" value="number of y pixels" />
+              <dim index="1" value="nP" />
+              <dim index="2" value="nXPixels" />
+              <dim index="3" value="nYPixels" />
             </dimensions>
             <attribute name="signal" type="NX_POSINT">
               <enumeration>
@@ -122,7 +137,7 @@
             The sample temperature or whatever sensor represents this value best
             </doc>
           <dimensions rank="1">
-            <dim index="1" value="NP" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
           <field name="x_translation" type="NX_FLOAT" units="NX_LENGTH">

--- a/applications/NXxbase.nxdl.xml
+++ b/applications/NXxbase.nxdl.xml
@@ -29,8 +29,7 @@
   >
     <symbols>
       <doc>
-        The symbol(s) listed here will be used below to coordinate datasets
-        with the same shape.
+        The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="nP">
         <doc>Number of points</doc>

--- a/applications/NXxeuler.nxdl.xml
+++ b/applications/NXxeuler.nxdl.xml
@@ -27,6 +27,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
     <doc>
       raw data from a :index:`four-circle diffractometer` with an :index:`eulerian cradle`, extends :ref:`NXxbase`
       
@@ -50,7 +59,7 @@
               at each scan point.
             </doc>
             <dimensions rank="1">
-              <dim index="1" value="np" />
+              <dim index="1" value="nP" />
             </dimensions>
           </field>
         </group>
@@ -63,7 +72,7 @@
             scan point
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="chi" type="NX_FLOAT" units="NX_ANGLE" axis="1">
@@ -72,7 +81,7 @@
             cradle at each scan point
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="phi" type="NX_FLOAT" units="NX_ANGLE" signal="1">
@@ -81,7 +90,7 @@
             cradle at each scan point
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
       </group>

--- a/applications/NXxeuler.nxdl.xml
+++ b/applications/NXxeuler.nxdl.xml
@@ -27,14 +27,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
-  <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
+    <symbols>
+      <doc>
+        The symbol(s) listed here will be used below to coordinate datasets
+        with the same shape.
+      </doc>
+      <symbol name="nP">
+        <doc>Number of points</doc>
+      </symbol>
 	</symbols>
     <doc>
       raw data from a :index:`four-circle diffractometer` with an :index:`eulerian cradle`, extends :ref:`NXxbase`

--- a/applications/NXxeuler.nxdl.xml
+++ b/applications/NXxeuler.nxdl.xml
@@ -29,8 +29,7 @@
   >
     <symbols>
       <doc>
-        The symbol(s) listed here will be used below to coordinate datasets
-        with the same shape.
+        The symbol(s) listed here will be used below to coordinate datasets with the same shape.
       </doc>
       <symbol name="nP">
         <doc>Number of points</doc>

--- a/applications/NXxkappa.nxdl.xml
+++ b/applications/NXxkappa.nxdl.xml
@@ -27,6 +27,15 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
   <doc>
     raw data from a kappa geometry (CAD4) single crystal diffractometer, extends :ref:`NXxbase`
     
@@ -48,7 +57,7 @@
         <field name="polar_angle" type="NX_FLOAT" units="NX_ANGLE">
           <doc>The polar_angle (two theta) at each scan point</doc>
           <dimensions rank="1">
-            <dim index="1" value="np"/>
+            <dim index="1" value="nP"/>
           </dimensions>
         </field>
       </group>
@@ -61,7 +70,7 @@
           scan point
         </doc>
         <dimensions rank="1">
-          <dim index="1" value="np" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
       <field name="kappa" type="NX_FLOAT" units="NX_ANGLE" axis="1">
@@ -69,7 +78,7 @@
           This is an array holding the kappa angle at each scan point
         </doc>
         <dimensions rank="1">
-          <dim index="1" value="np" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
       <field name="phi" type="NX_FLOAT" units="NX_ANGLE" axis="1">
@@ -77,7 +86,7 @@
           This is an array holding the phi angle at each scan point
         </doc>
         <dimensions rank="1">
-          <dim index="1" value="np" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
       <field name="alpha" type="NX_FLOAT" units="NX_ANGLE">

--- a/applications/NXxkappa.nxdl.xml
+++ b/applications/NXxkappa.nxdl.xml
@@ -28,14 +28,14 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
-	</symbols>
+    <doc>
+      The symbol(s) listed here will be used below to coordinate datasets
+      with the same shape.
+    </doc>
+    <symbol name="nP">
+      <doc>Number of points</doc>
+    </symbol>
+  </symbols>
   <doc>
     raw data from a kappa geometry (CAD4) single crystal diffractometer, extends :ref:`NXxbase`
     

--- a/applications/NXxkappa.nxdl.xml
+++ b/applications/NXxkappa.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-      The symbol(s) listed here will be used below to coordinate datasets
-      with the same shape.
+      The symbol(s) listed here will be used below to coordinate datasets with the same shape.
     </doc>
     <symbol name="nP">
       <doc>Number of points</doc>

--- a/applications/NXxlaue.nxdl.xml
+++ b/applications/NXxlaue.nxdl.xml
@@ -28,14 +28,14 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nE">
-				<doc>Number of energies</doc>
-			</symbol>
-	</symbols>
+    <doc>
+        The symbol(s) listed here will be used below to coordinate datasets
+        with the same shape.
+    </doc>
+    <symbol name="nE">
+        <doc>Number of energies</doc>
+    </symbol>
+  </symbols>
   <doc>
     raw data from a single crystal laue camera, extends :ref:`NXxrot`
     

--- a/applications/NXxlaue.nxdl.xml
+++ b/applications/NXxlaue.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-        The symbol(s) listed here will be used below to coordinate datasets
-        with the same shape.
+        The symbol(s) listed here will be used below to coordinate datasets with the same shape.
     </doc>
     <symbol name="nE">
         <doc>Number of energies</doc>

--- a/applications/NXxlaue.nxdl.xml
+++ b/applications/NXxlaue.nxdl.xml
@@ -27,6 +27,15 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nE">
+				<doc>Number of energies</doc>
+			</symbol>
+	</symbols>
   <doc>
     raw data from a single crystal laue camera, extends :ref:`NXxrot`
     
@@ -46,12 +55,12 @@
             <field name="data">
               <doc>expect  ``signal=1 axes="energy"``</doc>
               <dimensions rank="1">
-                <dim index="1" value="ne" />
+                <dim index="1" value="nE" />
               </dimensions>
             </field>
            <field name="wavelength" units="NX_WAVELENGTH">
               <dimensions rank="1">
-                <dim index="1" value="ne" />
+                <dim index="1" value="nE" />
               </dimensions>
             </field>
            <doc>

--- a/applications/NXxnb.nxdl.xml
+++ b/applications/NXxnb.nxdl.xml
@@ -28,14 +28,14 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
-	</symbols>
+    <doc>
+      The symbol(s) listed here will be used below to coordinate datasets
+      with the same shape.
+    </doc>
+    <symbol name="nP">
+      <doc>Number of points</doc>
+    </symbol>
+  </symbols>
   <doc>
     raw data from a single crystal diffractometer, extends :ref:`NXxbase`
     

--- a/applications/NXxnb.nxdl.xml
+++ b/applications/NXxnb.nxdl.xml
@@ -27,6 +27,15 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
   <doc>
     raw data from a single crystal diffractometer, extends :ref:`NXxbase`
     
@@ -53,7 +62,7 @@
             The polar_angle (gamma) of the detector for each scan point.
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
         <field name="tilt_angle" type="NX_FLOAT" units="NX_ANGLE"
@@ -63,7 +72,7 @@
             scattering plane.
           </doc>
           <dimensions rank="1">
-            <dim index="1" value="np" />
+            <dim index="1" value="nP" />
           </dimensions>
         </field>
       </group>
@@ -76,7 +85,7 @@
           scan point
         </doc>
         <dimensions rank="1">
-          <dim index="1" value="np" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
     </group>

--- a/applications/NXxnb.nxdl.xml
+++ b/applications/NXxnb.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-      The symbol(s) listed here will be used below to coordinate datasets
-      with the same shape.
+      The symbol(s) listed here will be used below to coordinate datasets with the same shape.
     </doc>
     <symbol name="nP">
       <doc>Number of points</doc>

--- a/applications/NXxrot.nxdl.xml
+++ b/applications/NXxrot.nxdl.xml
@@ -27,6 +27,15 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
+  <symbols>
+			<doc>
+				The symbol(s) listed here will be used below to coordinate datasets
+				with the same shape.  
+			</doc>
+			<symbol name="nP">
+				<doc>Number of points</doc>
+			</symbol>
+	</symbols>
   <doc>
     raw data from a rotation camera, extends :ref:`NXxbase` 
     
@@ -68,14 +77,14 @@
         axis="1">
         <doc>This is an array holding the sample rotation start angle at each  scan point</doc>
         <dimensions rank="1">
-          <dim index="1" value="np" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
       <field name="rotation_angle_step" type="NX_FLOAT" units="NX_ANGLE"
         axis="1">
         <doc>This is an array holding the step made for sample rotation angle at each  scan point</doc>
         <dimensions rank="1">
-          <dim index="1" value="np" />
+          <dim index="1" value="nP" />
         </dimensions>
       </field>
     </group>

--- a/applications/NXxrot.nxdl.xml
+++ b/applications/NXxrot.nxdl.xml
@@ -28,14 +28,14 @@
   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
   >
   <symbols>
-			<doc>
-				The symbol(s) listed here will be used below to coordinate datasets
-				with the same shape.  
-			</doc>
-			<symbol name="nP">
-				<doc>Number of points</doc>
-			</symbol>
-	</symbols>
+    <doc>
+      The symbol(s) listed here will be used below to coordinate datasets
+      with the same shape.
+    </doc>
+    <symbol name="nP">
+      <doc>Number of points</doc>
+    </symbol>
+  </symbols>
   <doc>
     raw data from a rotation camera, extends :ref:`NXxbase` 
     

--- a/applications/NXxrot.nxdl.xml
+++ b/applications/NXxrot.nxdl.xml
@@ -29,8 +29,7 @@
   >
   <symbols>
     <doc>
-      The symbol(s) listed here will be used below to coordinate datasets
-      with the same shape.
+      The symbol(s) listed here will be used below to coordinate datasets with the same shape.
     </doc>
     <symbol name="nP">
       <doc>Number of points</doc>

--- a/base_classes/NXdisk_chopper.nxdl.xml
+++ b/base_classes/NXdisk_chopper.nxdl.xml
@@ -86,7 +86,7 @@
 			Timestamps of the top-dead-center signal. The times are relative
 			to the "start" attribute and in the units specified in the "units"
 			attribute. Please note that absolute
-			timestamps under unix are relative to ``1970-01-01T00:00:00.0``.
+			timestamps under unix are relative to ``1970-01-01T00:00:00.0Z``.
 		</doc>
 		<attribute name="start" type="NX_DATE_TIME" />
 	</field>


### PR DESCRIPTION
also a standard is proposed for a symbol naming convention as many definitions refer to a similar symbol "meaning" but the naming was arbitrary, number of points for example (nP, numP, NumP etc).

Fixes #800, fixes #786, fixes #787, fixes #788