### PR TITLE
Rewrite the NXdata scaling_factor and offset fields

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -174,7 +174,7 @@
                 <doc>
                         An optional offset to apply to the values in data.
 
-                        See :ref:`scaling_factor` for more information.
+                        See :ref:`scaling_factor &lt;/NXmx/ENTRY/DATA/scaling_factor-field&gt;` for more information.
                 </doc>
                 </field>
 

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -143,13 +143,13 @@
                     </dimensions>
                 </field>
 
-                <field name="scaling_factor" type="NX_FLOAT" optional="true">
+                <field name="data_scaling_factor" type="NX_FLOAT" optional="true">
                     <doc>
                         An optional scaling factor to apply to the values in data.
 
                         The elements in data are often stored as integers for efficiency reasons and need
-                        further correction, generating floats.  The two fields scaling_factor and offset
-                        allow linear corrections using the following convention:
+                        further correction, generating floats.  The two fields data_scaling_factor and
+                        data_offset allow linear corrections using the following convention:
 
                         .. code-block::
 
@@ -160,9 +160,9 @@
                         Use these fields to specify gain and/or pedestal constants that need to be applied
                         to the data to correct it to physical values.  For example, if the detector gain
                         is 10 counts per photon and a constant background of 400 needs to be subtracted
-                        off the pixels, specify scaling_factor as 0.1 and offset as -400 to specifiy the
-                        required conversion from raw counts to pedestal-corrected photons. It is implied
-                        processing software will apply these corrections on-the-fly during processing.
+                        off the pixels, specify data_scaling_factor as 0.1 and data_offset as -400 to
+                        specifiy the required conversion from raw counts to pedestal-corrected photons. It
+                        is implied processing software will apply these corrections on-the-fly during processing.
 
                         The rank of these fields should either be a single value for the full dataset, a
                         single per-pixel array applied to every image (rank (i, j) or (i, j, k)),
@@ -170,11 +170,11 @@
                         (np, 1), (np, i, j) or (np, i, j, k)).
                 </doc>
                 </field>
-                <field name="offset" type="NX_FLOAT" optional="true">
+                <field name="data_offset" type="NX_FLOAT" optional="true">
                 <doc>
                         An optional offset to apply to the values in data.
 
-                        See :ref:`scaling_factor &lt;/NXmx/ENTRY/DATA/scaling_factor-field&gt;` for more information.
+                        See :ref:`data_scaling_factor &lt;/NXmx/ENTRY/DATA/data_scaling_factor-field&gt;` for more information.
                 </doc>
                 </field>
 

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -142,6 +142,43 @@
                         <dim index="4" value="k" required="false"/>
                     </dimensions>
                 </field>
+
+                <field name="scaling_factor" type="NX_FLOAT" optional="true">
+                    <doc>
+                        An optional scaling factor to apply to the values in data.
+
+                        The elements in data are often stored as integers for efficiency reasons and need
+                        further correction, generating floats.  The two fields scaling_factor and offset
+                        allow linear corrections using the following convention:
+
+                        .. code-block::
+
+                                corrected_data = (data + offset) * scaling_factor
+
+                        This formula will derive the actual physical value, when necessary.
+
+                        Use these fields to specify gain and/or pedestal constants that need to be applied
+                        to the data to correct it to physical values.  For example, if the detector gain
+                        is 10 counts per photon and a constant background of 400 needs to be subtracted
+                        off the pixels, specify scaling_factor as 0.1 and offset as -400 to specifiy the
+                        required conversion from raw counts to pedestal-corrected photons. It is implied
+                        processing software will apply these corrections on-the-fly during processing.
+
+                        The rank of these fields should either be a single value for the full dataset, a
+                        single per-pixel array applied to every image (rank (i, j) or (i, j, k)),
+                        a per-image correction specified with an array whose slowest rank is nP (rank
+                        (np, 1), (np, i, j) or (np, i, j, k)).
+                </doc>
+                </field>
+                <field name="offset" type="NX_FLOAT" optional="true">
+                <doc>
+                        An optional offset to apply to the values in data.
+
+                        See :ref:`scaling_factor` for more information.
+                </doc>
+                </field>
+
+
             </group>
 
             <group type="NXsample">

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -155,7 +155,7 @@
 
                                 corrected_data = (data + offset) * scaling_factor
 
