### PR TITLE
Greatly simplify the NX_CHAR documentation

### DIFF
--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -473,12 +473,7 @@
 	<xs:simpleType name="NX_CHAR">
 		<xs:annotation>
 			<xs:documentation>
-				The preferred string representation is :index:`UTF-8`. 
-				Both fixed-length strings and variable-length strings are valid. 
-				String arrays cannot be used where only a string is expected 
-				(title, start_time, end_time, ``NX_class`` attribute,...). 
-				Fields or attributes requiring the use of string arrays will be 
-				clearly marked as such (like the ``NXdata`` attribute ``auxiliary_signals``). 
+				A string of characters. The preferred string encoding is :index:`UTF-8`. 
 				This is the default field type.
 			</xs:documentation>
 		</xs:annotation>


### PR DESCRIPTION
Idea is to state that NX_CHAR is a string of characters, and remove the other documentation that doesn't seem as necessary nowadays.

Fixes #1441