### PR TITLE
Bug fix: `NXcomponent` notation in `NXsample_component`

### DIFF
--- a/base_classes/NXsample_component.nxdl.xml
+++ b/base_classes/NXsample_component.nxdl.xml
@@ -25,7 +25,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	name="NXsample_component" 
-	type="group" extends="Nxcomponent"
+	type="group" extends="NXcomponent"
 	>
 
 	<symbols>


### PR DESCRIPTION
This is a fix for a bug introduced in #1525.  `NXsample_component` extends `NXcomponent`, but the notation was wrong (`Nx` instead of `NX`). Should be an easy merge with no vote needed.

I also did a `git grep`, this is the only place where this shows up.