### PR TITLE
html artifact for easy documentation checking of pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,22 @@ jobs:
           ls -lAFgh build/manual/build/html/index.html
           ls -lAFgh build/manual/build/latex/nexus.pdf
 
+      - name: Upload HTML artifacts
+        if: ${{ env.python_version == env.python_deploy_version }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: html
+          path: build/manual/build/html/
+          retention-days: 30
+
+      - name: Upload PDF artifacts
+        if: ${{ env.python_version == env.python_deploy_version }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: nexus.pdf
+          path: build/manual/build/latex/nexus.pdf
+          retention-days: 30
+
       - name: Build and Commit the User Manual
         if: ${{ github.event.inputs.deploy && env.python_version == env.python_deploy_version }}
         uses: sphinx-notes/pages@master


### PR DESCRIPTION
Closes #1280

Keep the HTML artifacts for HTML checking by reviewers of pull requests.

Limitations of this approach:

* you don't have a link that lands you on the docs of the PR, you can only download the docs and view them locally
* the download links are rather hidden
* there is a time limit on the artifacts (I current took 30 days)

![image](https://github.com/nexusformat/definitions/assets/7264703/a924f815-3a1b-4b07-96fc-86a875e7f764)
