### PR TITLE
Deprecate incr attribute of dimension type

### DIFF
--- a/base_classes/NXfilter.nxdl.xml
+++ b/base_classes/NXfilter.nxdl.xml
@@ -149,7 +149,7 @@
 	</field>
 	<field name="coating_roughness" type="NX_FLOAT" units="NX_LENGTH">
 		<doc>coating roughness (RMS) of supermirror filter</doc>
-		<dimensions rank="1"><dim index="1" incr="1" value="nsurf"/></dimensions>
+		<dimensions rank="1"><dim index="1" value="nsurf"/></dimensions>
 	</field>
     <attribute name="default">
         <doc>

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -1335,6 +1335,9 @@
 					<xs:attribute name="incr" type="nx:NX_CHAR">
 						<xs:annotation>
 							<xs:documentation>
+								Deprecated: 2016-11-23 telco 
+								(https://github.com/nexusformat/definitions/issues/330)
+								
 								The dimension specification is related to
 								the ``refindex`` axis within the ``ref`` field by an
 								offset of ``incr``.  Requires ``ref`` and ``refindex``


### PR DESCRIPTION
- Fixes #963 
- close nexusformat/NIAC#112. 

Also remove from NXfilter's coating_roughness field (which was add in 20090304 by change f86bdcb4591707db84346207dbbc49297c75c8a0)