### PR TITLE
Deploy by running CI manually

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,12 +4,16 @@ on:
   push:
     branches:
       - main   # push commit to the main branch
-    tags:
-      - 'v2*'  # push tag starting with "v2" to the main branch
   pull_request:
     branches:
       - main   # pull request to the main branch
   workflow_dispatch:   # allow manual triggering
+    inputs:
+      deploy:
+        description: 'Deploy documentation'
+        type: boolean
+        required: true
+        default: false
 
 defaults:
   run:
@@ -33,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy Information
-        if: ${{ startsWith(github.ref, 'refs/tags') && env.python_version == '3.7' }}
+        if: ${{ github.event.inputs.deploy && env.python_version == '3.7' }}
         run: |
           echo "The HTML NeXus User Manual will be pushed to"
           echo " https://github.com/nexusformat/definitions/tree/gh-pages"
@@ -81,14 +85,14 @@ jobs:
           ls -lAFgh build/manual/build/latex/nexus.pdf
 
       - name: Build and Commit the User Manual
-        if: ${{ startsWith(github.ref, 'refs/tags') && env.python_version == '3.7' }}
+        if: ${{ github.event.inputs.deploy && env.python_version == '3.7' }}
         uses: sphinx-notes/pages@master
         with:
           # path to the conf.py directory
           documentation_path: build/manual/source
 
       - name: Deploy the User Manual
-        if: ${{ startsWith(github.ref, 'refs/tags') && env.python_version == '3.7' }}
+        if: ${{ github.event.inputs.deploy && env.python_version == '3.7' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes 
- #1029
- #1199
- #1200

After this MR

1. the CI runs **without deployment** for every pull request to the main branch and push (tags or commits) to the master branch
2. the CI can only run **with deployment** when triggered manually, with "Deploy documentation" enabled, similar to [this](https://www.softwaretester.blog/detecting-github-workflow-job-run-status-changes).