### PR TITLE
update ci.yaml to use actions/upload-artifact@v4, black format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload the User Manual and the Impatient Guide
         if: ${{ github.event.inputs.upload && env.python_version == env.python_deploy_version }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nexus-definitions-docs
           path: build/html

--- a/dev_tools/tests/test_nxdl_utils.py
+++ b/dev_tools/tests/test_nxdl_utils.py
@@ -1,6 +1,4 @@
-"""This is a code that performs several tests on nexus tool
-
-"""
+"""This is a code that performs several tests on nexus tool"""
 
 from pathlib import Path
 


### PR DESCRIPTION
`actions/upload-artifact@v3` is [deprecated as of Jan 30](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This updates to v4.

@PeterC-DLS would you be able to review this? All builds in the other branches are failing because of the deprecation.

This PR also contains a change to `dev_tools/tests/test_nxdl_utils.py` that comes from using a newer version of black (as black is not pinned in this repo).