### PR TITLE
Remove limitation on how entries are named

### DIFF
--- a/applications/NXarchive.nxdl.xml
+++ b/applications/NXarchive.nxdl.xml
@@ -37,7 +37,7 @@
 	        a mechanism to link all aspects of ISIS research from 
 	        proposal through to publication. 
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <attribute name="index"></attribute>
       <field name="title" />
       <field name="experiment_identifier" type="NX_CHAR">

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -33,12 +33,6 @@
     It has been drawn up with hemispherical electron analysers in mind. 
   </doc>
   <group type="NXentry">
-    <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
-      <doc>
-        NeXus convention is to use "entry1", "entry2", ... 
-        for analysis software to locate each entry.
-      </doc>
-    </attribute>
     <field name="title" type="NX_CHAR"/>
     <field name="start_time" type="NX_DATE_TIME"/>
     <field name="definition">

--- a/applications/NXarpes.nxdl.xml
+++ b/applications/NXarpes.nxdl.xml
@@ -33,7 +33,7 @@
     It has been drawn up with hemispherical electron analysers in mind. 
   </doc>
   <group type="NXentry">
-    <attribute name="entry">
+    <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
       <doc>
         NeXus convention is to use "entry1", "entry2", ... 
         for analysis software to locate each entry.

--- a/applications/NXdirecttof.nxdl.xml
+++ b/applications/NXdirecttof.nxdl.xml
@@ -28,7 +28,7 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
     <doc>This is a application definition for raw data from a direct geometry TOF spectrometer</doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXfluo.nxdl.xml
+++ b/applications/NXfluo.nxdl.xml
@@ -38,7 +38,7 @@
     <doc>
       This is an application definition for raw data from an X-ray fluorescence experiment
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXindirecttof.nxdl.xml
+++ b/applications/NXindirecttof.nxdl.xml
@@ -36,7 +36,7 @@
         </symbol>
     </symbols>
     <doc>This is a application definition for raw data from an indirect geometry TOF spectrometer</doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -43,7 +43,6 @@
     </symbols>
     <doc>Application definition for any :math:`I(Q)` data.</doc>
     <group type="NXentry">
-        <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438"/>
         <field name="title"/>
       <field name="definition">
         <doc> Official NeXus NXDL schema to which this file conforms </doc>

--- a/applications/NXiqproc.nxdl.xml
+++ b/applications/NXiqproc.nxdl.xml
@@ -43,9 +43,7 @@
     </symbols>
     <doc>Application definition for any :math:`I(Q)` data.</doc>
     <group type="NXentry">
-        <attribute name="entry">
-          <!-- TODO documentation string needed here -->
-        </attribute>
+        <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438"/>
         <field name="title"/>
       <field name="definition">
         <doc> Official NeXus NXDL schema to which this file conforms </doc>

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -44,7 +44,7 @@
   <doc>
     This is the application definition for a TOF laue diffractometer
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>
       <enumeration>

--- a/applications/NXmonopd.nxdl.xml
+++ b/applications/NXmonopd.nxdl.xml
@@ -47,7 +47,7 @@
         with a single detector or a powder diffractometer with a position 
         sensitive detector.
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
         <field name="title"/>
         <field name="start_time" type="NX_DATE_TIME"/>
         <field name="definition">

--- a/applications/NXrefscan.nxdl.xml
+++ b/applications/NXrefscan.nxdl.xml
@@ -41,7 +41,7 @@
     It does not have the information to calculate the resolution
     since it does not have any apertures.
   </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="end_time" type="NX_DATE_TIME" />

--- a/applications/NXreftof.nxdl.xml
+++ b/applications/NXreftof.nxdl.xml
@@ -42,7 +42,7 @@
 	  </symbol>
     </symbols>
     <doc>This is an application definition for raw data from a TOF reflectometer. </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="end_time" type="NX_DATE_TIME" />

--- a/applications/NXsastof.nxdl.xml
+++ b/applications/NXsastof.nxdl.xml
@@ -49,7 +49,7 @@
     at a time-of-flight source.
    </doc>
   <group type="NXentry">
-    <attribute name="entry">
+    <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
       <doc>NeXus convention is to use "entry1", "entry2", ... for analysis software to locate each entry</doc>
     </attribute>
     <field name="title"/>

