### PR TITLE
remove tip at bottom of every NXDL , place it on NXDL chapter page

### DIFF
--- a/manual/source/nxdl.rst
+++ b/manual/source/nxdl.rst
@@ -76,6 +76,22 @@ to validate NeXus data files.  In fact, all of the tables in the
 :ref:`Class Definitions <ClassDefinitions>` Chapter
 have been generated directly from the NXDL files.
 
+.. sidebar:: Writing references and anchors in the documentation.
+
+   .. tip::
+
+      Use the reST anchors when writing documentation in
+      NXDL source files.
+      Since the anchors have no title or caption associated,
+      you will need to supply text with the reference, such as::
+
+          :ref:`this text will appear <anchor>`
+
+      Since these anchors are absolute references, they may be
+      used anywhere in the documentation source 
+      (that is, within XML ``<doc>`` structures 
+      in `.nxdl.xml` files or in ``.rst`` files).
+
 The language of NXDL files is intentionally quite small,
 to provide only that which is necessary to describe
 scientific data structures (or to establish the

--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -66,19 +66,19 @@ def printAnchorList():
             )
             # fmt: on
         print(table)
-        print(
-            ".. tip::\n"
-            "   Use the reST anchors when writing documentation in\n"
-            "   NXDL source files.\n"
-            "   Since the anchors have no title or caption associated,\n"
-            "   you will need to supply text with the reference, such as::\n\n"
-            "       :ref:`this text will appear <anchor>`\n\n"
-            "   Since these anchors are absolute references, they may be\n"
-            "   used anywhere in the documentation source \n"
-            "   (that is, within XML ``<doc>`` structures \n"
-            "   in `.nxdl.xml` files or in ``.rst`` files).\n"
-            # &lt;doc&gt;
-        )
+        # print(
+        #     ".. tip::\n"
+        #     "   Use the reST anchors when writing documentation in\n"
+        #     "   NXDL source files.\n"
+        #     "   Since the anchors have no title or caption associated,\n"
+        #     "   you will need to supply text with the reference, such as::\n\n"
+        #     "       :ref:`this text will appear <anchor>`\n\n"
+        #     "   Since these anchors are absolute references, they may be\n"
+        #     "   used anywhere in the documentation source \n"
+        #     "   (that is, within XML ``<doc>`` structures \n"
+        #     "   in `.nxdl.xml` files or in ``.rst`` files).\n"
+        #     # &lt;doc&gt;
+        # )
 
 
 def fmtTyp( node ):

--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -66,19 +66,6 @@ def printAnchorList():
             )
             # fmt: on
         print(table)
-        # print(
-        #     ".. tip::\n"
-        #     "   Use the reST anchors when writing documentation in\n"
-        #     "   NXDL source files.\n"
-        #     "   Since the anchors have no title or caption associated,\n"
-        #     "   you will need to supply text with the reference, such as::\n\n"
-        #     "       :ref:`this text will appear <anchor>`\n\n"
-        #     "   Since these anchors are absolute references, they may be\n"
-        #     "   used anywhere in the documentation source \n"
-        #     "   (that is, within XML ``<doc>`` structures \n"
-        #     "   in `.nxdl.xml` files or in ``.rst`` files).\n"
-        #     # &lt;doc&gt;
-        # )
 
 
 def fmtTyp( node ):


### PR DESCRIPTION
The tip shown below is out of place as it appears on every NXDL documentation web page.  Relocate it to fix #923.

![tip](https://user-images.githubusercontent.com/2279984/117159559-ffdf1e00-ad85-11eb-9d0a-df0ecb8b1ddf.png)