### PR TITLE
NXbeam: clarify how beams can be in either sample or instrument groups

### DIFF
--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -50,7 +50,8 @@
         its most likely use is in the :ref:`NXsample` group in which it defines the results of the neutron
         scattering by the sample, e.g., energy transfer, polarizations. Finally, There are cases where the beam is
         considered as a beamline component and this group may be defined as a subgroup directly inside
-        :ref:`NXinstrument`.
+        :ref:`NXinstrument`, in which case it is recommended that the position of the beam is specified by an 
+        :ref:`NXtransformations` group, unless the beam is at the origin (which is the sample).
 
         Note that incident_wavelength and related fields can be a scalar values or arrays, depending on the use case.
         To support these use cases, the explicit dimensionality of these fields is not specified, but it can be inferred

--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -48,7 +48,9 @@
         especially valuable in storing the results of instrument simulations in which it is useful
         to specify the beam profile, time distribution etc. at each beamline component. Otherwise,
         its most likely use is in the :ref:`NXsample` group in which it defines the results of the neutron
-        scattering by the sample, e.g., energy transfer, polarizations.
+        scattering by the sample, e.g., energy transfer, polarizations. Finally, There are cases where the beam is
+        considered as a beamline component and this group may be defined as a subgroup directly inside
+        :ref:`NXinstrument`.
 
         Note that incident_wavelength and related fields can be a scalar values or arrays, depending on the use case.
         To support these use cases, the explicit dimensionality of these fields is not specified, but it can be inferred


### PR DESCRIPTION
Add documentation about cases where NXbeam is defined as a subgroup directly inside a NXinstruments group.

Closes #1263 