-                        This formula will derive the actual physical value, when necessary.
+                        This formula will derive the corrected value, when necessary.
 
                         Use these fields to specify gain and/or pedestal constants that need to be applied
                         to the data to correct it to physical values.  For example, if the detector gain

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -400,16 +400,24 @@
 	<!-- Data vs. plot coordinates -->
 	<field name="scaling_factor" type="NX_FLOAT">
 		<doc>
-			The elements in data are usually float values really. For
-			efficiency reasons these are usually stored as integers
-			after scaling with a scale factor. This value is the scale
-			factor. It is required to get the actual physical value,
-			when necessary.
+			An optional scaling factor to apply to the values in data.
+
+			The elements in data are often stored as integers for efficiency reasons and need
+			further correction, generating floats.  The two fields scaling_factor and offset
+			allow linear corrections using the following convention:
+
+			.. code-block::
+
+				corrected_data = (data + offset) * scaling_factor
+
+			This formula will derive the actual physical value, when necessary.
 		</doc>
 	</field>
 	<field name="offset" type="NX_FLOAT">
 		<doc>
 			An optional offset to apply to the values in data.
+
+			See :ref:`scaling_factor` for more information.
 		</doc>
 	</field>
 

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -398,13 +398,13 @@
 	</field>
 
 	<!-- Data vs. plot coordinates -->
-	<field name="scaling_factor" type="NX_FLOAT">
+	<field name="FIELDNAME_scaling_factor" type="NX_FLOAT">
 		<doc>
-			An optional scaling factor to apply to the values in data.
+			An optional scaling factor to apply to the values in FIELDNAME (usually the signal).
 
 			The elements in data are often stored as integers for efficiency reasons and need
-			further correction, generating floats.  The two fields scaling_factor and offset
-			allow linear corrections using the following convention:
+			further correction, generating floats.  The two fields FIELDNAME_scaling_factor and
+			FIELDNAME_offset allow linear corrections using the following convention:
 
 			.. code-block::
 
@@ -413,13 +413,27 @@
 			This formula will derive the value to plot, when necessary.
 		</doc>
 	</field>
-	<field name="offset" type="NX_FLOAT">
+	<field name="FIELDNAME_offset" type="NX_FLOAT">
 		<doc>
-			An optional offset to apply to the values in data.
+			An optional offset to apply to the values in FIELDNAME (usually the signal).
 
-			See :ref:`scaling_factor &lt;/NXdata/scaling_factor-field&gt;` for more information.
+			See :ref:`FIELDNAME_scaling_factor &lt;/NXdata/FIELDNAME_scaling_factor-field&gt;` for more information.
 		</doc>
 	</field>
+
+	<field name="scaling_factor" type="NX_FLOAT" deprecated="Use FIELDNAME_scaling_factor instead">
+		<doc>
+			Due to scaling_factor being ambiguous in the case of multiple signals, use
+			FIELDNAME_scaling_factor instead
+		</doc>
+	</field>
+	<field name="offset" type="NX_FLOAT" deprecated="Use FIELDNAME_offset instead">
+		<doc>
+			Due to offset being ambiguous in the case of multiple signals, use
+			FIELDNAME_offset instead
+		</doc>
+	</field>
+
 
 	<!-- Other fields -->
 	<field name="title">

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -408,9 +408,9 @@
 
 			.. code-block::
 
-				corrected_data = (data + offset) * scaling_factor
+				plotted_data = (data + offset) * scaling_factor
 
-			This formula will derive the actual physical value, when necessary.
+			This formula will derive the value to plot, when necessary.
 		</doc>
 	</field>
 	<field name="offset" type="NX_FLOAT">

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -417,7 +417,7 @@
 		<doc>
 			An optional offset to apply to the values in data.
 
-			See :ref:`scaling_factor` for more information.
+			See :ref:`scaling_factor &lt;/NXdata/scaling_factor-field&gt;` for more information.
 		</doc>
 	</field>
 


### PR DESCRIPTION
Closes #1332

Also adds clarification in NXmx that these fields can be used as pedestal and gain correction fields, as well as elaborates on the possible rank options.  These rank options were implied (in my opinion) in the original wording, but in NXmx I made it more explicit.

Tagging @biochem-fan for reference