### PR TITLE
"Electron Source" rather than "Electron Microscope"

### DIFF
--- a/base_classes/NXsource.nxdl.xml
+++ b/base_classes/NXsource.nxdl.xml
@@ -56,7 +56,7 @@
 			<item value="Ion Source" />
 			<item value="UV Plasma Source" />
 			<item value="Metal Jet X-ray" />
-			<item value="Electron Microscope" />
+			<item value="Electron Source" />
 		</enumeration>
 	</field>
 	<field name="probe">


### PR DESCRIPTION
Simple change for consistency, following Zoom discussion.