### PR TITLE
removed NX_SPE from the definition fields enumeration list

### DIFF
--- a/applications/NXspe.nxdl.xml
+++ b/applications/NXspe.nxdl.xml
@@ -36,8 +36,7 @@
             <doc>Official NeXus NXDL schema to which this file conforms.</doc>
             <attribute name="version"/>
             <enumeration>
-                <item value="NXSPE"/>
-                <item value="NXspe"/>                
+                <item value="NXspe"/>
             </enumeration>
         </field>
         <group type="NXcollection" name="NXSPE_info">


### PR DESCRIPTION
removed the invalid NX_SPE from the definition field enumeration list because it does not point to a valid NXDL schema, fixes #911 :

```
            <enumeration>
                <item value="NXSPE"/>
                <item value="NXspe"/>                
            </enumeration>
```
is now 
```
            <enumeration>
                <item value="NXspe"/>                
            </enumeration>
```
