### PR TITLE
Add missing anchor closing tag to contributor

### DIFF
--- a/manual/source/_templates/sourcelink.html
+++ b/manual/source/_templates/sourcelink.html
@@ -39,6 +39,7 @@
       	title="{{ tooltip_string }}"
 		    data-hovercard-type="user" data-hovercard-url="/users/{{ var_list[1] }}/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self">
        <img class="avatar circle" src="{{ var_list[2] }}" data-view-component="true" alt="GitHub Avatar">
+      </a>
       {% endfor %}
     </ul>
    </div>


### PR DESCRIPTION
Contributor links were not closed causing the next anchor to point elsewhere. This fixes #1301