### PR TITLE
Add bit-depth-image

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -666,6 +666,12 @@
                         </doc>
                     </field>
 
+                    <field name="bit_depth_image" type="NX_INT" recommended="true">
+                        <doc>
+                            The number of bits per pixel are saved to the image data.
+                        </doc>
+                    </field>
+
                     <field name="detector_readout_time" type="NX_FLOAT" units="NX_TIME"
                         minOccurs="0">
                         <doc>


### PR DESCRIPTION
Fixes #1258 by including it, using effectively the same definition as is currently in the field from DECTRIS