### PR TITLE
Publish manual to parent directory

### DIFF
--- a/.github/workflows/publish-sphinx.yml
+++ b/.github/workflows/publish-sphinx.yml
@@ -79,7 +79,7 @@ jobs:
         wget https://github.com/nexusformat/code/raw/master/applications/NXtranslate/docs/NXtranslate.pdf -O ./build/manual/source/_static/NXtranslate.pdf
 
     - name: Build (html) and Commit
-      uses: sphinx-notes/pages@master
+      uses: sphinx-notes/pages@v2
       with:
         # path to conf.py directory
         documentation_path: build/manual/source


### PR DESCRIPTION
This PR tries to publish the documentation to [https://nexusformat.github.io](https://nexusformat.github.io/definitions)

- #1129