### PR TITLE
`nameType="partial"` fixes for some base classes

### DIFF
--- a/base_classes/NXcalibration.nxdl.xml
+++ b/base_classes/NXcalibration.nxdl.xml
@@ -169,7 +169,7 @@
              :ref:`/NXdata/FIELDNAME_offset &lt;/NXdata/FIELDNAME_offset-field&gt;`.
         </doc>
     </field>
-    <field name="mapping_MAPPING" type="NX_FLOAT">
+    <field name="mapping_MAPPING" nameType="partial" type="NX_FLOAT" >
         <doc>
              Mapping data for calibration.
              

--- a/base_classes/NXhistory.nxdl.xml
+++ b/base_classes/NXhistory.nxdl.xml
@@ -33,7 +33,7 @@
              Any activity that was performed on the physical entity prior or during the experiment.
         </doc>
     </group>
-    <attribute name="identifierNAME">
+    <attribute name="identifierNAME" nameType="partial">
         <doc>
              An ID or reference to the location or a unique (globally
              persistent) identifier of e.g. another file which gives

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -184,7 +184,7 @@
 			</doc>
 		</attribute>
 	</field>
-	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="any" type="NX_NUMBER" minOccurs="0" maxOccurs="unbounded">
+	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="partial" type="NX_NUMBER" minOccurs="0" maxOccurs="unbounded">
 		<doc>
 			``AXISNAME_end`` is a placeholder for a name constructed from the actual
 			name of an axis to which ``_end`` has been appended.
@@ -193,7 +193,7 @@
 			at the corresponding positions given in the ``AXISNAME`` field.
 		</doc>
 	</field>
-	<field name="AXISNAME_increment_set" units="NX_TRANSFORMATION"  nameType="any" type="NX_NUMBER" minOccurs="0">
+	<field name="AXISNAME_increment_set" units="NX_TRANSFORMATION"  nameType="partial" type="NX_NUMBER" minOccurs="0">
 		<doc>
 			``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
 			name of an axis to which ``_increment_set`` has been appended.


### PR DESCRIPTION
Fixes the `nameType`  for four different concepts:
- NXtransformations/AXISNAME_end -> was nameType="any", should be nameType="partial"
- NXtransformations/AXISNAME_increment -> was nameType="any", should be nameType="partial"
- NXhistory/identifierName -> has no nameType, should be nameType="partial"
- NXcalibration/identifierName -> has no nameType, should be nameType="partial"

For the fields in NXtransformations, this was probably a copy-paste error. For NXhistory and NXcalibration, which were recently added by me, it was simply forgotten to add the `nameType`. 