### PR TITLE
NXlog: use average_value_errors instead average_value_error

### DIFF
--- a/base_classes/NXlog.nxdl.xml
+++ b/base_classes/NXlog.nxdl.xml
@@ -92,7 +92,11 @@
 		<doc>Description of logged value</doc>
 	</field>
 	<field name="average_value" type="NX_FLOAT" units="NX_ANY"/>
-	<field name="average_value_error" type="NX_FLOAT" units="NX_ANY">
+	<field name="average_value_error" type="NX_FLOAT" units="NX_ANY"
+	        deprecated="see: https://github.com/nexusformat/definitions/issues/639">
+		<doc>estimated uncertainty (often used: standard deviation) of average_value</doc>
+	</field>
+	<field name="average_value_errors" type="NX_FLOAT" units="NX_ANY">
 		<doc>estimated uncertainty (often used: standard deviation) of average_value</doc>
 	</field>
 	<field name="minimum_value" type="NX_FLOAT" units="NX_ANY"/>


### PR DESCRIPTION
Fixes #639