--- a/applications/NXsastof.nxdl.xml
+++ b/applications/NXsastof.nxdl.xml
@@ -49,9 +49,6 @@
     at a time-of-flight source.
    </doc>
   <group type="NXentry">
-    <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
-      <doc>NeXus convention is to use "entry1", "entry2", ... for analysis software to locate each entry</doc>
-    </attribute>
     <field name="title"/>
     <field name="start_time" type="NX_DATE_TIME"/>
     <field name="definition">

--- a/applications/NXsqom.nxdl.xml
+++ b/applications/NXsqom.nxdl.xml
@@ -43,7 +43,7 @@
     a sensible way.
   </doc>
   <group type="NXentry">
-    <attribute name="entry"> </attribute>
+    <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438"> </attribute>
     <field name="title"/>
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>

--- a/applications/NXsqom.nxdl.xml
+++ b/applications/NXsqom.nxdl.xml
@@ -43,7 +43,6 @@
     a sensible way.
   </doc>
   <group type="NXentry">
-    <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438"> </attribute>
     <field name="title"/>
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>

--- a/applications/NXtas.nxdl.xml
+++ b/applications/NXtas.nxdl.xml
@@ -41,7 +41,7 @@
     It is for the trademark scan of the TAS, the Q-E scan. 
     For your alignment scans use the rules in :ref:`NXscan`.
   </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" type="NX_CHAR" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXtofnpd.nxdl.xml
+++ b/applications/NXtofnpd.nxdl.xml
@@ -39,7 +39,7 @@
       </symbol>
 	</symbols>
     <doc>This is a application definition for raw data from a TOF neutron powder diffractometer</doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXtofraw.nxdl.xml
+++ b/applications/NXtofraw.nxdl.xml
@@ -39,7 +39,7 @@
       </symbol>
 	</symbols>
     <doc>This is an application definition for raw data from a generic TOF instrument</doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXtofsingle.nxdl.xml
+++ b/applications/NXtofsingle.nxdl.xml
@@ -45,7 +45,7 @@
       </symbol>
 	</symbols>
     <doc>This is a application definition for raw data from a generic TOF instrument</doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXtomo.nxdl.xml
+++ b/applications/NXtomo.nxdl.xml
@@ -48,7 +48,7 @@
           a number of dark field images are measured, some bright field images and, of course the sample. 
           In order to distinguish between them images carry a image_key.
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title"  minOccurs="0" maxOccurs="1"/> 
       <field name="start_time" type="NX_DATE_TIME"  minOccurs="0" maxOccurs="1"/> 
       <field name="end_time" type="NX_DATE_TIME"  minOccurs="0" maxOccurs="1"/> 

--- a/applications/NXtomophase.nxdl.xml
+++ b/applications/NXtomophase.nxdl.xml
@@ -55,7 +55,7 @@
       some dark field images are measured, some bright field images and, of course the sample. In order 
       to properly sort the order of the images taken, a sequence number is stored with each image.
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="end_time" type="NX_DATE_TIME" />

--- a/applications/NXtomoproc.nxdl.xml
+++ b/applications/NXtomoproc.nxdl.xml
@@ -40,7 +40,7 @@
         </symbol>
 	</symbols>
     <doc>This is an application definition for the final result of a tomography experiment: a 3D construction of some volume of physical properties.</doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="definition">
         <doc> Official NeXus NXDL schema to which this file conforms </doc>

--- a/applications/NXxas.nxdl.xml
+++ b/applications/NXxas.nxdl.xml
@@ -42,7 +42,7 @@
       absorbed beam.
     </doc>
     <group type="NXentry">
-        <attribute name="entry">
+        <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
             <doc>
                NeXus convention is to use "entry1", "entry2", ... 
                for analysis software to locate each entry.

--- a/applications/NXxas.nxdl.xml
+++ b/applications/NXxas.nxdl.xml
@@ -42,12 +42,6 @@
       absorbed beam.
     </doc>
     <group type="NXentry">
-        <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
-            <doc>
-               NeXus convention is to use "entry1", "entry2", ... 
-               for analysis software to locate each entry.
-            </doc>
-        </attribute>
         <field name="title"/>
         <field name="start_time" type="NX_DATE_TIME"/>
         <field name="definition">

