### PR TITLE
Update NXprocess documentation

### DIFF
--- a/base_classes/NXprocess.nxdl.xml
+++ b/base_classes/NXprocess.nxdl.xml
@@ -58,4 +58,14 @@
             The name will be numbered to allow for ordering of steps.
         </doc>
     </group>
+    <group type="NXparameters">
+        <doc>
+            Parameters used in performing the data analysis.
+        </doc>
+    </group>
+    <group type="NXdata">
+        <doc>
+            The data resulting from the operation.
+        </doc>
+    </group>
 </definition>

--- a/base_classes/NXprocess.nxdl.xml
+++ b/base_classes/NXprocess.nxdl.xml
@@ -26,7 +26,12 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     name="NXprocess" 
 	type="group" extends="NXobject">
-    <doc>Document an event of data processing, reconstruction, or analysis for this data.</doc>
+    <doc>
+        The :ref:`NXprocess` class describes an operation used to
+        process data as part of an analysis workflow, providing
+        information such as the software used, the date of the
+        operation, the input parameters, and the resulting data. 
+    </doc>
     <field name="program" type="NX_CHAR">
         <doc>Name of the program used</doc>
     </field>

--- a/base_classes/NXprocess.nxdl.xml
+++ b/base_classes/NXprocess.nxdl.xml
@@ -37,8 +37,8 @@
     </field>
     <field name="sequence_index" type="NX_POSINT">
         <doc>
-            Sequence index of processing, 
-            for determining the order of multiple **NXprocess** steps.  
+            Sequence index of processing, for determining the order of
+            multiple **NXprocess** steps.  
             Starts with 1.
         </doc>
     </field>
@@ -50,10 +50,10 @@
     </field>
     <group type="NXnote">
         <doc>
-            The note will contain information about how the data was processed
-            or anything about the data provenance. 
-            The contents of the note can be anything that the processing code 
-            can understand, or simple text.
+            The note will contain information about how the data was
+            processed or anything about the data provenance. The
+            contents of the note can be anything that the processing
+            code can understand, or simple text.
             
             The name will be numbered to allow for ordering of steps.
         </doc>


### PR DESCRIPTION
A NIAC Telco discussion indicated that it was common practice to store the results of data analysis within the NXprocess group describing the operation. On reflection, I believe that this is a very valuable way of storing processed data, although I haven't used NXprocess groups in this way before. There are many advantages to encapsulating both the description of the process (program name, data, input parameters) with the resulting data.

This PR does not change anything substantively. It modifies the base class documentation to make this usage more evident to non-specialists and explicity adds NXparameter and NXdata groups to store input parameters and the resulting data. Strictly speaking, both these group additions are redundant because their base classes have been added to the NXobject base class and are therefore already allowed. However, I think it is useful to add them here to show typical ways in which NXprocess groups are structured. As with groups in all base classes, their actual inclusion in a NeXus file is optional, unless an application definition explicitly requires them.