### PR TITLE
590 nxdetector dimensions

### DIFF
--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -31,13 +31,15 @@
             >
 
   <symbols>
-    <doc>These symbols will be used below to illustrate the coordination of the shapes of datasets and the 
-	    preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
-	    will vary according to the situation) and the general ordering principle is slowest to fastest.</doc>
-    <symbol name="np"><doc>number of scan points (only present in scanning measurements)</doc></symbol>
+    <doc>These symbols will be used below to illustrate the coordination of the rank and sizes of datasets and the 
+	  preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
+	  will vary according to the situation) and the general ordering principle is slowest to fastest.
+	  The type of each dimension should follow the order of scan points, detector pixels,
+	  then time-of-flight (i.e. spectroscopy, spectrometry).</doc>
+	  
+    <symbol name="nP"><doc>number of scan points (only present in scanning measurements)</doc></symbol>
     <symbol name="i"><doc>number of detector pixels in the first (slowest) direction</doc></symbol>
     <symbol name="j"><doc>number of detector pixels in the second (faster) direction</doc></symbol>
-    <symbol name="k"><doc>number of detector pixels in the third (if necessary, fastest) direction</doc></symbol>
     <symbol name="tof"><doc>number of bins in the time-of-flight histogram</doc></symbol>
   </symbols>
 
@@ -92,12 +94,14 @@
 
   <field name="data" type="NX_NUMBER" units="NX_ANY">
     <doc>Data values from the detector. The rank and dimension ordering should follow a principle of
-	  slowest to fastest measurement axes and may be explicitly specified in the application definitions.
+	  slowest to fastest measurement axes and may be explicitly specified in application definitions.
 	  The type of each dimension should should follow the order of scan points, detector pixels 
-	  (slowest readout to fastest readout), time-of-flight (i.e.spectroscopy, spectrometry).</doc>
+	  (slowest readout to fastest readout), then time-of-flight (i.e. spectroscopy, spectrometry).
+	  The rank and dimension sizes (see symbol list) shown here are merely illustrative of coordination
+	  between related datasets.</doc>
 
     <dimensions rank="4">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
       <dim index="4" value="tof" />
@@ -115,13 +119,13 @@
 
   <field name="data_errors" type="NX_NUMBER" units="NX_ANY">
     <doc>
-      The best estimate of the uncertainty in the data value. Where
+      The best estimate of the uncertainty in the data value (array size should match the data field). Where
       possible, this should be the standard deviation, which has the same units
       as the data. The form data_error is deprecated.
     </doc>
 
     <dimensions rank="4">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
       <dim index="4" value="tof" />
@@ -152,6 +156,11 @@
     <attribute name="long_name">
       <doc>x-axis offset from detector center</doc>
     </attribute>
+
+    <dimensions rank="2">
+      <dim index="1" value="i" />
+      <dim index="2" value="j" />
+    </dimensions>
   </field>
 
   <field name="y_pixel_offset" type="NX_FLOAT" units="NX_LENGTH">
@@ -177,6 +186,11 @@
     <attribute name="long_name">
       <doc>y-axis offset from detector center</doc>
     </attribute>
+
+    <dimensions rank="2">
+      <dim index="1" value="i" />
+      <dim index="2" value="j" />
+    </dimensions>
   </field>
 
 
@@ -203,6 +217,11 @@
     <attribute name="long_name">
       <doc>y-axis offset from detector center</doc>
     </attribute>
+
+    <dimensions rank="2">
+      <dim index="1" value="i" />
+      <dim index="2" value="j" />
+    </dimensions>
   </field>
 
   <field name="distance" type="NX_FLOAT" units="NX_LENGTH">
@@ -215,7 +234,7 @@
     </doc>
 
     <dimensions rank="3">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
     </dimensions>
@@ -234,7 +253,7 @@
     </doc>
 
     <dimensions rank="3">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
     </dimensions>
@@ -253,7 +272,7 @@
     </doc>
 
     <dimensions rank="3">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
     </dimensions>
@@ -308,7 +327,7 @@
     <doc>Detector dead time</doc>
 
     <dimensions rank="3">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
     </dimensions>
@@ -401,10 +420,9 @@
     <field name="efficiency" type="NX_FLOAT" units="NX_DIMENSIONLESS">
       <doc>efficiency of the detector</doc>
 
-      <dimensions rank="3">
+      <dimensions rank="2">
         <dim index="1" value="i" />
         <dim index="2" value="j" />
-        <dim index="3" value="k" />
       </dimensions>
     </field>
 
@@ -423,10 +441,9 @@
            have the same dimensionality.
       </doc>
 
-      <dimensions rank="3">
+      <dimensions rank="2">
         <dim index="1" value="i" />
         <dim index="2" value="j" />