--- a/applications/NXxasproc.nxdl.xml
+++ b/applications/NXxasproc.nxdl.xml
@@ -39,7 +39,7 @@
        Processed data from XAS. This is energy versus I(incoming)/I(absorbed).
     </doc>
     <group type="NXentry">
-        <attribute name="entry">
+        <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
             <doc>
                 NeXus convention is to use "entry1", "entry2", ... 
                 for analysis software to locate each entry.

--- a/applications/NXxasproc.nxdl.xml
+++ b/applications/NXxasproc.nxdl.xml
@@ -39,12 +39,6 @@
        Processed data from XAS. This is energy versus I(incoming)/I(absorbed).
     </doc>
     <group type="NXentry">
-        <attribute name="entry" deprecated="See https://github.com/nexusformat/definitions/issues/1438">
-            <doc>
-                NeXus convention is to use "entry1", "entry2", ... 
-                for analysis software to locate each entry.
-            </doc>
-        </attribute>
         <field name="title"/>
       <field name="definition">
         <doc> Official NeXus NXDL schema to which this file conforms </doc>

--- a/applications/NXxbase.nxdl.xml
+++ b/applications/NXxbase.nxdl.xml
@@ -44,7 +44,7 @@
     <doc>
       This definition covers the common parts of all monochromatic single crystal raw data application definitions.
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="title" />
       <field name="start_time" type="NX_DATE_TIME" />
       <field name="definition">

--- a/applications/NXxeuler.nxdl.xml
+++ b/applications/NXxeuler.nxdl.xml
@@ -42,7 +42,7 @@
       of :ref:`NXxbase` plus the data defined here. All four angles are 
       logged in order to support arbitrary scans in reciprocal space.
     </doc>
-    <group type="NXentry" name="entry">
+    <group type="NXentry">
       <field name="definition">
         <doc> Official NeXus NXDL schema to which this file conforms </doc>
         <enumeration>

--- a/applications/NXxkappa.nxdl.xml
+++ b/applications/NXxkappa.nxdl.xml
@@ -44,7 +44,7 @@
     the content of :ref:`NXxbase` plus the
     data defined here.
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>
       <enumeration>

--- a/applications/NXxlaue.nxdl.xml
+++ b/applications/NXxlaue.nxdl.xml
@@ -41,7 +41,7 @@
     This is the application definition for raw data from a single crystal laue 
     camera. It extends :ref:`NXxrot`.
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>
       <enumeration>

--- a/applications/NXxlaueplate.nxdl.xml
+++ b/applications/NXxlaueplate.nxdl.xml
@@ -33,7 +33,7 @@
     This is the application definition for raw data from a single crystal Laue 
     camera with an image plate as a detector. It extends :ref:`NXxlaue`.
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>
       <enumeration>

--- a/applications/NXxnb.nxdl.xml
+++ b/applications/NXxnb.nxdl.xml
@@ -46,7 +46,7 @@
     logged in order to support arbitrary scans in
     reciprocal space.
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>
       <enumeration>

--- a/applications/NXxrot.nxdl.xml
+++ b/applications/NXxrot.nxdl.xml
@@ -42,7 +42,7 @@
     It extends :ref:`NXxbase`, so the full definition is the content of :ref:`NXxbase`
     plus the data defined here.
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc>Official NeXus NXDL schema to which this file conforms.</doc>
       <enumeration>

--- a/contributed_definitions/NXxpcs.nxdl.xml
+++ b/contributed_definitions/NXxpcs.nxdl.xml
@@ -47,7 +47,7 @@
     that this XPCS data will be part of multi-modal data set that could involve e.g., :ref:`NXcanSAS` or
     1D and/or 2D data.
   </doc>
-  <group type="NXentry" name="entry">
+  <group type="NXentry">
     <field name="definition">
       <doc> Official NeXus NXDL schema to which this file conforms </doc>
       <enumeration>


### PR DESCRIPTION
- Change all instances of <group type="NXentry" name="entry"> to <group type="NXentry"> (24 instances)
- Deprecate all instances of <attribute name="entry"> (6 instances)

Fixes #1438

This was voted on in [NIAC 2024](https://www.nexusformat.org/content/NIAC2024_minutes/#session-e-sept-28th-1330-utc) so this only needs a review from @nexusformat/developers