### PR TITLE
Apply corrections and update EPICS area detector attributes example

### DIFF
--- a/manual/source/examples/epics/attributes-reformatted.xml
+++ b/manual/source/examples/epics/attributes-reformatted.xml
@@ -17,13 +17,13 @@
                description="Image counter"/>
     <Attribute name="calc1_val"           
                type="EPICS_PV" 
-               source="prj:userCalc1.VAL"            
-               datatype="DBR_NATIVE" 
+               source="$(P)userCalc1.VAL"            
+               dbrtype="DBR_NATIVE" 
                description="some calculation result"/>
     <Attribute name="calc2_val"           
                type="EPICS_PV" 
-               source="prj:userCalc2.VAL"            
-               datatype="DBR_NATIVE" 
+               source="$(P)userCalc2.VAL"            
+               dbrtype="DBR_NATIVE" 
                description="another calculation result"/>
     <Attribute name="MaxSizeX"            
                type="PARAM"    

--- a/manual/source/examples/epics/attributes.xml
+++ b/manual/source/examples/epics/attributes.xml
@@ -6,8 +6,8 @@
     >
     <Attribute name="AcquireTime"         type="EPICS_PV" source="13SIM1:cam1:AcquireTime"      dbrtype="DBR_NATIVE"  description="Camera acquire time"/>
     <Attribute name="ImageCounter"        type="PARAM"    source="ARRAY_COUNTER"                datatype="INT"        description="Image counter"/>
-    <Attribute name="calc1_val"           type="EPICS_PV" source="prj:userCalc1.VAL"            datatype="DBR_NATIVE" description="some calculation result"/>
-    <Attribute name="calc2_val"           type="EPICS_PV" source="prj:userCalc2.VAL"            datatype="DBR_NATIVE" description="another calculation result"/>
+    <Attribute name="calc1_val"           type="EPICS_PV" source="$(P)userCalc1.VAL"            dbrtype="DBR_NATIVE"  description="some calculation result"/>
+    <Attribute name="calc2_val"           type="EPICS_PV" source="$(P)userCalc2.VAL"            dbrtype="DBR_NATIVE"  description="another calculation result"/>
     <Attribute name="MaxSizeX"            type="PARAM"    source="MAX_SIZE_X"                   datatype="INT"        description="Detector X size"/>
     <Attribute name="MaxSizeY"            type="PARAM"    source="MAX_SIZE_Y"                   datatype="INT"        description="Detector Y size"/>
     <Attribute name="CameraModel"         type="PARAM"    source="MODEL"                        datatype="STRING"     description="Camera model"/>


### PR DESCRIPTION
While working on https://github.com/areaDetector/ADCore/issues/512, found the example file did not validate as expected.  Correct a minor typo (`datatype` -> `dbrtype`) and revise the example to show a macro expansion (https://github.com/areaDetector/ADCore/pull/522).