### PR TITLE
add base class NXcircuit

### DIFF
--- a/base_classes/NXcircuit.nxdl.xml
+++ b/base_classes/NXcircuit.nxdl.xml
@@ -1,0 +1,162 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+#
+# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXcircuit" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <doc>
+             Constant to be used in the definition: the number of channels of the
+             circuit board.
+        </doc>
+        <symbol name="N_channel">
+            <doc>
+                 number of channels of the circuit board.
+            </doc>
+        </symbol>
+    </symbols>
+    <doc>
+         Base class for circuit devices.
+         
+         Electronic circuits are hardware components connecting several electronic components to achieve
+         specific functionality, e.g. amplifying a voltage or convert a voltage to binary numbers, etc.
+    </doc>
+    <group name="hardware" type="NXfabrication">
+        <doc>
+             Hardware where the circuit is implanted; includes information about the hardware manufacturers and
+             type (e.g. part number)
+             All the elements below may be single numbers of an array of values with length N_channel
+             describing multiple input and output channels.
+        </doc>
+    </group>
+    <field name="components">
+        <doc>
+             List of components used in the circuit, e.g., resistors, capacitors, transistors or any
+             other complex components.
+        </doc>
+    </field>
+    <field name="connections">
+        <doc>
+             Description of how components are interconnected, including connection points
+             and wiring.
+        </doc>
+    </field>
+    <field name="power_source">
+        <doc>
+             Details of the power source for the circuit, including voltage and current
+             ratings.
+        </doc>
+    </field>
+    <field name="signal_type">
+        <doc>
+             Type of signal (input signal) the circuit is designed to handle, e.g., analog,
+             digital, mixed-signal.
+        </doc>
+    </field>
+    <!--should this be a min / max range?-->
+    <field name="operating_frequency" type="NX_NUMBER" units="NX_FREQUENCY">
+        <doc>
+             The operating frequency of the circuit, see also bandwidth below, which is possibly
+             centered around this frequency. However, not necessarily (e.g. running a 100 kHz bandwidth
+             amplifier at low, audio frequencies 1 - 20,000 Hz)
+        </doc>
+    </field>
+    <!--we may need an NX_RESISTANCE defined-->
+    <field name="input_impedance" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             Input impedance of the circuit.
+        </doc>
+    </field>
+    <field name="output_impedance" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             Output impedance of the circuit.
+        </doc>
+    </field>
+    <field name="gain" type="NX_NUMBER" units="NX_UNITLESS">
+        <doc>
+             Gain of the circuit, if applicable, usually all instruments have a gain which might be
+             important or not.
+        </doc>
+    </field>
+    <field name="noise_level" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             RMS noise level (in current or voltage) in the circuit in voltage or current.
+        </doc>
+    </field>
+    <field name="bandwidth" type="NX_NUMBER" units="NX_FREQUENCY">
+        <doc>
+             The bandwidth of the frequency response of the circuit.
+        </doc>
+    </field>
+    <field name="temperature_range" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             Operating temperature range of the circuit.
+        </doc>
+    </field>
+    <group name="calibration" type="NXcalibration">
+        <doc>
+             Calibration data for the circuit.
+        </doc>
+    </group>
+    <field name="offset" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             Offset value for current or voltage.
+        </doc>
+    </field>
+    <field name="output_channels" type="NX_NUMBER">
+        <doc>
+             Number of output channels collected to this circuit. Most probably N_channel.
+        </doc>
+    </field>
+    <field name="output_signal" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             Type of output signal, e.g., voltage, current, digital.
+        </doc>
+    </field>
+    <field name="power_consumption" type="NX_NUMBER" units="NX_ANY">
+        <doc>
+             Power consumption of the circuit per unit time.
+        </doc>
+    </field>
+    <field name="status_indicators">
+        <doc>
+             Status indicators for the circuit, e.g., LEDs, display readouts.
+        </doc>
+    </field>
+    <field name="protection_features" type="NX_CHAR">
+        <doc>
+             Protection features built into the circuit, e.g., overvoltage protection,
+             thermal shutdown.
+        </doc>
+    </field>
+    <field name="acquisition_time" type="NX_NUMBER" units="NX_TIME">
+        <doc>
+             Updated rate for several processes using the input signal, e.g., History Graph, the circuit
+             uses for any such process.
+        </doc>
+    </field>
+    <field name="output_slew_rate" type="NX_CHAR">
+        <doc>
+             The rate at which the signal changes when ramping from the starting
+             value.
+        </doc>
+    </field>
+</definition>


### PR DESCRIPTION
`NXcircuit` is a base class for electronic circuit devices. We imagine it to be quite useful in classes where the actual implementation of the electronic circuit is of great importance for the measurements, e.g. for scanning probe microscopy or for certain electron detectors. 

Since  `NXcircuit`  is supposed to be used in many places, it was planned to be part of `NXcomponent`. It was requested that it be removed from #1525, so it is readded here.

Should be listed within `NXcomponent` once #1525 has been approved.