### PR TITLE
in NXentry & NXsubentry, link to manual page instead of discussion

### DIFF
--- a/base_classes/NXentry.nxdl.xml
+++ b/base_classes/NXentry.nxdl.xml
@@ -33,13 +33,14 @@
 	<attribute name="default">
 		<doc>
 			.. index:: plotting
-			
-			Declares which :ref:`NXdata` (or :ref:`NXsubentry`) group 
-			contains the data to be shown by default.
-			It is needed to resolve ambiguity when more than one :ref:`NXdata` group exists. 
+
+			Declares which :ref:`NXdata` group contains the data
+			to be shown by default.
+			It is needed to resolve ambiguity when more than
+			one :ref:`NXdata` group exists.
 			The value is the name of the default :ref:`NXdata` group.
-			
-			For more information about how NeXus identifies the default 
+
+			For more information about how NeXus identifies the default
 			plottable data, see the
 			:ref:`Find Plottable Data, v3 &lt;Find-Plottable-Data-v3&gt;`
 			section.

--- a/base_classes/NXentry.nxdl.xml
+++ b/base_classes/NXentry.nxdl.xml
@@ -39,11 +39,10 @@
 			It is needed to resolve ambiguity when more than one :ref:`NXdata` group exists. 
 			The value is the name of the default :ref:`NXdata` group.
 			
-			It is recommended (as of NIAC2014 [#]_) to use this attribute
-			to help define the path to the default dataset to be plotted.
-			
-			.. [#] NIAC2014 discussion summary:
-			    https://www.nexusformat.org/2014_How_to_find_default_data.html
+			For more information about how NeXus identifies the default 
+			plottable data, see the
+			:ref:`Find Plottable Data, v3 &lt;Find-Plottable-Data-v3&gt;`
+			section.
 		</doc>
 	</attribute>
 	

--- a/base_classes/NXsubentry.nxdl.xml
+++ b/base_classes/NXsubentry.nxdl.xml
@@ -40,10 +40,10 @@
 			one :ref:`NXdata` group exists. 
 			The value is the name of the default :ref:`NXdata` group.
 			
-			It is recommended (as of NIAC2014) to use this attribute
-			to help define the path to the default dataset to be plotted.
-			See https://www.nexusformat.org/2014_How_to_find_default_data.html
-			for a summary of the discussion.
+			For more information about how NeXus identifies the default 
+			plottable data, see the
+			:ref:`Find Plottable Data, v3 &lt;Find-Plottable-Data-v3&gt;`
+			section.
 		</doc>
 	</attribute>
 	

--- a/base_classes/NXsubentry.nxdl.xml
+++ b/base_classes/NXsubentry.nxdl.xml
@@ -33,14 +33,14 @@
 	<attribute name="default">
 		<doc>
 			.. index:: plotting
-			
-			Declares which :ref:`NXdata` group contains the data 
+
+			Declares which :ref:`NXdata` group contains the data
 			to be shown by default.
-			It is needed to resolve ambiguity when more than 
-			one :ref:`NXdata` group exists. 
+			It is needed to resolve ambiguity when more than
+			one :ref:`NXdata` group exists.
 			The value is the name of the default :ref:`NXdata` group.
-			
-			For more information about how NeXus identifies the default 
+
+			For more information about how NeXus identifies the default
 			plottable data, see the
 			:ref:`Find Plottable Data, v3 &lt;Find-Plottable-Data-v3&gt;`
 			section.


### PR DESCRIPTION
To FIX #916, change the documentation field of the `@default` attribute to point to the manual page describing how NeXus describes the default plottable data.  Currently, the documentation points to the NIAC2014 discussion of the topic.