### PR TITLE
Allowing the recommended xml attribute for nexus attributes

### DIFF
--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -989,6 +989,14 @@
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="recommended" use="optional" type="nx:NX_BOOLEAN" default="false" >
+			<xs:annotation>
+				<xs:documentation>
+					A synonym for optional, but with the recommendation that this
+					attribute be specified.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:attribute name="optional" type="nx:NX_BOOLEAN" default="true">
 			<xs:annotation>
 				<xs:documentation>


### PR DESCRIPTION
It is allowed for fields and groups to be recommended.
However, this is not allowed for attributes.

This PR allows recommended setting for attributes as well.

- close https://github.com/nexusformat/NIAC/issues/140