### PR TITLE
DOC doc string all on one line

### DIFF
--- a/contributed_definitions/NXcsg.nxdl.xml
+++ b/contributed_definitions/NXcsg.nxdl.xml
@@ -30,9 +30,7 @@
 	   xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	   >
   <doc>
-    constructive solid geometry NeXus class, using :ref:`NXquadric`
-    and :ref:`NXoff_geometry`.
-  </doc>
+    Constructive Solid Geometry base class, using :ref:`NXquadric` and :ref:`NXoff_geometry`</doc>
   <field
      name="operation">
     <doc>


### PR DESCRIPTION
For NXDL class summaries, only first line of doc block will be used.  Revise obvious content to fit.