### PR TITLE
NXmx: make NXdetector_channel optional

### DIFF
--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -809,7 +809,7 @@
                         </doc>
                     </field>
 
-                    <group name="CHANNELNAME_channel" type="NXdetector_channel">
+                    <group name="CHANNELNAME_channel" type="NXdetector_channel" optional="true">
                         <doc>
                             Group containing the description and metadata for a single channel from a multi-channel
                             detector.


### PR DESCRIPTION
Fixes #1511

The vibe from the telco where this was discussed was that this doesn't need a vote since it's a bugfix.