### PR TITLE
NXdetector: Add virtual_pixel_correction_applied

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -629,6 +629,18 @@
                             the data recorded here, false otherwise.
                         </doc>
                     </field>
+                    <field name="virtual_pixel_interpolation_applied" type="NX_BOOLEAN"
+                        minOccurs="0">
+                        <doc>
+                            True when virtual pixel interpolation has been applied, false otherwise.
+
+                            When virtual pixel interpolation is applied, values of some pixels may
+                            contain interpolated values. For example, to account for space between
+                            readout chips on a module, physical pixels on edges and corners between
+                            chips may have larger sensor areas and counts may be distributed between
+                            their logical pixels.
+                        </doc>
+                    </field>
 
                     <field name="bit_depth_readout" type="NX_INT" recommended="true">
                         <doc>

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -743,6 +743,17 @@
       <dim index="1" value="m"/>
     </dimensions>
   </field>
+  <field name="virtual_pixel_interpolation_applied" type="NX_BOOLEAN" >
+    <doc>
+      True when virtual pixel interpolation has been applied, false otherwise.
+
+      When virtual pixel interpolation is applied, values of some pixels may
+      contain interpolated values. For example, to account for space between
+      readout chips on a module, physical pixels on edges and corners between
+      chips may have larger sensor areas and counts may be distributed between
+      their logical pixels.
+    </doc>
+  </field>
   <field name="bit_depth_readout" type="NX_INT">
     <doc>
       How many bits the electronics reads per pixel.


### PR DESCRIPTION
We use virtual pixels to account for the space in between chips. For that, the edge pixels of the chips are extended into the gaps, creating more counts on those edges.The virtual pixel correction distributes these counts over the logical pixels.