### PR TITLE
Adds makefile refinements and nyaml as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Build artifacts
 build/
 makelog.txt
+nyaml/
 
 # Unknown
 /python/

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ prepare ::
 
 pdf ::
 	$(SPHINX) -M latexpdf $(BUILD_DIR)/manual/source/ $(BUILD_DIR)/manual/build
-	cp $(BUILD_DIR)/manual/build/latex/nexus-fairmat.pdf $(BUILD_DIR)/manual/source/_static/NeXusManual.pdf
+	cp $(BUILD_DIR)/manual/build/latex/nexus.pdf $(BUILD_DIR)/manual/source/_static/NeXusManual.pdf
 
 html ::
 	$(SPHINX) -b html -W $(BUILD_DIR)/manual/source/ $(BUILD_DIR)/manual/build/html
@@ -95,7 +95,7 @@ all ::
 	@echo "HTML built: `ls -lAFgh $(BUILD_DIR)/impatient-guide/build/html/index.html`"
 	@echo "PDF built: `ls -lAFgh $(BUILD_DIR)/impatient-guide/build/latex/NXImpatient.pdf`"
 	@echo "HTML built: `ls -lAFgh $(BUILD_DIR)/manual/build/html/index.html`"
-	@echo "PDF built: `ls -lAFgh $(BUILD_DIR)/manual/build/latex/nexus-fairmat.pdf`"
+	@echo "PDF built: `ls -lAFgh $(BUILD_DIR)/manual/build/latex/nexus.pdf`"
 
 $(BASE_CLASS_DIR)/%.nxdl.xml : $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml
 	nyaml2nxdl $< --output-file $@

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,15 @@
 
 PYTHON = python3
 SPHINX = sphinx-build
-BUILD_DIR = "build"
-BASE_CLASS_DIR := base_classes
-CONTRIB_DIR := contributed_definitions
-APPDEF_DIR := applications
-NYAML_SUBDIR := nyaml
+BUILD_DIR = build
+BASE_CLASS_DIR = base_classes
+CONTRIB_DIR = contributed_definitions
+APPDEF_DIR = applications
+NYAML_SUBDIR = nyaml
 
