### PR TITLE
Clarify pixel size in NXmx

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -348,6 +348,9 @@
                             a full data array, rather than with a hyperslab within
                             a larger array, then a single module should be defined,
                             spanning the entire array.
+
+                            Note, the pixel size is given as values in the array
+                            fast_pixel_direction and slow_pixel_direction.
                         </doc>
                         <field name="data_origin" type="NX_INT">
                             <doc>


### PR DESCRIPTION
This is copied in from NXdetector_module

Noticed when reviewing NXmx that it would be good to exactly state how to specify the pixel size, like we do for the base class.