### PR TITLE
State in the manual that NX_CHAR is the default field type

### DIFF
--- a/manual/source/nxdl-types.rst
+++ b/manual/source/nxdl-types.rst
@@ -16,7 +16,8 @@ describe the expected type of data for a NeXus field. These terms are very
 broad. More specific terms are used in actual NeXus data files that describe
 size and array dimensions. In addition to the types in the following table, the
 ``NAPI`` type is defined when one wishes to permit a field
-with any of these data types.
+with any of these data types. The default type ``NX_CHAR`` is applied in cases 
+where a field is defined in an NXDL specification without explicit assignment of a type.
 
 ..  Generated from ../nxdlTypes.xsd via a custom Python tool
     ../../utils/types2rst.py ../../nxdlTypes.xsd > types.table

--- a/manual/source/nxdl-types.rst
+++ b/manual/source/nxdl-types.rst
@@ -17,7 +17,7 @@ broad. More specific terms are used in actual NeXus data files that describe
 size and array dimensions. In addition to the types in the following table, the
 ``NAPI`` type is defined when one wishes to permit a field
 with any of these data types. The default type ``NX_CHAR`` is applied in cases 
-where a field is defined in an NXDL specification without explicit assignment of a type.
+where a field or attribute is defined in an NXDL specification without explicit assignment of a ``type``.
 
 ..  Generated from ../nxdlTypes.xsd via a custom Python tool
     ../../utils/types2rst.py ../../nxdlTypes.xsd > types.table

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -460,7 +460,7 @@
 				String arrays cannot be used where only a string is expected 
 				(title, start_time, end_time, ``NX_class`` attribute,...). 
 				Fields or attributes requiring the use of string arrays will be 
-				clearly marked as such (like the ``NXdata`` attribute auxiliary_signals). 
+				clearly marked as such (like the ``NXdata`` attribute ``auxiliary_signals``). 
 				This is the default field type.
 			</xs:documentation>
 		</xs:annotation>

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -460,7 +460,8 @@
 				String arrays cannot be used where only a string is expected 
 				(title, start_time, end_time, ``NX_class`` attribute,...). 
 				Fields or attributes requiring the use of string arrays will be 
-				clearly marked as such (like the ``NXdata`` attribute auxiliary_signals).
+				clearly marked as such (like the ``NXdata`` attribute auxiliary_signals). 
+				This is the default field type.
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />


### PR DESCRIPTION
State in the manual that NX_CHAR is the default field type, to reflect the existing NXDL behaviour. This change only documents current behaviour and fixes #892.