### PR TITLE
`extends` attribute to clarify if a field in a specified `NXdata` is a `AXISNAME` or `DATA`

### DIFF
--- a/contributed_definitions/NXiv_temp.nxdl.xml
+++ b/contributed_definitions/NXiv_temp.nxdl.xml
@@ -90,9 +90,9 @@
                  There should also be a field with an array of rank equal to the number of different temperature setpoints and each child's dimension
                  equal to the number of voltage setpoints.
             </doc>
-            <field name="temperature" type="NX_NUMBER"/>
-            <field name="voltage" type="NX_NUMBER"/>
-            <field name="current" type="NX_NUMBER">
+            <field name="temperature" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
+            <field name="voltage" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
+            <field name="current" type="NX_NUMBER" extends="/NXdata/DATA">
                 <dimensions rank="2">
                     <dim index="1" value="n_different_temperatures"/>
                     <dim index="2" value="n_different_voltages"/>

--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -593,6 +593,7 @@ class NXClassDocGenerator:
             self._print_enumeration(
                 collapse_indent + self._INDENTATION_UNIT, ns, node_list[0]
             )
+
     def _print_attribute(self, ns, kind, node, optional, indent, parent_path):
         name = node.get("name")
         formatted_name = get_rst_formatted_name(node)
@@ -606,7 +607,6 @@ class NXClassDocGenerator:
         )
         self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
         self._print_doc_enum(indent, ns, node)
-
 
     def _print_extends_text(self, ns, node, indent):
         extends_text = node.get("extends", None)

--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -607,7 +607,7 @@ class NXClassDocGenerator:
         )
         self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
         self._print_doc_enum(indent, ns, node)
-   
+
     def _get_extends_text(self, node):
         extends = node.get("extends", None)
         if extends:

--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -607,11 +607,12 @@ class NXClassDocGenerator:
         )
         self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
         self._print_doc_enum(indent, ns, node)
-
-    def _print_extends_text(self, ns, node, indent):
-        extends_text = node.get("extends", None)
-        if extends_text is not None:
-            self._print(f"\n{indent}This field extends: {extends_text}\n")
+   
+    def _get_extends_text(self, node):
+        extends = node.get("extends", None)
+        if extends:
+            return f"(:ref:`{extends.split("/")[-1]} <{extends}-field>`) "
+        return ""
 
     def _print_if_deprecated(self, ns, node, indent):
         deprecated = node.get("deprecated", None)
@@ -640,6 +641,7 @@ class NXClassDocGenerator:
                 dims = self._analyze_dimensions(ns, node)
 
                 optional_text = self._get_required_or_optional_text(node)
+                extends_test = self._get_extends_text(node)
                 self._print(
                     f"{indent}{self._hyperlink_target(parent_path, name, 'field')}"
                 )
@@ -647,6 +649,7 @@ class NXClassDocGenerator:
                 self._print(
                     f"{indent}{formatted_name}: "
                     f"{optional_text}"
+                    f"{extends_test}"
                     f"{self._format_type(node)}"
                     f"{dims}"
                     f"{self._format_units(node)}"

--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -593,7 +593,6 @@ class NXClassDocGenerator:
             self._print_enumeration(
                 collapse_indent + self._INDENTATION_UNIT, ns, node_list[0]
             )
-
     def _print_attribute(self, ns, kind, node, optional, indent, parent_path):
         name = node.get("name")
         formatted_name = get_rst_formatted_name(node)
@@ -607,6 +606,12 @@ class NXClassDocGenerator:
         )
         self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
         self._print_doc_enum(indent, ns, node)
+
+
+    def _print_extends_text(self, ns, node, indent):
+        extends_text = node.get("extends", None)
+        if extends_text is not None:
+            self._print(f"\n{indent}This field extends: {extends_text}\n")
 
     def _print_if_deprecated(self, ns, node, indent):
         deprecated = node.get("deprecated", None)
@@ -648,7 +653,7 @@ class NXClassDocGenerator:
                     f" {self.get_first_parent_ref(f'{parent_path}/{name}', 'field')}"
                     "\n"
                 )
-
+                self._print_extends_text(ns, node, indent + self._INDENTATION_UNIT)
                 self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
                 self._print_doc_enum(indent, ns, node)
 

--- a/dev_tools/docs/xsd.py
+++ b/dev_tools/docs/xsd.py
@@ -252,29 +252,6 @@ class XSDDocGenerator:
             self._print(self._indent(indentLevel) + "\n")
 
     def get_doc_from_node(self, node, retval=None):