-        <dim index="3" value="k" />
       </dimensions>
     </field>
   </group>
@@ -443,7 +460,7 @@
       the rank of this field should be less than or equal to (detector rank + 1).
     </doc>
     <dimensions rank="3">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
       <dim index="2" value="i" />
       <dim index="3" value="j" />
     </dimensions>
@@ -452,14 +469,14 @@
   <field name="start_time" type="NX_FLOAT" units="NX_TIME">
     <doc>start time for each frame, with the ``start`` attribute as absolute reference</doc>
     <dimensions rank="1">
-       <dim index="1" value="np"/>
+       <dim index="1" value="nP"/>
     </dimensions>
     <attribute name="start" type="NX_DATE_TIME" />
   </field>
   <field name="stop_time" type="NX_FLOAT" units="NX_TIME">
     <doc>stop time for each frame, with the ``start`` attribute as absolute reference</doc>
     <dimensions rank="1">
-      <dim index="1" value="np"/>
+      <dim index="1" value="nP"/>
     </dimensions>
     <attribute name="start" type="NX_DATE_TIME" />
   </field>
@@ -491,7 +508,7 @@
     <doc>Elapsed actual counting time</doc>
 
     <dimensions rank="1">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
     </dimensions>
   </field>
 
@@ -511,6 +528,7 @@
     </doc>
 
     <dimensions rank="1">
+      <!-- TODO: Should this be nP, or should the symbol be added to the list -->
       <dim index="1" value="nBrightFrames" />
     </dimensions>
   </field>
@@ -535,7 +553,7 @@
 
   <field name="frame_start_number" type="NX_INT">
     <doc>
-      This is the start number of the first frame of a scan. In PX one
+      This is the start number of the first frame of a scan. In protein crystallography measurements one
       often scans a couple of frames on a give sample, then does something else,
       then returns to the same sample and scans some more frames. Each time with
       a new data file. This number helps concatenating such measurements.
@@ -706,7 +724,7 @@
      This is time for each frame. This is exposure_time + readout time.
    </doc>
    <dimensions rank="1">
-      <dim index="1" value="NP" />
+      <dim index="1" value="nP" />
     </dimensions>
   </field>
   <field name="gain_setting" type="NX_CHAR">

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -528,8 +528,7 @@
     </doc>
 
     <dimensions rank="1">
-      <!-- TODO: Should this be nP, or should the symbol be added to the list -->
-      <dim index="1" value="nBrightFrames" />
+      <dim index="1" value="nP" />
     </dimensions>
   </field>
 

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -139,6 +139,11 @@
   Can be multidimensional when needed.
     </doc>
 
+    <dimensions rank="2">
+      <dim index="1" value="i" />
+      <dim index="2" value="j" />
+    </dimensions>
+
     <attribute name="axis" type="NX_POSINT"
       deprecated="see: https://github.com/nexusformat/definitions/issues/436">
       <enumeration>
@@ -156,11 +161,6 @@
     <attribute name="long_name">
       <doc>x-axis offset from detector center</doc>
     </attribute>
-
-    <dimensions rank="2">
-      <dim index="1" value="i" />
-      <dim index="2" value="j" />
-    </dimensions>
   </field>
 
   <field name="y_pixel_offset" type="NX_FLOAT" units="NX_LENGTH">
@@ -168,6 +168,11 @@
   Offset from the detector center in the y-direction.
   Can be multidimensional when different values are required for each pixel.
     </doc>
+
+    <dimensions rank="2">
+      <dim index="1" value="i" />
+      <dim index="2" value="j" />
+    </dimensions>
 
     <attribute name="axis" type="NX_POSINT"
       deprecated="see: https://github.com/nexusformat/definitions/issues/436">
@@ -186,11 +191,6 @@
     <attribute name="long_name">
       <doc>y-axis offset from detector center</doc>
     </attribute>
-
-    <dimensions rank="2">
-      <dim index="1" value="i" />
-      <dim index="2" value="j" />
-    </dimensions>
   </field>
 
 
@@ -199,6 +199,11 @@
 	Offset from the detector center in the z-direction.
 	Can be multidimensional when different values are required for each pixel.
     </doc>
+
+    <dimensions rank="2">
+      <dim index="1" value="i" />
+      <dim index="2" value="j" />
+    </dimensions>
 
     <attribute name="axis" type="NX_POSINT"
       deprecated="see: https://github.com/nexusformat/definitions/issues/436">
@@ -217,11 +222,6 @@
     <attribute name="long_name">
       <doc>y-axis offset from detector center</doc>
     </attribute>
