### PR TITLE
add `target` attribute to `NXobject` using new field super-type

### DIFF
--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -97,7 +97,7 @@
     </field>
     <attribute name="target" type="NX_CHAR">
 		<doc>
-			This attribute can be used to describe that this field is connected to another field.
+			This attribute can be used to describe that this group is connected to another group.
 			For links, this must be set to the path of the target of the link.
 
 			See :ref:`FIELDNAME/@target &lt;//NXobject/FIELDNAME@target-attribute&gt;` for more information

--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -64,6 +64,46 @@
             Boolean mask of FIELDNAME values. The value is masked if set to 1.
         </doc>
     </field>
+    <field name="FIELDNAME" type="NX_DTYPE" minOccurs="0">
+        <doc>
+            This is a generic field that defines the attributes that all fields can have.
+        </doc>
+        <attribute name="target" type="NX_CHAR">
+            <doc>
+                This attribute can be used to describe that this field is connected to another field.
+                For links, this must be set to the path of the target of the link.
+
+                Declares the absolute path of an existing field or group.
+
+                Matching regular expression::
+
+                    (/[a-zA-Z_][\w_]*(:[a-zA-Z_][\w_]*)?)+
+
+                For example, given a ``/entry/instrument/detector/polar_angle`` field which is to be
+                connected/linked to /entry/data/polar_angle`` in an ``NXdata`` group, this would be the
+                NeXus data file structure::
+
+                    /: NeXus data file
+                        /entry:NXentry
+                            /data:NXdata
+                                /polar_angle:NX_NUMBER
+                                    @target="/entry/instrument/detector/polar_angle"
+                            /instrument:NXinstrument
+                                /detector:NXdetector
+                                    /polar_angle:NX_NUMBER
+                                        @target="/entry/instrument/detector/polar_angle"
+            </doc>
+        </attribute>
+    </field>
+    <attribute name="target" type="NX_CHAR">
+		<doc>
+			This attribute can be used to describe that this field is connected to another field.
+			For links, this must be set to the path of the target of the link.
+
+			See :ref:`FIELDNAME/@target &lt;//NXobject/FIELDNAME@target-attribute&gt;` for more information
+			how to use this attribute.
+		</doc>
+	</attribute>
 	<field name="identifierNAME" type="NX_CHAR" nameType="partial">
 		<doc>
 			An identifier for a (persistent) resource.

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -454,6 +454,7 @@
 			<xs:documentation>any valid NeXus field or attribute type</xs:documentation>
 		</xs:annotation>
 		<xs:union memberTypes="
+			nxdl:NX_DTYPE
 			nxdl:ISO8601
 			nxdl:NX_BINARY
 			nxdl:NX_BOOLEAN
@@ -472,6 +473,31 @@
 			"/>
 	</xs:simpleType>
 	
+	<xs:simpleType name="NX_DTYPE">
+		<xs:annotation>
+			<xs:documentation>
+			    The union of all nxdl types. To be used if the type cannot be defined.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:union memberTypes="
+			nxdl:ISO8601
+			nxdl:NX_BINARY
+			nxdl:NX_BOOLEAN
+			nxdl:NX_CCOMPLEX
+			nxdl:NX_CHAR
+			nxdl:NX_COMPLEX
+			nxdl:NX_DATE_TIME
+			nxdl:NX_FLOAT
+			nxdl:NX_INT
+			nxdl:NX_NUMBER
+			nxdl:NX_PCOMPLEX
+			nxdl:NX_POSINT
+			nxdl:NX_QUATERNION
+			nxdl:NX_UINT
+			nxdl:NX_CHAR_OR_NUMBER
+			" />
+	</xs:simpleType>
+
 	<xs:simpleType name="NX_CHAR">
 		<xs:annotation>
 			<xs:documentation>


### PR DESCRIPTION
Follow up to #1410.

This is an initial draft for how attributes that are always allowed could be added. The idea is that a new generic field (with the new super-dtype `NX_DTYPE`) is added to `NXobject` that contains these default attributes.

For now, only the attribute `@target` was added (see comparable discussion in #1410).

In general, I believe the issue is a bit bigger. The `nxdl.xsd` file [defines](https://github.com/nexusformat/definitions/blob/main/nxdl.xsd#L692) multiple `<xs:attribute>` for the `fieldType` (like `units`, `long_name`, `signal`). However, some of these are used as XML attributes (i.e., writing something like 
```
<field name="my_field" type="NX_NUMBER" units=NX_ANY"/>
```
Then again, some other of these attributes are (to my understanding) to be used like this 
```
<field name="my_field">
    <attribute name="long_name"/> # same for axes, signal, primary, etc.
</field>
```

This may be due to me misunderstanding XML design, but I think with the definitions in the nxdl.xd file only the first use case (as XML attributes) is defined, whereas the second use case is not. To illustrate, this passes the schema validation:
```
<field name="my_field" long_name="a_longer_name" primary=0 signal=1</field>
```
I think this is not intended and rather these attributes should be defined somewhere else as attributes that each field can have. The mechanism given in this PR using a generic field in `NXobject` would be one way to define these.
