### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Deploy Information
         if: ${{ github.event.inputs.deploy && env.python_version == env.python_deploy_version }}


### PR DESCRIPTION
Remove fetch-depth setting as a shallow clone is sufficient