### PR TITLE
improve the 'dimensions' tag rst rendering

### DIFF
--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -295,10 +295,10 @@ def analyzeDimensions(ns, parent):
             rank = "."
 
     if dims_from_field:
-        return ' (Rank: %s, Dimensions:%s)' % (rank, dims)
+        return ' (Rank: %s, Dimensions: %s)' % (rank, dims)
     elif dims:
         dims = ', '.join(dims)
-        return ' (Rank: %s, Dimensions:[%s])' % (rank, dims)
+        return ' (Rank: %s, Dimensions: [%s])' % (rank, dims)
     else:
         return ' (Rank: %s)' % rank
 

--- a/utils/nxdl2rst.py
+++ b/utils/nxdl2rst.py
@@ -405,8 +405,8 @@ def printFullTree(ns, parent, name, indent, parent_path):
         print( '%s.. index:: %s (field)\n' %
                ( indent, index_name ) )
         print(
-            '%s**%s%s**: %s%s%s\n' % (
-                indent, name, dims, optional_text, fmtTyp(node), fmtUnits(node)
+            '%s**%s**: %s%s%s%s\n' % (
+                indent, name, optional_text, fmtTyp(node), dims, fmtUnits(node)
                 ))
 
         printIfDeprecated( ns, node, indent+INDENTATION_UNIT )


### PR DESCRIPTION
Closes #936 This does not change the meaning of the `dimensions` xml tag but rather the rst rendering. Problems with the original rendering:
* some users were using for example `"field[n]"` as the HDF5 dataset name instead of `"field"`
* rendering sometimes gave the wrong idea about rank symbol and/or dimensions symbols (e.g. the DATA fiield of NXdata, see bellow)

These are the different dimensions that can occur:

## Fixed rank

```xml
<field name="data" type="NX_INT" signal="1">
  <dimensions rank="3">
    <dim index="1" value="nP" />
    <dim index="2" value="xDim" />
    <dim index="3" value="yDim" />
  </dimensions>
</field>
```

[NXscan example](https://manual.nexusformat.org/classes/applications/NXscan.html#nxscan-entry-instrument-detector-data-field)

Old rendering

![image](https://user-images.githubusercontent.com/7264703/173601705-88d06bfe-8f51-4aec-900a-421f354f5695.png)

New rendering

![image](https://user-images.githubusercontent.com/7264703/173868526-1f8e1cdd-f604-47b0-aa2e-e3f628214038.png)

## Variable rank because of optional dimensions

```xml
<field name="data" type="NX_NUMBER" recommended="true">
    <doc>
        For a dimension-2 detector, the rank of the data array will be 3.
        For a dimension-3 detector, the rank of the data array will be 4.
        This allows for the introduction of the frame number as the
        first index.
    </doc>
    <dimensions rank="dataRank">
        <dim index="1" value="nP" />
        <dim index="2" value="i" />
        <dim index="3" value="j" />
        <dim index="4" value="k" required="false"/>
    </dimensions>
</field>
```

[NXmx example](https://manual.nexusformat.org/classes/applications/NXmx.html#nxmx-entry-instrument-detector-data-field)

Old rendering

![image](https://user-images.githubusercontent.com/7264703/173600875-9b2b3b48-2fc3-4f24-b710-d630026868df.png)

New rendering

![image](https://user-images.githubusercontent.com/7264703/173858539-10773d90-b655-4cc2-b3ca-c0bc97fa3837.png)

## Variable rank because no dimensions specified

```xml
<field name="DATA" type="NX_NUMBER" nameType="any">
   <dimensions rank="dataRank">
	<doc>
		The rank (``dataRank``) of the ``data`` must satisfy
		``1 &lt;= dataRank &lt;= NX_MAXRANK=32``.  
		At least one ``dim`` must have length ``n``.
	</doc>
	<dim index="0" value="n"><!-- index="0": cannot know to which dimension this applies a priori --></dim>
   </dimensions>
</field>
```

The legacy way above is still supported but you could also do this

```xml
  <dimensions rank="dataRank">
  </dimensions>
```

[NXdata example](https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-data-field)

![image](https://user-images.githubusercontent.com/7264703/173603376-91705046-172e-415f-ba36-4115cfabb0fe.png)

Old rendering

![image](https://user-images.githubusercontent.com/7264703/173603112-23e0853d-8fd0-4de1-bd10-ed2e45802d49.png)

New rendering

![image](https://user-images.githubusercontent.com/7264703/173858757-d9317bf9-cc08-4db7-a13e-9f757b251036.png)

## Same rank and dimensions as another field

```xml
<field name="group_index" type="NX_INT">
	<doc>
	An array of unique identifiers for detectors or groupings 
	of detectors.
	
	Each ID is a unique ID for the corresponding detector or group
	named in the field group_names.  The IDs are positive integers
	starting with 1. 
	</doc>
       <dimensions><dim index="1" value="i"/></dimensions>
</field>
<field name="group_parent" type="NX_INT">
	<doc>
	An array of the hierarchical levels of the parents of detectors
	or groupings of detectors.
	
	A top-level grouping has parent level -1.</doc>
	<dimensions><dim index="1" ref="group_index"/></dimensions>
</field>
```

[Nxdetector_group example](https://manual.nexusformat.org/classes/base_classes/NXdetector_group.html#nxdetector-group-group-parent-field)

Old rendering

![image](https://user-images.githubusercontent.com/7264703/173602228-0a94238c-b262-4824-809e-8f5f0c95d48d.png)

New rendering

![image](https://user-images.githubusercontent.com/7264703/173858889-a90bdb9f-d305-4d95-bd5c-7b603f00aced.png)