-        def handle_code_and_literals(self, text):
-            """
-            This function ensures inline code (``code``) and code blocks (.. code-block::) are correctly handled for reStructuredText.
-            """
-            lines = text.splitlines()
-            self._print(text, lines)
-            result_lines = []
-
-            for line in lines:
-                # Check for inline code (e.g., ``code``)
-                if "``" in line:
-                    line = self.handle_inline_code(line)
-
-                # Check for code blocks (i.e., .. code-block::)
-                if line.strip().startswith(".. code-block"):
-                    # We assume the block is correctly formatted, so leave it as is
-                    result_lines.append(f"{line.strip()}")
-
-                else:
-                    result_lines.append(line)
-
-            return "\n".join(result_lines)
-
         annotation_node = node.find("xs:annotation", self.ns)
         if annotation_node is None:
             return retval
@@ -302,10 +279,7 @@ class XSDDocGenerator:
             htmlparser = HTMLParser.HTMLParser()
             text = htmlparser.unescape(text)
 
-            # Handle potential inline code and code blocks
-            text = self.handle_code_and_literals(text)
-
-            return text.lstrip()
+        return text.lstrip()
 
     def add_figure(self, name, indentLevel=0):
         imageFile = f"img/nxdl/nxdl_{name}.png"

--- a/dev_tools/docs/xsd.py
+++ b/dev_tools/docs/xsd.py
@@ -252,6 +252,29 @@ class XSDDocGenerator:
             self._print(self._indent(indentLevel) + "\n")
 
     def get_doc_from_node(self, node, retval=None):
+        def handle_code_and_literals(self, text):
+            """
+            This function ensures inline code (``code``) and code blocks (.. code-block::) are correctly handled for reStructuredText.
+            """
+            lines = text.splitlines()
+            self._print(text, lines)
+            result_lines = []
+
+            for line in lines:
+                # Check for inline code (e.g., ``code``)
+                if "``" in line:
+                    line = self.handle_inline_code(line)
+
+                # Check for code blocks (i.e., .. code-block::)
+                if line.strip().startswith(".. code-block"):
+                    # We assume the block is correctly formatted, so leave it as is
+                    result_lines.append(f"{line.strip()}")
+
+                else:
+                    result_lines.append(line)
+
+            return "\n".join(result_lines)
+
         annotation_node = node.find("xs:annotation", self.ns)
         if annotation_node is None:
             return retval
@@ -279,7 +302,10 @@ class XSDDocGenerator:
             htmlparser = HTMLParser.HTMLParser()
             text = htmlparser.unescape(text)
 
-        return text.lstrip()
+            # Handle potential inline code and code blocks
+            text = self.handle_code_and_literals(text)
+
+            return text.lstrip()
 
     def add_figure(self, name, indentLevel=0):
         imageFile = f"img/nxdl/nxdl_{name}.png"

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -970,30 +970,39 @@ https://stackoverflow.com/a/48980995/1046449 -->
 							in the inheritance hierarchy this field is derived from.
 
 							This attribute is to be used in cases where there is an ambiguity
-							in the inheritance. An example are the ``AXISNAME`` and ``DATA``
-							fields in ``NXdata``, which are both of type ``NX_NUMBER``.
-							Thus, when specializing ``NXdata`` in an application definition,
-							``extends`` attribute allows to specify whether a field in the
-							specialized ``NXdata`` is an ``AXISNAME`` and ``DATA``.
+							in the inheritance. At the moment, this is only the case for the
+							``AXISNAME`` and ``DATA`` fields in ``NXdata``, which are both of
+							type ``NX_NUMBER``. Thus, when specializing ``NXdata`` in an application
+							 definition, the ``extends`` attribute allows to specify whether a field
+							in the specialized ``NXdata`` is an ``AXISNAME`` and ``DATA``.
 
 							For example, consider the following NXDL snippet:
 
-							<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXiv_temp" extends="NXsensor_scan" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
-								<doc>
-									Application definition for temperature-dependent IV curve measurements.
-								</doc>
-								<group type="NXentry">
-									<group type="NXdata">
-										<doc>
-											This NXdata contains multiple fields. Temperature and voltage are supposed to specialize `AXISNAME`, whereas
-											`current` is specializing `DATA`.
-										</doc>
-										<field name="temperature" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
-										<field name="voltage" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
-										<field name="current" type="NX_NUMBER" extends="/NXdata/DATA"/>
+							.. code-block:: xml
+								:linenos:
+								
+								<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" 
+											xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+											category="application" 
+											name="NXexample" 
+											extends="NXobject" 
+											type="group" 
+											xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+									<doc>
+										Example application definition.
+									</doc>
+									<group type="NXentry">
+										<group type="NXdata">
+											<doc>
+												This NXdata contains multiple fields. ``temperature`` and ``voltage``
+												specialize ``AXISNAME``, whereas ``current`` specializes ``DATA``.
+											</doc>
+											<field name="temperature" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
+											<field name="voltage" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
+											<field name="current" type="NX_NUMBER" extends="/NXdata/DATA"/>
+										</group>
 									</group>
