### PR TITLE
Sync saturation and countrate to NXmx

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -628,9 +628,24 @@
                     <field name="countrate_correction_applied" type="NX_BOOLEAN"
                         minOccurs="0">
                         <doc>
-                            True when a count-rate correction has already been applied in
-                            the data recorded here, false otherwise.
+                            Counting detectors usually are not able to measure all incoming particles,
+                            especially at higher count-rates. Count-rate correction is applied to
+                            account for these errors.
+
+                            True when count-rate correction has been applied, false otherwise.
                         </doc>
+                    </field>
+                    <field name="countrate_correction_lookup_table" type="NX_NUMBER" >
+                        <doc>
+                            The countrate_correction_lookup_table defines the LUT used for count-rate
+                            correction. It maps a measured count :math:`c` to its corrected value
+                            :math:`countrate\_correction\_lookup\_table[c]`.
+
+                            :math:`m` denotes the length of the table.
+                        </doc>
+                        <dimensions rank="1">
+                            <dim index="1" value="m"/>
+                        </dimensions>
                     </field>
                     <field name="virtual_pixel_interpolation_applied" type="NX_BOOLEAN"
                         minOccurs="0">
@@ -691,7 +706,7 @@
                         </doc>
                     </field>
 
-                    <field name="saturation_value" type="NX_INT" minOccurs="0">
+                    <field name="saturation_value" type="NX_NUMBER" minOccurs="0">
                         <doc>
                             The value at which the detector goes into saturation.
                             Data above this value is known to be invalid.
@@ -702,7 +717,7 @@
                         </doc>
                     </field>
 
-                    <field name="underload_value" type="NX_INT" minOccurs="0">
+                    <field name="underload_value" type="NX_NUMBER" minOccurs="0">
                         <doc>
                             The lowest value at which pixels for this detector
                             would be reasonably be measured.


### PR DESCRIPTION
- Updates saturation/underload to use NX_NUMBER
- Clarifies countrate_correction_applied and adds countrate_correction_lookup_table

Both are recent changes to NXdetector

Fixes #1215