### PR TITLE
NXmonochromator: deprecate _error fields

### DIFF
--- a/base_classes/NXmonochromator.nxdl.xml
+++ b/base_classes/NXmonochromator.nxdl.xml
@@ -43,7 +43,7 @@
     <field name="wavelength" type="NX_FLOAT" units="NX_WAVELENGTH">
         <doc>wavelength selected</doc>
     </field> 
-    <field name="wavelength_error" type="NX_FLOAT" units="NX_WAVELENGTH">
+    <field name="wavelength_error" type="NX_FLOAT" units="NX_WAVELENGTH"
 	deprecated="see https://github.com/nexusformat/definitions/issues/820">
         <doc>wavelength standard deviation</doc>
     </field>
@@ -53,7 +53,7 @@
     <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
         <doc>energy selected</doc>
     </field> 
-    <field name="energy_error" type="NX_FLOAT" units="NX_ENERGY">
+    <field name="energy_error" type="NX_FLOAT" units="NX_ENERGY"
 	deprecated="see https://github.com/nexusformat/definitions/issues/820">
         <doc>energy standard deviation</doc>
     </field> 

--- a/base_classes/NXmonochromator.nxdl.xml
+++ b/base_classes/NXmonochromator.nxdl.xml
@@ -44,14 +44,22 @@
         <doc>wavelength selected</doc>
     </field> 
     <field name="wavelength_error" type="NX_FLOAT" units="NX_WAVELENGTH">
+	deprecated="see https://github.com/nexusformat/definitions/issues/820">
         <doc>wavelength standard deviation</doc>
-    </field> 
+    </field>
+    <field name="wavelength_errors" type="NX_FLOAT" units="NX_WAVELENGTH">
+        <doc>wavelength standard deviation</doc>
+    </field>
     <field name="energy" type="NX_FLOAT" units="NX_ENERGY">
         <doc>energy selected</doc>
     </field> 
     <field name="energy_error" type="NX_FLOAT" units="NX_ENERGY">
+	deprecated="see https://github.com/nexusformat/definitions/issues/820">
         <doc>energy standard deviation</doc>
     </field> 
+    <field name="energy_errors" type="NX_FLOAT" units="NX_ENERGY">
+        <doc>energy standard deviation</doc>
+    </field>
     <group type="NXdata" name="distribution"/> 
     <group type="NXgeometry" name="geometry"/> 
     <group type="NXcrystal"><doc>Use as many crystals as necessary to describe</doc></group>


### PR DESCRIPTION
In favor of _errors fields (fixes #820)