-
-    <dimensions rank="2">
-      <dim index="1" value="i" />
-      <dim index="2" value="j" />
-    </dimensions>
   </field>
 
   <field name="distance" type="NX_FLOAT" units="NX_LENGTH">

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -31,11 +31,13 @@
             >
 
   <symbols>
-    <doc>These symbols will be used below to illustrate the coordination of the rank and sizes of datasets and the 
-	  preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
-	  will vary according to the situation) and the general ordering principle is slowest to fastest.
-	  The type of each dimension should follow the order of scan points, detector pixels,
-	  then time-of-flight (i.e. spectroscopy, spectrometry).</doc>
+    <doc>
+      These symbols will be used below to illustrate the coordination of the rank and sizes of datasets and the 
+      preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
+	    will vary according to the situation) and the general ordering principle is slowest to fastest.
+	    The type of each dimension should follow the order of scan points, detector pixels,
+	    then time-of-flight (i.e. spectroscopy, spectrometry).
+    </doc>
 	  
     <symbol name="nP"><doc>number of scan points (only present in scanning measurements)</doc></symbol>
     <symbol name="i"><doc>number of detector pixels in the first (slowest) direction</doc></symbol>
@@ -93,12 +95,14 @@
   </field>
 
   <field name="data" type="NX_NUMBER" units="NX_ANY">
-    <doc>Data values from the detector. The rank and dimension ordering should follow a principle of
-	  slowest to fastest measurement axes and may be explicitly specified in application definitions.
-	  The type of each dimension should should follow the order of scan points, detector pixels 
-	  (slowest readout to fastest readout), then time-of-flight (i.e. spectroscopy, spectrometry).
-	  The rank and dimension sizes (see symbol list) shown here are merely illustrative of coordination
-	  between related datasets.</doc>
+    <doc>
+      Data values from the detector. The rank and dimension ordering should follow a principle of
+	    slowest to fastest measurement axes and may be explicitly specified in application definitions.
+	    The type of each dimension should should follow the order of scan points, detector pixels 
+	    (slowest readout to fastest readout), then time-of-flight (i.e. spectroscopy, spectrometry).
+	    The rank and dimension sizes (see symbol list) shown here are merely illustrative of coordination
+	    between related datasets.
+    </doc>
 
     <dimensions rank="4">
       <dim index="1" value="nP" />

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -31,7 +31,9 @@
             >
 
   <symbols>
-    <doc>These symbols will be used below to coordinate datasets with the same shape.</doc>
+    <doc>These symbols will be used below to illustrate the coordination of the shapes of datasets and the 
+	    preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
+	    will vary according to the situation) and the general ordering principle is slowest to fastest.</doc>
     <symbol name="np"><doc>number of scan points (only present in scanning measurements)</doc></symbol>
     <symbol name="i"><doc>number of detector pixels in the first (slowest) direction</doc></symbol>
     <symbol name="j"><doc>number of detector pixels in the second (faster) direction</doc></symbol>
@@ -89,7 +91,10 @@
   </field>
 
   <field name="data" type="NX_NUMBER" units="NX_ANY">
-    <doc>Data values from the detector.</doc>
+    <doc>Data values from the detector. The rank and dimension ordering should follow a principle of
+	  slowest to fastest measurement axes and may be explicitly specified in the application definitions.
+	  The type of each dimension should should follow the order of scan points, detector pixels 
+	  (slowest readout to fastest readout), time-of-flight (i.e.spectroscopy, spectrometry).</doc>
 
     <dimensions rank="4">
       <dim index="1" value="np" />

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -34,11 +34,11 @@
     <doc>
       These symbols will be used below to illustrate the coordination of the rank and sizes of datasets and the 
       preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
-	    will vary according to the situation) and the general ordering principle is slowest to fastest.
-	    The type of each dimension should follow the order of scan points, detector pixels,
-	    then time-of-flight (i.e. spectroscopy, spectrometry).
+      will vary according to the situation) and the general ordering principle is slowest to fastest.
+      The type of each dimension should follow the order of scan points, detector pixels,
+      then time-of-flight (i.e. spectroscopy, spectrometry).
     </doc>
-	  
+    
     <symbol name="nP"><doc>number of scan points (only present in scanning measurements)</doc></symbol>
     <symbol name="i"><doc>number of detector pixels in the first (slowest) direction</doc></symbol>
     <symbol name="j"><doc>number of detector pixels in the second (faster) direction</doc></symbol>
@@ -97,11 +97,11 @@
   <field name="data" type="NX_NUMBER" units="NX_ANY">
     <doc>
       Data values from the detector. The rank and dimension ordering should follow a principle of
