### PR TITLE
XDS: clarify the definition of the optional attribute in relation to minOccurs for fields and groups

### DIFF
--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -502,7 +502,7 @@ https://stackoverflow.com/a/48980995/1046449 -->
 		<xs:attribute name="optional" use="optional" type="nx:NX_BOOLEAN" default="false" >
 			<xs:annotation>
 				<xs:documentation>
-					The value "true" is equivalent to minOccurs=0 while the value
+					A value of "true" is equivalent to minOccurs=0 while a value of
 					"false" is equivalent to minOccurs>0.
 				</xs:documentation>
 			</xs:annotation>
@@ -838,7 +838,7 @@ https://stackoverflow.com/a/48980995/1046449 -->
 				<xs:attribute name="optional" use="optional" type="nx:NX_BOOLEAN" default="false" >
 					<xs:annotation>
 						<xs:documentation>
-							The value "true" is equivalent to minOccurs=0 while the value
+							A value of "true" is equivalent to minOccurs=0 while a value of
 							"false" is equivalent to minOccurs>0.
 						</xs:documentation>
 					</xs:annotation>

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -502,7 +502,8 @@ https://stackoverflow.com/a/48980995/1046449 -->
 		<xs:attribute name="optional" use="optional" type="nx:NX_BOOLEAN" default="false" >
 			<xs:annotation>
 				<xs:documentation>
-					A synonym for minOccurs=0.
+					The value "true" is equivalent to minOccurs=0 while the value
+					"false" is equivalent to minOccurs>0.
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -837,7 +838,8 @@ https://stackoverflow.com/a/48980995/1046449 -->
 				<xs:attribute name="optional" use="optional" type="nx:NX_BOOLEAN" default="false" >
 					<xs:annotation>
 						<xs:documentation>
-							A synonym for minOccurs=0.
+							The value "true" is equivalent to minOccurs=0 while the value
+							"false" is equivalent to minOccurs>0.
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>


### PR DESCRIPTION
optional is only a synonym for minOccurs=0 when optional=true.

When optional is false, this must mean the opposite so minOccurs>0 since nonNegativeUnbounded (not specifying the exact value of minOccurs, we only know it is greater than 0).