-								</group>
-							</definition>
+								</definition>							
 
 							Here, the ``extends`` attribute is used to specify that the ``temperature`` and ``voltage`` fields are specializations
 							of the ``AXISNAME`` field, whereas the ``current`` field is a specialization of the ``DATA`` field.

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -963,6 +963,47 @@ https://stackoverflow.com/a/48980995/1046449 -->
 						</xs:restriction>
 					</xs:simpleType>
 				</xs:attribute>
+				<xs:attribute name="extends" use="optional">
+					<xs:annotation>
+						<xs:documentation>
+							The ``extends`` attribute allows to specify which field
+							in the inheritance hierarchy this field is derived from.
+
+							This attribute is to be used in cases where there is an ambiguity
+							in the inheritance. An example are the ``AXISNAME`` and ``DATA``
+							fields in ``NXdata``, which are both of type ``NX_NUMBER``.
+							Thus, when specializing ``NXdata`` in an application definition,
+							``extends`` attribute allows to specify whether a field in the
+							specialized ``NXdata`` is an ``AXISNAME`` and ``DATA``.
+
+							For example, consider the following NXDL snippet:
+
+							<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXiv_temp" extends="NXsensor_scan" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+								<doc>
+									Application definition for temperature-dependent IV curve measurements.
+								</doc>
+								<group type="NXentry">
+									<group type="NXdata">
+										<doc>
+											This NXdata contains multiple fields. Temperature and voltage are supposed to specialize `AXISNAME`, whereas
+											`current` is specializing `DATA`.
+										</doc>
+										<field name="temperature" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
+										<field name="voltage" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
+										<field name="current" type="NX_NUMBER" extends="/NXdata/DATA"/>
+									</group>
+								</group>
+							</definition>
+
+							Here, the ``extends`` attribute is used to specify that the ``temperature`` and ``voltage`` fields are specializations
+							of the ``AXISNAME`` field, whereas the ``current`` field is a specialization of the ``DATA`` field.
+
+							Note that the ``extends`` keyword shall only be used in cases where there is an ambiguity in the inheritance, such as
+							the example above. The ``extends`` attribute must not be used when such ambiguity does not exist. Especially, it is
+							not alllowed to specify the ``extends`` attribute for fields that are not part of the inheritance hierarchy.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:attributeGroup ref="nx:nameTypeAttributeGroup"/>
 			</xs:extension>
 		</xs:complexContent>

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -973,34 +973,24 @@ https://stackoverflow.com/a/48980995/1046449 -->
 							in the inheritance. At the moment, this is only the case for the
 							``AXISNAME`` and ``DATA`` fields in ``NXdata``, which are both of
 							type ``NX_NUMBER``. Thus, when specializing ``NXdata`` in an application
-							 definition, the ``extends`` attribute allows to specify whether a field
+							definition, the ``extends`` attribute allows to specify whether a field
 							in the specialized ``NXdata`` is an ``AXISNAME`` and ``DATA``.
 
-							For example, consider the following NXDL snippet:
+							For example, consider the following NXDL snippet::
 
-							.. code-block:: xml
-							    :linenos:
-
-								<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" 
-											xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-											category="application" 
-											name="NXexample" 
-											extends="NXobject" 
-											type="group" 
-											xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
-									<doc>Example application definition.</doc>
-									<group type="NXentry">
-										<group type="NXdata">
-											<doc>
-												This NXdata contains multiple fields. ``temperature`` and ``voltage``
-												specialize ``AXISNAME``, whereas ``current`` specializes ``DATA``.
-											</doc>
-											<field name="temperature" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
-											<field name="voltage" type="NX_NUMBER" extends="/NXdata/AXISNAME"/>
-											<field name="current" type="NX_NUMBER" extends="/NXdata/DATA"/>
-										</group>
-									</group>
-								</definition>
+								&lt;definition xmlns=&quot;http://definition.nexusformat.org/nxdl/3.1&quot; xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot; category=&quot;application&quot; name=&quot;NXexample&quot; extends=&quot;NXobject&quot; type=&quot;group&quot; xsi:schemaLocation=&quot;http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd&quot;&gt;
+									&lt;doc&gt;Example application definition.&lt;/doc&gt;
+									&lt;group type=&quot;NXentry&quot;&gt;
+										&lt;group type=&quot;NXdata&quot;&gt;
+											&lt;doc&gt;
+												This NXdata contains multiple fields. ``temperature`` and ``voltage``specialize ``AXISNAME``, whereas ``current`` specializes ``DATA``.
+											&lt;/doc&gt;
+										&lt;field name=&quot;temperature&quot; type=&quot;NX_NUMBER&quot; extends=&quot;/NXdata/AXISNAME&quot;/&gt;
+										&lt;field name=&quot;voltage&quot; type=&quot;NX_NUMBER&quot; extends=&quot;/NXdata/AXISNAME&quot;/&gt;
+										&lt;field name=&quot;current&quot; type=&quot;NX_NUMBER&quot; extends=&quot;/NXdata/DATA&quot;/&gt;																		 
+										&lt;/group&gt;
+									&lt;/group&gt;
+								&lt;/definition&gt;
 
 							Here, the ``extends`` attribute is used to specify that the ``temperature`` and ``voltage`` fields are specializations
 							of the ``AXISNAME`` field, whereas the ``current`` field is a specialization of the ``DATA`` field.

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -979,8 +979,8 @@ https://stackoverflow.com/a/48980995/1046449 -->
 							For example, consider the following NXDL snippet:
 
 							.. code-block:: xml
