### PR TITLE
add image_key to NXdetector

### DIFF
--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -665,7 +665,7 @@
       * invalid = 3
       * background (no sample, but buffer where applicable) = 4
 
-      In cases where the make data is of type :ref:`NXlog` this can also be an NXlog.
+      In cases where the data is of type :ref:`NXlog` this can also be an NXlog.
     </doc>
     <dimensions rank="1">
       <dim index="1" value="np" />

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -654,7 +654,7 @@
       recording the different measurements preserves the chronological order with is important for
       correct processing.
 
-      This is used for example in tomography ():ref:`NXtomo`) sample projections,
+      This is used for example in tomography (`:ref:`NXtomo`) sample projections,
       dark and flat images, a magic number is recorded per frame.
 
       The key is as follows:

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -646,6 +646,32 @@
       <dim index="2" value="j"/>
     </dimensions>
   </field>
+
+  <field name="image_key" type="NX_INT" >
+    <doc>
+      This field allow to distinguish different types of exposure to the same detector "data" field.
+      Some techniques require frequent (re-)calibration inbetween measuremnts and this way of
+      recording the different measurements preserves the chronological order with is important for
+      correct processing.
+
+      This is used for example in tomography ():ref:`NXtomo`) sample projections,
+      dark and flat images, a magic number is recorded per frame.
+
+      The key is as follows:
+
+      * projection (sample) = 0
+      * flat field = 1
+      * dark field = 2
+      * invalid = 3
+      * background (no sample, but buffer where applicable) = 4
+
+      In cases where the make data is of type :ref:`NXlog` this can also be an NXlog.
+    </doc>
+    <dimensions rank="1">
+      <dim index="1" value="np" />
+    </dimensions>
+  </field>
+
   <field name="countrate_correction_applied" type="NX_BOOLEAN" >
     <doc>
       True when a count-rate correction has already been applied in the


### PR DESCRIPTION
When accepting NXtomo we accidentally introduced the `image_key` field to `NXdetector`. This is not only useful for tomography, but can be used in all cases, where various calibrations are interspersed with "normal" exposures of the sample. It preserves the sequence of the measurements are taken and does not require any (implied) protocol. 

Since this is already part of NeXus and in active use, through NXtomo, this should relatively non-contentious.