### PR TITLE
Permit simple inheritance for base classes

### DIFF
--- a/manual/source/design.rst
+++ b/manual/source/design.rst
@@ -524,13 +524,14 @@ annotate or in a ``NXcollection``. All of the base classes are documented in the
 Inheritance in NeXus
 --------------------
 
-Simple inheritance is supported in NeXus for both base classes and application defintions (which are
+Single inheritance is supported in NeXus for both base classes and application definitions (which are
 described below).  Extending a base class or application definition inherits the properties and objects of the
-parent class or definiton, such as groups, fields, attributes, and symbol tables. These properties and objects
-of the parent can then be overriden by the subclass.  Only single inheritance is allowed (you can only inherit
+parent class or definition, such as groups, fields, attributes, and symbol tables. These properties and objects
+of the parent can then be overridden by the subclass.  Only single inheritance is allowed (you can only inherit
 from a single parent).
 
-Use the ``@extends`` attribute of a definition to indicate which definition is being subclassed.
+Use the ``@extends`` attribute of a definition to indicate which definition is being subclassed. Base classes
+should extend from ``NXobject`` unless they are being subclassed.
 
 .. _NXdata-facilitates-TheDefaultPlot:
 

--- a/manual/source/design.rst
+++ b/manual/source/design.rst
@@ -519,7 +519,7 @@ But there are some base classes which have special uses which need to be mention
 These groups can appear anywhere in the NeXus hierarchy, where needed. Preferably close to the component they
 annotate or in a ``NXcollection``. All of the base classes are documented in the reference manual.
 
-.. inheritance:
+.. _inheritance:
 
 Inheritance in NeXus
 --------------------

--- a/manual/source/design.rst
+++ b/manual/source/design.rst
@@ -519,6 +519,19 @@ But there are some base classes which have special uses which need to be mention
 These groups can appear anywhere in the NeXus hierarchy, where needed. Preferably close to the component they
 annotate or in a ``NXcollection``. All of the base classes are documented in the reference manual.
 
+.. inheritance:
+
+Inheritance in NeXus
+--------------------
+
+Simple inheritance is supported in NeXus for both base classes and application defintions (which are
+described below).  Extending a base class or application definition inherits the properties and objects of the
+parent class or definiton, such as groups, fields, attributes, and symbol tables. These properties and objects
+of the parent can then be overriden by the subclass.  Only single inheritance is allowed (you can only inherit
+from a single parent).
+
+Use the ``@extends`` attribute of a definition to indicate which definition is being subclassed.
+
 .. _NXdata-facilitates-TheDefaultPlot:
 
 ``NXdata`` Facilitates Automatic Plotting
@@ -645,7 +658,7 @@ Yet another way to look at a NeXus application definition is to understand it as
 between data files and the software which uses this file. Much like an interface in the Java or other modern
 object oriented programming languages.
 
-In contrast to NeXus base classes, NeXus supports inheritance in application definitions.
+Like base classes, NeXus supports :ref:`inheritance` in application definitions.
 
 Please note that a NeXus Application Definition will only define the bare minimum of data necessary to perform
 common analysis with data. Practical files will nearly always contain more data. One of the beauties of NeXus is

--- a/manual/source/faq.rst
+++ b/manual/source/faq.rst
@@ -232,19 +232,24 @@ This is a list of commonly asked questions concerning the NeXus data format.
    class within the definition are valid instances of
    the original class, but not vice-versa?
 
-   Keep in mind that NeXus is not specifically object oriented.
-   The putative super class might be either
-   :ref:`NXentry` (for single-technique data, such as SAXS)
-   or :ref:`NXsubentry` (for multi-technique data
-   such as SAXS/WAXS/USAXS/GIWAXS or SAXS/SANS).
+   Yes.  When writing an application definition, you can
+   add additional metadata to base classes that are not in the
+   base class definition. This essentially sub-classes the
+   original base class.
 
-   If you are thinking of a new application definition that uses
-   another as a starting point (like a super class), then there
-   is an ``extends`` attribute in the definition element of the
-   NXDL file (example here from :ref:`NXarpes`)::
+   This is different than using the ``extends`` attribute, which
+   can be used to make new base classes that inherit the properties
+   of the parent classes, or new application definitions that use
+   another as a starting point. For example the
+   ``NXelectron_detector`` base class extends the ``NXdetector``
+   base class::
 
-       <definition name="NXarpes" extends="NXobject" type="group"
+     <definition category="base" name="NXelectron_detector" extends="NXdetector">
 
-   which describes this relationship. For most (?all?) all NXDL
-   files to date, they extend the :ref:`NXobject` base class
-   (the base object of NeXus).
+   This is similar to how the application definition ``NXdirecttof`` extends
+   the ``NXtofraw`` application definition::
+
+     <definition category="application" name="NXdirecttof" extends="NXtofraw">
+
+   Most NXDL files extend the :ref:`NXobject` base class (the base object
+   of NeXus).


### PR DESCRIPTION
- Adds section on "Inheritance in NeXus" to design.rst
- Changes "In contrast to NeXus base classes, NeXus supports inheritance in application definitions." to "Like base classes, NeXus supports inheritance in application definitions."
- Rewrites the FAQ question on inheritance

Notably, I left this paragraph alone in design.rst, as I didn't think that discussion needed to be cluttered by inheritance and that it didn't contradict the use of inheritance:

> NeXus base classes are not proper classes in the same sense as used in object oriented programming languages. In fact the use of the term classes is actually misleading but has established itself during the development of NeXus. NeXus base classes are rather dictionaries of field names and their meanings which are permitted in a particular NeXus group implementing the NeXus class. This sounds complicated but becomes easy if you consider that most NeXus groups describe instrument components. Then for example, a NXmonochromator base class describes all the possible field names which NeXus allows to be used to describe a monochromator.

Also noteably, I found that the definition of [`@extends`](https://www.nexusformat.org/content/NIAC2024_minutes/#session-g-sept-29th-1000-utc) didn't need changing:

> The `extends` attribute allows this definition to subclass from another NXDL, otherwise `extends="NXobject"` should be used.

My grepping and googling found these instances of specific discussion of inheritance but I might have missed some.  If anyone else spots more, let me know!

This is as voted on in [NIAC 2024](https://www.nexusformat.org/content/NIAC2024_minutes/#session-g-sept-29th-1000-utc) and so only needs a review by @nexusformat/developers.

Closes #1442