### PR TITLE
Fix documentation of NXaperture

### DIFF
--- a/base_classes/NXaperture.nxdl.xml
+++ b/base_classes/NXaperture.nxdl.xml
@@ -27,7 +27,10 @@
     name="NXaperture" 
     type="group" extends="NXobject">
 
-    <doc>A beamline aperture. This group is deprecated, use NXslit instead.</doc>
+    <doc>
+      A beamline aperture.
+
+      Note, the group was incorrectly documented as deprecated, but it is not and it is in common use.</doc>
     <!-- TODO compare with "screens" in SHADOW -->
 
     <field name="depends_on" type="NX_CHAR">
@@ -55,6 +58,11 @@
         the instrument. The dependency chain may however traverse similar groups in
         other component groups.
        </doc>
+    </group>
+    <group type="NXoff_geometry">
+      <doc>
+        Use this group to describe the shape of the aperture
+      </doc>
     </group>
     <group type="NXgeometry" deprecated="Use the field `depends_on` and :ref:`NXtransformations` to position the aperture and :ref:`NXoff_geometry` to describe its shape">
         <doc>


### PR DESCRIPTION
- NXaperture was marked as deprecated but it is not, so fix the documentation
- Explicitly add an unnamed NXoff_geometry field, the existence of which was implied by the GEOMETRY deprecation

Fixes #1231