### PR TITLE
adjust string for examples so they appear on new lines

### DIFF
--- a/utils/units2rst.py
+++ b/utils/units2rst.py
@@ -58,7 +58,7 @@ def worker(nodeMatchString, section = 'units'):
                     examples.append("``"+example.text+"``")
             a = words.text
             if len(examples) > 0:
-                a = a.strip() + ", example(s): " + " | ".join(examples)
+                a = ' '.join(a.split()) + ",\n\texample(s): " + " | ".join(examples)
             db[node_name] = a
 
 #             for item in node.xpath('xs:restriction//xs:enumeration', namespaces=ns):


### PR DESCRIPTION
- fixes #979 

a single newline character was ignored during conversion to html, new line with a tab worked and rendered it looks ok