### PR TITLE
Description of `NXindirecttof`

### DIFF
--- a/applications/NXindirecttof.nxdl.xml
+++ b/applications/NXindirecttof.nxdl.xml
@@ -35,7 +35,7 @@
             <doc>Number of detectors</doc>
         </symbol>
     </symbols>
-    <doc>This is a application definition for raw data from a direct geometry TOF spectrometer</doc>
+    <doc>This is a application definition for raw data from an indirect geometry TOF spectrometer</doc>
     <group type="NXentry" name="entry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />


### PR DESCRIPTION
"a direct" changed to "an indirect" in the description of `NXindirecttof`.