### PR TITLE
more items that should not be added to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ manual/source/.introduction.rst.swp
 manual/source/nexus.pdf
 manual/source/nxdl_desc.rst
 manual/source/*.table
+manual/source/classes/*/*/
+manual/source/classes/*/index.rst
 manual/source/classes/*/NX*.rst
 manual/source/classes/*/*.nxdl.xml
 manual/source/classes/contributed_definitions/canSAS


### PR DESCRIPTION
Today, I found these uncommitted items in my _local_ clone of the definitions repository:

```bash
(bluesky_2022_1) prjemian@zap:~/.../NeXus/definitions$ git status
On branch more-ignore-items
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	manual/source/classes/applications/canSAS/
	manual/source/classes/applications/index.rst
	manual/source/classes/base_classes/index.rst
	manual/source/classes/contributed_definitions/container/
	manual/source/classes/contributed_definitions/index.rst
```
