### PR TITLE
NXevent_data: add missing _zero to cue_timestamp in docstring

### DIFF
--- a/base_classes/NXevent_data.nxdl.xml
+++ b/base_classes/NXevent_data.nxdl.xml
@@ -103,7 +103,7 @@
 	<field name="cue_index" type="NX_INT">
 	  <doc>
 	    Index into the event_id, event_time_offset pair matching the corresponding
-	    cue_timestamp. 
+	    cue_timestamp_zero.
 	  </doc>
 	</field>
     <attribute name="default">


### PR DESCRIPTION
There is no cue_timestamp that could be referenced here. The documentation is virtually the same, but correct, in NXlog.