### PR TITLE
Fixes automatic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,8 @@ dependencies = [
 [project.urls]
 "Homepage" = "https://nexusformat.org"
 
-[project.scripts]
-
-[tools.setuptools_scm]
-version_scheme = "guess-next-dev"
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"
 local_scheme = "node-and-date"
 
 [tool.setuptools]


### PR DESCRIPTION
This fixes a typo which resulted in setuptools-scm not being able to resolve the version (was always 0.0.0).

It also enables `no-guess-dev`, i.e. no new versions are guessed from the current ones, as this makes no sense for date based versioning.