### PR TITLE
NXdata errors on an axis, signal or auxiliary signal

### DIFF
--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -355,10 +355,6 @@
 				Do not use the ``axes`` attribute with the ``axis`` attribute.
 			</doc>
 		</attribute>
-		<!--
-			NIAC2018 voted to use FIELDNAME_errors, not @uncertainties
-			https://github.com/nexusformat/definitions/issues/634
-		-->
 		<attribute name="long_name">
 			<doc>data label</doc>
 		</attribute>

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -43,7 +43,7 @@
 	<symbols>
 		<doc>These symbols will be used below to coordinate fields with the same shape.</doc>
 		<symbol name="dataRank"><doc>rank of the ``DATA`` field</doc></symbol>
-		<symbol name="n"><doc>length of the ``VARIABLE`` field</doc></symbol>
+		<symbol name="n"><doc>length of the ``AXISNAME`` field</doc></symbol>
 		<symbol name="nx"><doc>length of the ``x`` field</doc></symbol>
 		<symbol name="ny"><doc>length of the ``y`` field</doc></symbol>
 		<symbol name="nz"><doc>length of the ``z`` field</doc></symbol>
@@ -166,7 +166,7 @@
 		
 		It is strongly recommended that there is at least one :ref:`NXdata`
 		group in each :ref:`NXentry` group.
-		Note that the fields named ``VARIABLE`` and ``DATA`` 
+		Note that the fields named ``AXISNAME`` and ``DATA``
 		can be defined with different names.  
 		(Upper case is used to indicate that the actual name is left to the user.)
 		The ``signal`` and ``axes`` attributes of the 
@@ -304,14 +304,14 @@
 			</doc>
 		</attribute>
 	</field>
-	<field name="VARIABLE_errors" type="NX_NUMBER" nameType="any">
+	<field name="FIELDNAME_errors" type="NX_NUMBER" nameType="any">
 		<doc>
 			"Errors" (meaning *uncertainties* or *standard deviations*)
-			associated with any field named ``VARIABLE`` in this ``NXdata``
+			associated with any field named ``FIELDNAME`` in this ``NXdata``
 			group (e.g. an axis, signal or auxiliary signal).
 
-			The dimensions of the ``VARIABLE_errors`` field must match
-			the dimensions of the ``VARIABLE`` field.
+			The dimensions of the ``FIELDNAME_errors`` field must match
+			the dimensions of the ``FIELDNAME`` field.
 		</doc>
 	</field>
 	<field name="DATA" type="NX_NUMBER" nameType="any">
@@ -356,7 +356,7 @@
 			</doc>
 		</attribute>
 		<!--
-			NIAC2018 voted to use VARIABLE_errors, not @uncertainties
+			NIAC2018 voted to use FIELDNAME_errors, not @uncertainties
 			https://github.com/nexusformat/definitions/issues/634
 		-->
 		<attribute name="long_name">

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -367,7 +367,7 @@
 		<doc>
 			Standard deviations of data values - 
 			the data array is identified by the group attribute ``signal``. 
-			The ``errors`` array must have the same dimensions as ``FIELDNAME``.
+			The ``errors`` array must have the same dimensions as ``DATA``.
 			Client is responsible for defining the dimensions of the data.
 		</doc>
 		<dimensions rank="dataRank">

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -363,11 +363,11 @@
 			<doc>data label</doc>
 		</attribute>
 	</field>
-	<field name="errors" type="NX_NUMBER" deprecated="Use ``DATA_errors`` instead (NIAC2018)">
+	<field name="errors" type="NX_NUMBER" deprecated="Use ``FIELDNAME_errors`` instead (NIAC2018)">
 		<doc>
 			Standard deviations of data values - 
 			the data array is identified by the group attribute ``signal``. 
-			The ``errors`` array must have the same dimensions as ``data``.
+			The ``errors`` array must have the same dimensions as ``FIELDNAME``.
 			Client is responsible for defining the dimensions of the data.
 		</doc>
 		<dimensions rank="dataRank">

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -363,7 +363,7 @@
 			<doc>data label</doc>
 		</attribute>
 	</field>
-	<field name="errors" type="NX_NUMBER" deprecated="Use ``FIELDNAME_errors`` instead (NIAC2018)">
+	<field name="errors" type="NX_NUMBER" deprecated="Use ``DATA_errors`` instead (NIAC2018)">
 		<doc>
 			Standard deviations of data values - 
 			the data array is identified by the group attribute ``signal``. 

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -270,7 +270,7 @@
 		but not to describe how the data is to be plotted.
 		(https://www.nexusformat.org/NIAC2018Minutes.html#nxdata-plottype--attribute)
 	</doc>
-	<field name="VARIABLE" type="NX_NUMBER" nameType="any">
+	<field name="AXISNAME" type="NX_NUMBER" nameType="any">
 		<doc>
 	 		Dimension scale defining an axis of the data.
 	 		Client is responsible for defining the dimensions of the data.
@@ -306,24 +306,13 @@
 	</field>
 	<field name="VARIABLE_errors" type="NX_NUMBER" nameType="any">
 		<doc>
-			"Errors" (actually *uncertainties*) associated with axis ``VARIABLE``.
-			Client is responsible for defining the dimensions of the data.
-			The name of this field may be changed to fit the circumstances 
-			but is matched with the *VARIABLE* field with ``_errors`` appended.
-			
-			This pattern of using ``VARIABLE_errors`` can be used 
-			throughout a NeXus data file to associate uncertainties 
-			with a field named ``VARIABLE``.  This pattern also 
-			applies to other relationships such as ``VARIABLE_resolutions``
-			to connect additional data with a certain field. 
+			"Errors" (meaning *uncertainties* or *standard deviations*)
+			associated with any field named ``VARIABLE`` in this ``NXdata``
+			group (e.g. an axis, signal or auxiliary signal).
+
+			The dimensions of the ``VARIABLE_errors`` field must match
+			the dimensions of the ``VARIABLE`` field.
 		</doc>
-		<dimensions rank="1">
-			<doc>
-				A dimension scale must have a rank of 1 and has length ``n``, 
-				same as ``VARIABLE``.
-			</doc>
-			<dim index="1" value="n"/>
-		</dimensions>
 	</field>
 	<field name="DATA" type="NX_NUMBER" nameType="any">
 		<doc>
@@ -374,7 +363,7 @@
 			<doc>data label</doc>
 		</attribute>
 	</field>
-	<field name="errors" type="NX_NUMBER">
+	<field name="errors" type="NX_NUMBER" deprecated="Use ``DATA_errors`` instead (NIAC2018)">
 		<doc>
 			Standard deviations of data values - 
 			the data array is identified by the group attribute ``signal``. 


### PR DESCRIPTION
Closes #1044 

Currently [`NXdata`](https://manual.nexusformat.org/classes/base_classes/NXdata.html) does not allow errors on auxiliary signals.

This PR solves that by
* renaming the `VARIABLE` field to `AXISNAME`
* updating the doc of `VARIABLE_errors` to say it applies to axes, signal or auxiliary signals: this is the actual change, although it is already somewhat support by NeXus as described [here](https://manual.nexusformat.org/datarules.html?highlight=errors).
* deprecate `errors` in favor of `VARIABLE_errors`  for the signal field