### PR TITLE
Fix typo in NXdetector.nxdl.xml

### DIFF
--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -719,7 +719,7 @@
       recording the different measurements preserves the chronological order with is important for
       correct processing.
 
-      This is used for example in tomography (`:ref:`NXtomo`) sample projections,
+      This is used for example in tomography (:ref:`NXtomo`) sample projections,
       dark and flat images, a magic number is recorded per frame.
 
       The key is as follows:


### PR DESCRIPTION
Typo that breaks the link to NXtomo in the doc