### PR TITLE
maxOccurs is optional which means it has a default.

### DIFF
--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -506,7 +506,7 @@ https://stackoverflow.com/a/48980995/1046449 -->
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<xs:attribute name="maxOccurs" use="optional" type="nx:nonNegativeUnbounded">
+		<xs:attribute name="maxOccurs" use="optional" type="nx:nonNegativeUnbounded" default="unbounded">
 			<xs:annotation>
 				<xs:documentation>
 					Maximum number of times this ``group`` is allowed to be present within its
@@ -841,7 +841,7 @@ https://stackoverflow.com/a/48980995/1046449 -->
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
-				<xs:attribute name="maxOccurs" use="optional"  default="1" type="nx:nonNegativeUnbounded">
+				<xs:attribute name="maxOccurs" use="optional" default="1" type="nx:nonNegativeUnbounded">
 					<xs:annotation>
 						<xs:documentation>
 							Defines the maximum number of times this element may be used.  Its


### PR DESCRIPTION
The default of maxOccurs for groups seems to "unbounded": https://github.com/nexusformat/definitions/issues/1513#issuecomment-2495512150. I'm not sure where this comes from though.

The default of maxOccurs for fields seems to be 1.

So the default is different from groups and fields which surprises me.