### PR TITLE
NXvelocity_selector description update

### DIFF
--- a/base_classes/NXvelocity_selector.nxdl.xml
+++ b/base_classes/NXvelocity_selector.nxdl.xml
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format
-# 
+#
 # Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
-# 
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -24,9 +24,9 @@
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" category="base"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-    name="NXvelocity_selector" 
+    name="NXvelocity_selector"
     type="group" extends="NXobject">
-	<doc>A neutron velocity selector</doc>
+	<doc>A neutron or electron velocity selector</doc>
 	<field name="type">
 		<doc>velocity selector type</doc>
 	</field>
@@ -72,10 +72,10 @@
     <attribute name="default">
         <doc>
             .. index:: plotting
-            
-            Declares which child group contains a path leading 
+
+            Declares which child group contains a path leading
             to a :ref:`NXdata` group.
-            
+
             It is recommended (as of NIAC2014) to use this attribute
             to help define the path to the default dataset to be plotted.
             See https://www.nexusformat.org/2014_How_to_find_default_data.html


### PR DESCRIPTION
I added "electron" to the description as the base class also seems to fit the requirements of an electron velocity selector and not only a neutron one.

This Pull request solves: #1354 