-	    slowest to fastest measurement axes and may be explicitly specified in application definitions.
-	    The type of each dimension should should follow the order of scan points, detector pixels 
-	    (slowest readout to fastest readout), then time-of-flight (i.e. spectroscopy, spectrometry).
-	    The rank and dimension sizes (see symbol list) shown here are merely illustrative of coordination
-	    between related datasets.
+      slowest to fastest measurement axes and may be explicitly specified in application definitions.
+      The type of each dimension should should follow the order of scan points, detector pixels 
+      (slowest readout to fastest readout), then time-of-flight (i.e. spectroscopy, spectrometry).
+      The rank and dimension sizes (see symbol list) shown here are merely illustrative of coordination
+      between related datasets.
     </doc>
 
     <dimensions rank="4">
@@ -139,8 +139,8 @@
 
   <field name="x_pixel_offset" type="NX_FLOAT" units="NX_LENGTH">
     <doc>
-  Offset from the detector center in x-direction.
-  Can be multidimensional when needed.
+      Offset from the detector center in x-direction.
+      Can be multidimensional when needed.
     </doc>
 
     <dimensions rank="2">
@@ -169,8 +169,8 @@
 
   <field name="y_pixel_offset" type="NX_FLOAT" units="NX_LENGTH">
     <doc>
-  Offset from the detector center in the y-direction.
-  Can be multidimensional when different values are required for each pixel.
+      Offset from the detector center in the y-direction.
+      Can be multidimensional when different values are required for each pixel.
     </doc>
 
     <dimensions rank="2">
@@ -200,8 +200,8 @@
 
   <field name="z_pixel_offset" type="NX_FLOAT" units="NX_LENGTH">
     <doc>
-	Offset from the detector center in the z-direction.
-	Can be multidimensional when different values are required for each pixel.
+      Offset from the detector center in the z-direction.
+      Can be multidimensional when different values are required for each pixel.
     </doc>
 
     <dimensions rank="2">

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -98,10 +98,26 @@
     <doc>
       Data values from the detector. The rank and dimension ordering should follow a principle of
       slowest to fastest measurement axes and may be explicitly specified in application definitions.
-      The type of each dimension should should follow the order of scan points, detector pixels 
-      (slowest readout to fastest readout), then time-of-flight (i.e. spectroscopy, spectrometry).
-      The rank and dimension sizes (see symbol list) shown here are merely illustrative of coordination
-      between related datasets.
+      
+      Mechanical scanning of objects (e.g. sample position/angle, incident beam energy, etc) tends to be
+      the slowest part of an experiment and so any such scan axes should be allocated to the first dimensions
+      of the array. Note that in some cases it may be useful to represent a 2D set of scan points as a single
+      scan-axis in the data array, especially if the scan pattern doesn't fit a rectangular array nicely.
+      Repetition of an experiment in a time series tends to be used similar to a slow scan axis
+      and so will often be in the first dimension of the data array.
+      
+      The next fastest axes are typically the readout of the detector. A point detector will not add any dimensions
+      (as it is just a single value per scan point) to the data array, a strip detector will add one dimension, an 
+      imaging detector will add two dimensions (e.g. X, Y axes) and detectors outputting higher dimensional data 
+      will add the corresponding number of dimensions. Note that the detector dimensions don't necessarily have to
+      be written in order of the actual readout speeds - the slowest to fastest rule principle is only a guide.
+      
+      Finally, detectors that operate in a time-of-flight mode, such as a neutron spectrometer or a silicon drift 
+      detector (used for X-ray fluorescence) tend to have their dimension(s) added to the last dimensions in the data array.
+      
+      The type of each dimension should should follow the order of scan points, detector pixels, 
+      then time-of-flight (i.e. spectroscopy, spectrometry). The rank and dimension sizes (see symbol list) 
+      shown here are merely illustrative of coordination between related datasets.
     </doc>
 
     <dimensions rank="4">

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -35,8 +35,10 @@
       These symbols will be used below to illustrate the coordination of the rank and sizes of datasets and the 
       preferred ordering of the dimensions. Each of these are optional (so the rank of the datasets 
       will vary according to the situation) and the general ordering principle is slowest to fastest.
-      The type of each dimension should follow the order of scan points, detector pixels,
-      then time-of-flight (i.e. spectroscopy, spectrometry).
+      The type of each dimension should follow the order of scan points, detector output (e.g. pixels),
+      then time-of-flight (i.e. spectroscopy, spectrometry). Note that the output of a detector is not limited 
+      to single values (0D), lists (1D) and images (2), but three or higher dimensional arrays can be produced 
+      by a detector at each trigger.
     </doc>
     
     <symbol name="nP"><doc>number of scan points (only present in scanning measurements)</doc></symbol>


### PR DESCRIPTION
fixes #590 by expanding doc strings to explain that the displayed dataset dimensions are only illustrative. The symbols used have also been made more consistent.