### PR TITLE
Adds setup python step in CI/CD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Deploy Information
         if: ${{ github.event.inputs.deploy && env.python_version == env.python_deploy_version }}
         run: |


### PR DESCRIPTION
The current CI/CD does not setup the different python version and just sets the `python-version` environment variable. I added a step to set the python version to the one of the current matrix element.

Fixes #1317 