-YBC_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(BASE_CLASS_DIR)/nyaml/*.yaml)))
-YCONTRIB_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(CONTRIB_DIR)/nyaml/*.yaml)))
-YAPPDEF_NXDL = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
+YBC_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(BASE_CLASS_DIR)/nyaml/*.yaml)))
+YCONTRIB_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(CONTRIB_DIR)/nyaml/*.yaml)))
+YAPPDEF_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
 
 
 .PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nxdl nyaml
@@ -34,6 +34,8 @@ help ::
 	@echo "make impatient-guide    Build html & PDF versions of the Guide for the Impatient. Requires prepare first."
 	@echo "make all                Builds complete web site for the manual (in build directory)."
 	@echo "make local              (Developer use) Test, prepare and build the HTML manual."
+	@echo "make nxdl               Build NXDL files from NYAML files in nyaml subdirectories."
+	@echo "make nyaml              Build NYAML files to nyaml subdirectories from NXDL files."
 	@echo ""
 	@echo "Note:  All builds of the manual will occur in the 'build/' directory."
 	@echo "   For a complete build, run 'make all' in the root directory."
@@ -58,8 +60,6 @@ test ::
 
 clean ::
 	$(RM) -rf $(BUILD_DIR)
-
-clean-nyaml ::
 	$(RM) -rf $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)
 	$(RM) -rf $(APPDEF_DIR)/$(NYAML_SUBDIR)
 	$(RM) -rf $(CONTRIB_DIR)/$(NYAML_SUBDIR)
@@ -106,7 +106,7 @@ $(CONTRIB_DIR)/%.nxdl.xml : $(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml
 $(APPDEF_DIR)/%.nxdl.xml : $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml
 	nyaml2nxdl $< --output-file $@
 
-nxdl: $(YBC_NXDL) $(YCONTRIB_NXDL) $(YAPPDEF_NXDL)
+nxdl: $(YBC_NXDL_TARGETS) $(YCONTRIB_NXDL_TARGETS) $(YAPPDEF_NXDL_TARGETS)
 
 nyaml:
 	$(MAKE) -f nyaml.mk

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Note: If set this will increase the build time of the documentation by approxima
 
     setenv GH_TOKEN <access token>
 
+### Working with nyaml files
+
+There exists a simplified format of nxdl, which is called nyaml.
+There is a [tool](https://github.com/FAIRmat-NFDI/nyaml) (`nyaml2nxdl`) available to convert between nxdl and nyaml.
+This tool is already installed when you installed the requirements for this repository and it is conveniently available from the make command.
+
+You can build nyaml files for all nxdl files with invoking
+
+    make nyaml
+
+which will created `.yaml` files in a subfolder called `nyaml` in the respective directory.
+
+From this you can do your changes and create nxdl files with
+
+    make nxdl
+
+from the yaml files.
+
 ## Repository content
 
 These are the components that define the structure of NeXus data files 

--- a/nyaml.mk
+++ b/nyaml.mk
@@ -1,0 +1,22 @@
+BASE_CLASS_DIR := base_classes
+CONTRIB_DIR := contributed_definitions
+APPDEF_DIR := applications
+NYAML_SUBDIR := nyaml
+NXDL_BC = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml))))
+NXDL_APPDEF = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
+NXDL_CONTRIB = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
+
+.PHONY: all nyaml
+
+$(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml : $(BASE_CLASS_DIR)/%.nxdl.xml
+	nyaml2nxdl $< --output-file $@
+
+$(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml : $(CONTRIB_DIR)/%.nxdl.xml
+	nyaml2nxdl $< --output-file $@
+
+$(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml : $(APPDEF_DIR)/%.nxdl.xml
+	nyaml2nxdl $< --output-file $@
+
+nyaml: $(NXDL_BC) $(NXDL_APPDEF) $(NXDL_CONTRIB)
+
+all: nyaml

--- a/nyaml.mk
+++ b/nyaml.mk
@@ -2,21 +2,24 @@ BASE_CLASS_DIR := base_classes
 CONTRIB_DIR := contributed_definitions
 APPDEF_DIR := applications
 NYAML_SUBDIR := nyaml
-NXDL_BC = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml))))
-NXDL_APPDEF = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
-NXDL_CONTRIB = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
+NXDL_BC_TARGETS = $(addprefix $(BASE_CLASS_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(BASE_CLASS_DIR)/*.nxdl.xml))))
+NXDL_APPDEF_TARGETS = $(addprefix $(APPDEF_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(APPDEF_DIR)/*.nxdl.xml))))
+NXDL_CONTRIB_TARGETS = $(addprefix $(CONTRIB_DIR)/nyaml/,$(notdir $(patsubst %.nxdl.xml,%.yaml,$(wildcard $(CONTRIB_DIR)/*.nxdl.xml))))
 
 .PHONY: all nyaml
 
 $(BASE_CLASS_DIR)/$(NYAML_SUBDIR)/%.yaml : $(BASE_CLASS_DIR)/%.nxdl.xml
+	@mkdir -p $(@D)
 	nyaml2nxdl $< --output-file $@
 
 $(CONTRIB_DIR)/$(NYAML_SUBDIR)/%.yaml : $(CONTRIB_DIR)/%.nxdl.xml
+	@mkdir -p $(@D)
 	nyaml2nxdl $< --output-file $@
 
 $(APPDEF_DIR)/$(NYAML_SUBDIR)/%.yaml : $(APPDEF_DIR)/%.nxdl.xml
+	@mkdir -p $(@D)
 	nyaml2nxdl $< --output-file $@
 
-nyaml: $(NXDL_BC) $(NXDL_APPDEF) $(NXDL_CONTRIB)
+nyaml: $(NXDL_BC_TARGETS) $(NXDL_APPDEF_TARGETS) $(NXDL_CONTRIB_TARGETS)
 
 all: nyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Prepare for Documentation
 lxml
 pyyaml
+nyaml
 
 # Documentation building
 sphinx>=5


### PR DESCRIPTION
This adds several things:

- Proper build of `nxdl.xml` files even if they are not present. This is now completely based on the available yaml files
- Removal of `nyaml` for loop
- Add a new Makefile `nyaml.mk` for building nyaml targets to be invoked like this `make -f nyaml.mk`
- [nyaml](https://github.com/FAIRmat-NFDI/nyaml) as a dependency to provide the `nyaml2nxdl` command. [Here](https://pypi.org/project/nyaml/) is the pypi page of nyaml.