### PR TITLE
Typo: NXtomoproc nX -> nY

### DIFF
--- a/applications/NXtomoproc.nxdl.xml
+++ b/applications/NXtomoproc.nxdl.xml
@@ -91,7 +91,7 @@
           </doc>
           <dimensions rank="3">
             <dim index="1" value="nX" />
-            <dim index="2" value="nX" />
+            <dim index="2" value="nY" />
             <dim index="3" value="nZ" />
           </dimensions>
           <attribute name="transform"></attribute>


### PR DESCRIPTION
Typo in the definition. This is a 3D volume so should be x,y,z.

Spotted by Paul Millar.