### PR TITLE
NX_COUNT was missing from the unit categories

### DIFF
--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -69,6 +69,7 @@
 			nxdl:NX_POWER 
 			nxdl:NX_PRESSURE
 			nxdl:NX_PULSES
+			nxdl:NX_COUNT
 			nxdl:NX_SCATTERING_LENGTH_DENSITY
 			nxdl:NX_SOLID_ANGLE
 			nxdl:NX_TEMPERATURE


### PR DESCRIPTION
Closes #1075 

Before the fix:

![image](https://user-images.githubusercontent.com/7264703/173558819-1c743115-47b3-496c-a18f-edadb9c2b744.png)

After the fix:

![image](https://user-images.githubusercontent.com/7264703/173558988-90416928-9815-4c2a-94f5-e75741745528.png)
