### PR TITLE
NXdata: @signal, @auxiliary_signals and @axes refer to direct NXdata children

### DIFF
--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -53,10 +53,12 @@
 		<doc>
 			.. index:: plotting
 			
-			Array of strings holding the names of additional signals to
-			be plotted with the default signal (specified by the
-			``signal`` attribute).  Each auxiliary signal needs to be of
-			the same shape as the default signal.
+			Array of strings holding the :ref:`names &lt;validItemName>` of additional
+			signals to be plotted with the default signal (specified by the
+			``signal`` attribute). These field(s) *must* exist and be direct children
+			of this NXdata group.
+			
+			Each auxiliary signal needs to be of the same shape as the default signal.
 			
 			..  NIAC2018:
 			    https://www.nexusformat.org/NIAC2018Minutes.html
@@ -69,9 +71,8 @@
 			.. index:: signal attribute value
 			
 			Declares which NeXus field is the default. 
-			The value is the name of the NeXus field to be plotted.
-			(The value :ref:`names &lt;validItemName>` an existing child
-			of this group. The child group must itself be a NeXus group.)
+			The value is the :ref:`name &lt;validItemName>` of the data field to be plotted.
+			This field must *exist* and be a direct child of this NXdata group.
 			
 			It is recommended (as of NIAC2014) to use this attribute
 			rather than adding a signal attribute to the field.
@@ -89,10 +90,11 @@
 			the ``signal`` attribute of this group). 
 			One entry is provided for every dimension in the *signal* field.
 			
-			The field(s) named as values (known as "axes") of this attribute 
-			*must* exist. An axis slice is specified using a field named 
-			``AXISNAME_indices`` as described below (where the text shown here
-			as ``AXISNAME`` is to be replaced by the actual field name).
+			The field(s) :ref:`named &lt;validItemName>` as values (known as "axes")
+			of this attribute *must* exist and be direct children of this NXdata group.
+			An axis slice is specified using a field named ``AXISNAME_indices``
+			as described below (where the text shown here as ``AXISNAME`` is to be
+			replaced by the actual field name).
 			
 			When no default axis is available for a particular dimension 
 			of the plottable data, use a "." in that position.  

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -54,9 +54,8 @@
 			.. index:: plotting
 			
 			Array of strings holding the :ref:`names &lt;validItemName>` of additional
-			signals to be plotted with the default signal (specified by the
-			``signal`` attribute). These field(s) *must* exist and be direct children
-			of this NXdata group.
+			signals to be plotted with the default :ref:`signal &lt;/NXdata@signal-attribute&gt;`.
+			These fields or links *must* exist and be direct children of this NXdata group.
 			
 			Each auxiliary signal needs to be of the same shape as the default signal.
 			
@@ -72,7 +71,7 @@
 			
 			Declares which NeXus field is the default. 
 			The value is the :ref:`name &lt;validItemName>` of the data field to be plotted.
-			This field must *exist* and be a direct child of this NXdata group.
+			This field or link *must* exist and be a direct child of this NXdata group.
 			
 			It is recommended (as of NIAC2014) to use this attribute
 			rather than adding a signal attribute to the field.
@@ -84,14 +83,16 @@
 		<doc>
 			.. index:: plotting
 			
-			String array that defines the independent data fields used in 
-			the default plot for all of the dimensions of the *signal* field
-			(the *signal* field is the field in this group that is named by
-			the ``signal`` attribute of this group). 
-			One entry is provided for every dimension in the *signal* field.
+			Array of strings holding the :ref:`names &lt;validItemName>` of
+			the independent data fields used in the default plot for all of
+			the dimensions of the :ref:`signal &lt;/NXdata@signal-attribute&gt;`
+			or :ref:`auxiliary signals &lt;/NXdata@auxiliary_signals-attribute&gt;`.
 			
-			The field(s) :ref:`named &lt;validItemName>` as values (known as "axes")
-			of this attribute *must* exist and be direct children of this NXdata group.
+			One name is provided for every dimension in the *signal* or *auxiliary signal* fields.
+			
+			The *axes* values are the names of fields or links that *must* exist and be direct
+			children of this NXdata group.
+
 			An axis slice is specified using a field named ``AXISNAME_indices``
 			as described below (where the text shown here as ``AXISNAME`` is to be
 			replaced by the actual field name).
@@ -102,8 +103,8 @@
 			
 				@axes=["time", ".", "."]
 			
-			Since there are three items in the list, the the *signal* field
-			must must be a three-dimensional array (rank=3).  The first dimension
+			Since there are three items in the list, the *signal* field
+			must be a three-dimensional array (rank=3). The first dimension
 			is described by the values of a one-dimensional array named ``time``
 			while the other two dimensions have no fields to be used as dimension scales.
 			

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -86,7 +86,7 @@
 			Array of strings holding the :ref:`names &lt;validItemName>` of
 			the independent data fields used in the default plot for all of
 			the dimensions of the :ref:`signal &lt;/NXdata@signal-attribute&gt;`
-			or :ref:`auxiliary signals &lt;/NXdata@auxiliary_signals-attribute&gt;`.
+			as well as any :ref:`auxiliary signals &lt;/NXdata@auxiliary_signals-attribute&gt;`.
 			
 			One name is provided for every dimension in the *signal* or *auxiliary signal* fields.
 			


### PR DESCRIPTION
Closes #1209 

Improved docs to clearly state that the strings in @signal, @auxiliary_signals, @axes refer to

* fields or links
* direct children of the NXdata group
* must exist