### PR TITLE
Adds git based versioning for `get_nxdl_version`

### DIFF
--- a/dev_tools/globals/nxdl.py
+++ b/dev_tools/globals/nxdl.py
@@ -9,8 +9,7 @@ relative URI "../nxdl.xsd" which means validation
 can only be done for NXDL files in subdirectories.
 """
 import os
-from subprocess import CalledProcessError
-from subprocess import run
+from subprocess import CalledProcessError, run
 from typing import Optional
 
 from .directories import get_nxdl_version_file

--- a/dev_tools/globals/nxdl.py
+++ b/dev_tools/globals/nxdl.py
@@ -8,6 +8,7 @@ Do not use these URL's for validation. That's what
 relative URI "../nxdl.xsd" which means validation
 can only be done for NXDL files in subdirectories.
 """
+
 import os
 from subprocess import CalledProcessError, run
 from typing import Optional

--- a/dev_tools/globals/nxdl.py
+++ b/dev_tools/globals/nxdl.py
@@ -8,6 +8,10 @@ Do not use these URL's for validation. That's what
 relative URI "../nxdl.xsd" which means validation
 can only be done for NXDL files in subdirectories.
 """
+import os
+from subprocess import CalledProcessError
+from subprocess import run
+from typing import Optional
 
 from .directories import get_nxdl_version_file
 
@@ -15,7 +19,31 @@ XSD_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
 NXDL_NAMESPACE = "http://definition.nexusformat.org/nxdl/3.1"
 
 
+def get_vcs_version(tag_match="*[0-9]*") -> Optional[str]:
+    """
+    The version of the Nexus standard and the NeXus Definition language
+    based on git tags and commits
+    """
+    try:
+        return (
+            run(
+                ["git", "describe", "--tags", "--long", "--match", tag_match],
+                cwd=os.path.join(os.path.dirname(__file__)),
+                check=True,
+                capture_output=True,
+            )
+            .stdout.decode("utf-8")
+            .strip()
+        )
+    except CalledProcessError:
+        return None
+
+
 def get_nxdl_version() -> str:
     """The version of the NeXus standard and the NeXus Definition language"""
-    with open(get_nxdl_version_file(), "r") as fh:
+    version = get_vcs_version()
+    if version is not None:
+        return version
+
+    with open(get_nxdl_version_file(), "r", encoding="utf-8") as fh:
         return fh.read().strip()

--- a/dev_tools/globals/nxdl.py
+++ b/dev_tools/globals/nxdl.py
@@ -10,7 +10,8 @@ can only be done for NXDL files in subdirectories.
 """
 
 import os
-from subprocess import CalledProcessError, run
+from subprocess import CalledProcessError
+from subprocess import run
 from typing import Optional
 
 from .directories import get_nxdl_version_file


### PR DESCRIPTION
We started to add a version based on the git tag and hash in pynxtools (see https://github.com/FAIRmat-NFDI/pynxtools/pull/124) and I thought could be useful as a general feature. This PR is just to start a discussion whether it is desired to have a versioning like this in this repository, too.

When a git repository is available it constructs a version string based on the last tag, commit distance and commit hash. If no repository is available this falls back to reading `NXDL_VERSION`.