### PR TITLE
nxdlTypes: invalid xs:element for unit examples

### DIFF
--- a/dev_tools/docs/xsd_units.py
+++ b/dev_tools/docs/xsd_units.py
@@ -43,16 +43,19 @@ def generate_xsd_units_doc(
         if node_name is None:
             continue
         if "nxdl:" + node_name in members:
-            words = node.xpath("xs:annotation/xs:documentation", namespaces=ns)[0]
+            unit_docs = node.xpath("xs:annotation/xs:documentation", namespaces=ns)[0]
             examples = []
-            for example in words.iterchildren():
-                nm = example.attrib.get("name")
-                if nm is not None and nm == "example":
-                    examples.append("``" + example.text + "``")
-            a = words.text
-            if len(examples) > 0:
-                a = " ".join(a.split()) + ",\n\texample(s): " + " | ".join(examples)
-            db[node_name] = a
+            for unit_docs_child in unit_docs.iterchildren():
+                name = unit_docs_child.attrib.get("name")
+                if name == "example":
+                    units_example = unit_docs_child.attrib["fixed"]
+                    examples.append(f"``{units_example}``")
+            unit_docs = unit_docs.text
+            if examples:
+                prefix = "\texamples: " if len(examples) > 1 else "\texample: "
+                examples = " | ".join(examples)
+                unit_docs = " ".join(unit_docs.split()) + f",\n{prefix}{examples}"
+            db[node_name] = unit_docs
 
             # for item in node.xpath("xs:restriction//xs:enumeration", namespaces=ns):
             #    key = "%s" % item.get("value")

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -88,7 +88,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of angle
-				<xs:element name="example">rad</xs:element>
+				<xs:element name="example" type="xs:string" fixed="rad"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -107,8 +107,8 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of area
-				<xs:element name="example">m^2</xs:element>
-				<xs:element name="example">barns</xs:element>
+				<xs:element name="example" type="xs:string" fixed="m^2"></xs:element>
+				<xs:element name="example" type="xs:string" fixed="barns"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -128,7 +128,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of area (alias of NX_AREA)
-				<xs:element name="example">barn</xs:element>
+				<xs:element name="example" type="xs:string" fixed="barn"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:union memberTypes="nxdl:NX_AREA" />
@@ -138,7 +138,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of electrical charge
-				<xs:element name="example">C</xs:element>
+				<xs:element name="example" type="xs:string" fixed="C"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -148,7 +148,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of electrical current
-				<xs:element name="example">A</xs:element>
+				<xs:element name="example" type="xs:string" fixed="A"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -159,7 +159,7 @@
 			<xs:documentation>
 				units for fields where the units cancel out
 				(NOTE: not the same as NX_UNITLESS)
-				<xs:element name="example">m/m</xs:element>
+				<xs:element name="example" type="xs:string" fixed="m/m"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -170,7 +170,7 @@
 			<xs:documentation>
 				units of emittance (``length * angle``) of a
 				radiation source
-				<xs:element name="example">nm*rad</xs:element>
+				<xs:element name="example" type="xs:string" fixed="nm*rad"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -180,8 +180,8 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of energy
-				<xs:element name="example">J</xs:element>
-				<xs:element name="example">keV</xs:element>
+				<xs:element name="example" type="xs:string" fixed="J"></xs:element>
+				<xs:element name="example" type="xs:string" fixed="keV"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -191,7 +191,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of flux
-				<xs:element name="example">1/s/cm^2</xs:element>
+				<xs:element name="example" type="xs:string" fixed="1/s/cm^2"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -201,7 +201,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of frequency
-				<xs:element name="example">Hz</xs:element>
+				<xs:element name="example" type="xs:string" fixed="Hz"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -211,7 +211,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of length
-				<xs:element name="example">m</xs:element>
+				<xs:element name="example" type="xs:string" fixed="m"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -221,7 +221,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of mass
-				<xs:element name="example">g</xs:element>
+				<xs:element name="example" type="xs:string" fixed="g"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -231,7 +231,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of mass density
-				<xs:element name="example">g/cm^3</xs:element>
+				<xs:element name="example" type="xs:string" fixed="g/cm^3"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -241,7 +241,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of molecular weight
-				<xs:element name="example">g/mol</xs:element>
+				<xs:element name="example" type="xs:string" fixed="g/mol"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -251,7 +251,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of 1/length^2
-				<xs:element name="example">1/m^2</xs:element>
+				<xs:element name="example" type="xs:string" fixed="1/m^2"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -261,7 +261,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of 1/length
-				<xs:element name="example">1/m</xs:element>
+				<xs:element name="example" type="xs:string" fixed="1/m"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -272,7 +272,7 @@
 			<xs:documentation>
 				units of time, period of pulsed source
 				(alias to `NX_TIME`)
-				<xs:element name="example">us</xs:element>
+				<xs:element name="example" type="xs:string" fixed="us"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -282,7 +282,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of power
-				<xs:element name="example">W</xs:element>
+				<xs:element name="example" type="xs:string" fixed="W"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -292,7 +292,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of pressure
-				<xs:element name="example">Pa</xs:element>
+				<xs:element name="example" type="xs:string" fixed="Pa"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -313,7 +313,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of scattering length density
-				<xs:element name="example">m/m^3</xs:element>
+				<xs:element name="example" type="xs:string" fixed="m/m^3"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<!-- isn't this an alias of NX_PER_AREA?
@@ -326,8 +326,8 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of solid angle
-				<xs:element name="example">sr</xs:element>
-				<xs:element name="example">steradian</xs:element>
+				<xs:element name="example" type="xs:string" fixed="sr"></xs:element>
+				<xs:element name="example" type="xs:string" fixed="steradian"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -337,7 +337,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of temperature
-				<xs:element name="example">K</xs:element>
+				<xs:element name="example" type="xs:string" fixed="K"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -347,7 +347,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of time
-				<xs:element name="example">s</xs:element>
+				<xs:element name="example" type="xs:string" fixed="s"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -358,7 +358,7 @@
 			<xs:documentation>
 				units of (neutron) time of flight
 				(alias to `NX_TIME`)
-				<xs:element name="example">s</xs:element>
+				<xs:element name="example" type="xs:string" fixed="s"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -396,7 +396,7 @@
 			<xs:documentation>
 				for fields that don't have a unit (e.g. hkl) so that they don't
 				inherit the wrong units (NOTE: not the same as NX_DIMENSIONLESS)
-				<xs:element name="example">""</xs:element>
+				<xs:element name="example" type="xs:string" fixed='""'></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -406,7 +406,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of voltage
-				<xs:element name="example">V</xs:element>
+				<xs:element name="example" type="xs:string" fixed="V"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -416,7 +416,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of volume
-				<xs:element name="example">m^3</xs:element>
+				<xs:element name="example" type="xs:string" fixed="m^3"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -426,7 +426,7 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of wavelength
-				<xs:element name="example">angstrom</xs:element>
+				<xs:element name="example" type="xs:string" fixed="angstrom"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -436,8 +436,8 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of wavenumber or Q
-				<xs:element name="example">1/nm</xs:element>
-				<xs:element name="example">1/angstrom</xs:element>
+				<xs:element name="example" type="xs:string" fixed="1/nm"></xs:element>
+				<xs:element name="example" type="xs:string" fixed="1/angstrom"></xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<!-- isn't this an alias of NX_PER_LENGTH? -->


### PR DESCRIPTION
Closes #1368

This is not valid (see https://www.w3schools.com/xml/el_element.asp)

```xml
<xs:element name="example">rad</xs:element>
```

This PR proposes

```xml
<xs:element name="example" type="xs:string" fixed="rad"></xs:element>
```

This validator detected the issue:

```python
import xmlschema
xmlschema.XMLSchema("nxdl.xsd")
```

Should we add this to the tests?