### PR TITLE
Add equipment_component to NXtransformations

### DIFF
--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -173,6 +173,15 @@
 				depends or the string ".".
 			</doc>
 		</attribute>
+		<attribute name="equipment_component" type="NX_CHAR">
+			<doc>
+				An arbitrary identifier of a component of the equipment to which
+				the transformation belongs, such as 'detector_arm' or 'detector_module'.
+				NXtransformations with the same equipment_component label form a logical
+				grouping which can be combined together into a single change-of-basis
+				operation.
+			</doc>
+		</attribute>
 	</field>
 	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="any" type="NX_NUMBER" minOccurs="0">
 		<doc>


### PR DESCRIPTION
This is an arbitrary identifier of a component of the equipment to which the transformation belongs, such as 'detector_arm' or 'detector_module'. NXtransformations with the same equipment_component label form a logical grouping which can be combined together into a single change-of-basis operation.

Ported in from ImageCIF:
http://www.bernstein-plus-sons.com/software/CBF/doc/cif_img_1.8.4.html#_axis.equipment_component