### PR TITLE
add a description field to the NXsensor group

### DIFF
--- a/base_classes/NXsensor.nxdl.xml
+++ b/base_classes/NXsensor.nxdl.xml
@@ -40,6 +40,9 @@
 	<field name="short_name">
 		<doc>Short name of sensor used e.g. on monitor display program</doc>
 	</field>
+	<field name="description">
+          <doc>Description of this sensor</doc>
+	</field>
 	<field name="attached_to">
 		<doc>where sensor is attached to ("sample" | "can")</doc>
 	</field>


### PR DESCRIPTION
It resolves #1329 by adding a `description` field to the NXsensor group.