### PR TITLE
use unbuffered stdout for python in make files

### DIFF
--- a/manual/source/Makefile
+++ b/manual/source/Makefile
@@ -24,13 +24,13 @@
 all :: types.table units.table nxdl_desc.rst subdirs
 
 types.table: ../../utils/types2rst.py ../../utils/units2rst.py ../../nxdlTypes.xsd
-	$(PYTHON) ../../utils/types2rst.py ../../nxdlTypes.xsd > $@
+	$(PYTHON) -u ../../utils/types2rst.py ../../nxdlTypes.xsd > $@
 
 units.table: ../../utils/units2rst.py ../../nxdlTypes.xsd
-	$(PYTHON) ../../utils/units2rst.py ../../nxdlTypes.xsd > $@
+	$(PYTHON) -u ../../utils/units2rst.py ../../nxdlTypes.xsd > $@
 
 nxdl_desc.rst: ../../utils/nxdl_desc2rst.py ../../nxdl.xsd
-	$(PYTHON) ../../utils/nxdl_desc2rst.py ../../nxdl.xsd > $@
+	$(PYTHON) -u ../../utils/nxdl_desc2rst.py ../../nxdl.xsd > $@
 
 clean ::
 	$(RM) types.table units.table nxdl_desc.rst

--- a/manual/source/classes/applications/Makefile
+++ b/manual/source/classes/applications/Makefile
@@ -46,7 +46,7 @@ index.rst ::
 	$(PYTHON) $(NXDLSUMMARY) applications
 
 %.rst : %.$(NXDL_SUFFIX) $(NXDL2RST) Makefile
-	$(PYTHON) $(NXDL2RST) $< > $@
+	$(PYTHON) -u $(NXDL2RST) $< > $@
 
 clean ::
 	$(RM) NX*.rst NX*.nxdl.xml

--- a/manual/source/classes/base_classes/Makefile
+++ b/manual/source/classes/base_classes/Makefile
@@ -46,7 +46,7 @@ index.rst ::
 	$(PYTHON) $(NXDLSUMMARY) base_classes
 
 %.rst : %.$(NXDL_SUFFIX) $(NXDL2RST) Makefile
-	$(PYTHON) $(NXDL2RST) $< > $@
+	$(PYTHON) -u $(NXDL2RST) $< > $@
 
 clean ::
 	$(RM) NX*.rst NX*.nxdl.xml

--- a/manual/source/classes/contributed_definitions/Makefile
+++ b/manual/source/classes/contributed_definitions/Makefile
@@ -46,7 +46,7 @@ index.rst ::
 	$(PYTHON) $(NXDLSUMMARY) contributed_definitions
 
 %.rst : %.$(NXDL_SUFFIX) $(NXDL2RST) Makefile
-	$(PYTHON) $(NXDL2RST) $< > $@
+	$(PYTHON) -u $(NXDL2RST) $< > $@
 
 clean ::
 	$(RM) NX*.rst NX*.nxdl.xml


### PR DESCRIPTION
Closes #1078 

It seems that doing `python ... > file.ext` in make files could result in `file.ext` to be incomplete.

The solution seems to be unbuffered stdout: `python -u ... > file.ext`