### PR TITLE
move NXpid to base_classes, add in NXactuator

### DIFF
--- a/base_classes/NXactuator.nxdl.xml
+++ b/base_classes/NXactuator.nxdl.xml
@@ -70,6 +70,12 @@
              For example, a heater can have the field output_power(NX_NUMBER).
         </doc>
     </field>
+    <group type="NXpid">
+        <doc>
+             If the actuator is PID-controlled, the settings of the PID controller can be
+             stored here.
+        </doc>
+    </group>
     <field name="depends_on" type="NX_CHAR">
         <doc>
              Refers to the last transformation specifying the position of the actuator

--- a/base_classes/NXpid.nxdl.xml
+++ b/base_classes/NXpid.nxdl.xml
@@ -78,7 +78,7 @@
              the slope of the error over time and multiplying this rate of
              change by the derivative gain K_d. The magnitude of the
              contribution of the derivative term to the overall control
-             action is termed the derivative gain, K_d
+             action is termed the derivative gain, K_d.
         </doc>
     </field>
 </definition>


### PR DESCRIPTION
This is a follow-up to https://github.com/nexusformat/definitions/pull/1414 where NXpid was mistakenly not included in the vote even though it was originally used within NXactuator. This PR moves NXpid to the base classes and adds it back to NXactuator.

This is a resubmission of #1522 which was marked as merged by GitHub after merging #1414 even though NXpid is not actually part of the `base_classes` yet.
