### PR TITLE
Generalise datatype of NXtomoproc data to NX_NUMBER

### DIFF
--- a/applications/NXtomoproc.nxdl.xml
+++ b/applications/NXtomoproc.nxdl.xml
@@ -83,7 +83,7 @@
         </group>
       </group>
       <group type="NXdata" name="data">
-        <field name="data" type="NX_INT" signal="1">
+        <field name="data" type="NX_NUMBER" signal="1">
           <doc>
             This is the reconstructed volume. This can be different
             things. Please indicate in the unit attribute what physical


### PR DESCRIPTION
Tomography software typically outputs floating point arrays for reconstructed data, so it is useful to store without further transformation.

Closes #1241

As discussed in Telco 20230213