### PR TITLE
Add revision attribute to NXentry and NXsubentry definition fields. 

### DIFF
--- a/base_classes/NXentry.nxdl.xml
+++ b/base_classes/NXentry.nxdl.xml
@@ -137,6 +137,7 @@
 		</doc>
 		<attribute name="version"><doc>NXDL version number</doc></attribute>
 		<attribute name="URL"><doc>URL of NXDL file</doc></attribute>
+		<attribute name="revision"><doc>Git commit id of the NXDL file</doc></attribute>
 	</field>
 	<field name="definition_local" deprecated="see same field in :ref:`NXsubentry` for preferred use">
 		<doc>

--- a/base_classes/NXsubentry.nxdl.xml
+++ b/base_classes/NXsubentry.nxdl.xml
@@ -104,6 +104,7 @@
 		<doc>Official NeXus NXDL schema to which this subentry conforms</doc>
 		<attribute name="version"><doc>NXDL version number</doc></attribute>
 		<attribute name="URL"><doc>URL of NXDL file</doc></attribute>
+		<attribute name="revision"><doc>Git commit id of the NXDL file</doc></attribute>
 	</field>
 	<field name="definition_local">
 		<doc>
@@ -114,6 +115,7 @@
 		</doc>
 		<attribute name="version"><doc>NXDL version number</doc></attribute>
 		<attribute name="URL"><doc>URL of NXDL file</doc></attribute>
+		<attribute name="revision"><doc>Git commit id of the NXDL file</doc></attribute>
 	</field>
 	<field name="start_time" type="NX_DATE_TIME">
 		<doc>Starting time of measurement</doc>


### PR DESCRIPTION
Specifies the git commit id of the NXDL file.

Draft proposal, probably subject to NIAC vote.  Requested by @kirienko in cctbx/cctbx_project#623 ([relevant comment](https://github.com/cctbx/cctbx_project/pull/623#issuecomment-870063066)).

@kirienko can you review and verify this is good for your purposes?