### PR TITLE
change g2 unit type to NX_DIMENSIONLESS

### DIFF
--- a/contributed_definitions/NXxpcs.nxdl.xml
+++ b/contributed_definitions/NXxpcs.nxdl.xml
@@ -102,7 +102,7 @@
             average intensity v. time (in the units of "frames")
         </doc>
       </field>
-      <field name="g2" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="g2" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
             normalized intensity auto-correlation function, see Lumma, Rev. Sci. Instr. (2000), Eq 1
 
@@ -145,7 +145,7 @@
           </enumeration>
         </attribute>
       </field>
-      <field name="g2_derr" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="g2_derr" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
             error values for the :math:`g_2` values.
 
@@ -160,7 +160,7 @@
           </enumeration>
         </attribute>
       </field>
-      <field name="G2_unnormalized" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="G2_unnormalized" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
             unnormalized intensity auto-correlation function.
 
@@ -277,7 +277,7 @@
           </enumeration>
         </attribute>
       </field>
-      <field name="g2_from_two_time_corr_func" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="g2_from_two_time_corr_func" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
           frame weighted average along the diagonal direction in ``two_time_corr_func``
 
@@ -319,7 +319,7 @@
         </enumeration>
         </attribute>
       </field>
-      <field name="g2_err_from_two_time_corr_func" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="g2_err_from_two_time_corr_func" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
             error values for the :math:`g_2` values.
 
@@ -335,7 +335,7 @@
           </enumeration>
         </attribute>
       </field>
-      <field name="g2_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="g2_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
           subset of frame weighted average along the diagonal direction in ``two_time_corr_func``
 
@@ -365,7 +365,7 @@
         </enumeration>
         </attribute>
       </field>
-      <field name="g2_err_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_UNITLESS" minOccurs="0" maxOccurs="1">
+      <field name="g2_err_from_two_time_corr_func_partials" type="NX_NUMBER" units="NX_DIMENSIONLESS" minOccurs="0" maxOccurs="1">
         <doc>
             error values for the :math:`g_2` values.
 


### PR DESCRIPTION
- Close #1005

On review of the equation for g2, the units are identical in numerator and denominator. The correct unit type for this is `NX_DIMENSIONLESS`.

@ambarb @AbbyGI @JulReinhardt - can you comment?