-								:linenos:
-								
+							    :linenos:
+
 								<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" 
 											xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 											category="application" 
@@ -988,9 +988,7 @@ https://stackoverflow.com/a/48980995/1046449 -->
 											extends="NXobject" 
 											type="group" 
 											xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
-									<doc>
-										Example application definition.
-									</doc>
+									<doc>Example application definition.</doc>
 									<group type="NXentry">
 										<group type="NXdata">
 											<doc>
@@ -1002,7 +1000,7 @@ https://stackoverflow.com/a/48980995/1046449 -->
 											<field name="current" type="NX_NUMBER" extends="/NXdata/DATA"/>
 										</group>
 									</group>
-								</definition>							
+								</definition>
 
 							Here, the ``extends`` attribute is used to specify that the ``temperature`` and ``voltage`` fields are specializations
 							of the ``AXISNAME`` field, whereas the ``current`` field is a specialization of the ``DATA`` field.


### PR DESCRIPTION
`NXdata` contains two renameable fields, `AXISNAME` and `DATA`, that are both of type `NX_NUMBER`. This naturally presents a problem in that any instance of any of the two must be properly allocated to either of the two concepts.

On the data level, this is not a problem since this can be handled by properly assigning the `@signal`  and `@axes` attributes and thus it is immediately clear which data field belongs to which concept (see [here](https://manual.nexusformat.org/datarules.html#find-plottable-data)).

The problem is however not solved on the **conceptual, data modelling** level, i.e., when writing base classes and application definitions. Consider the following situation (borrowed directly from [contributed_definitions/NXiv_temp](https://manual.nexusformat.org/classes/contributed_definitions/NXiv_temp.html)):
```xml
<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" name="NXiv_temp" extends="NXsensor_scan" type="group" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
    <doc>
         Application definition for temperature-dependent IV curve measurements.
    </doc>
    <group type="NXentry">
        <group type="NXdata">
            <doc>
                 This NXdata contains multiple fields. Temperature and voltage are supposed to specialize `AXISNAME`, whereas 
                 `current` is specializing `DATA`.
            </doc>
            <field name="temperature" type="NX_NUMBER"/>
            <field name="voltage" type="NX_NUMBER"/>
            <field name="current" type="NX_NUMBER"/>
        </group>
    </group>
</definition>
```

Here, we as humans know which field in `/NXiv_temp/NXentry/NXdata` is associated with which field in `NXdata`. However, there is no way for any interpretation tool to automatically understand this. Note that currently the way that each conceptual field is assigned to `AXISNAME` or `DATA` is by doing **namefitting**, i.e., by comparing whether the name of the field more closely resembles "axisname" or "data". For this particular example, this would lead to an assignment (on the conceptual level) of `/NXiv_temp/NXentry/NXdata/current` to `AXISNAME`, whereas `temperature` would be specializing `NXdata/AXISNAME`. See the pop-up link on the bottom of this screenshot, [here](https://fairmat-nfdi.github.io/nexus_definitions/classes/contributed_definitions/NXiv_temp.html#nxiv-temp-entry-data-current-field) we actually visualize which concept `current` is inheriting from.

![image](https://github.com/user-attachments/assets/922351b9-1724-4e44-9e45-04ddae6d81bd)

During file writing with actual data, we will assign `current` to `DATA` by adding it to the `signal`. However, any proper data management system will complain here because what we define on the conceptual level will _not_ be the same as what the data provider will injest.

So what I think is needed is a way to already define on the **data modelling** level which field is an axis and which one is a data field. 

As a fix, we add **an extra attribute `extends` to `fieldType`** where one can explicitly say which field in the inheritance shall be extended. The language is specifically chosen to indicate that this is only possible for the use case outlined above and **not** for any arbitrary case (to prevent people from just extending any arbitrary field defined somewhere else).

**EDIT**: added a rendering in the docs
![image](https://github.com/user-attachments/assets/8525b3c0-4c00-4906-944c-ecae3867d1a9)
This should probably be changed to using the proper link instead.