### PR TITLE
NXxpcs: add NXprocess group

### DIFF
--- a/contributed_definitions/NXxpcs.nxdl.xml
+++ b/contributed_definitions/NXxpcs.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2008-2021 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2022 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -577,5 +577,11 @@
         pick the next number in this sequence.
       </doc>
     </group>
+  </group>
+
+    <group type="NXprocess">
+      <doc>
+        Describe the computation process that produced these results.
+      </doc>
   </group>
 </definition>


### PR DESCRIPTION
This is processed data, so it needs a [NXprocess](https://manual.nexusformat.org/classes/base_classes/NXprocess.html#nxprocess) group to document details of the reconstruction process.

- Close #1006

@ambarb @AbbyGI @JulReinhardt - can you comment?