### PR TITLE
Update NXparameter documentation

### DIFF
--- a/base_classes/NXparameters.nxdl.xml
+++ b/base_classes/NXparameters.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -26,11 +26,74 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     name="NXparameters" 
 	type="group" extends="NXobject">
-    <doc>Container for parameters, usually used in processing or analysis.</doc>
+    <doc>
+        Container for parameters used in processing or analysing data.
+
+        This base class can be used in a number of different contexts,
+        and is allowed in any other base class. However, a common use
+        case is to store the results of optimizing parameters, for
+        example, by least-squares fitting, so a number of attributes
+        have been defined for this purpose. Normally, this group will be
+        stored in a :ref:NXprocess group, which defines the program used
+        to process these parameters. If multiple functions are used to
+        analyze the data, there can be additional NXparameter groups for
+        each one.        
+    </doc>
+    <attribute name="model">
+        <doc>
+            The name of the model used in optimizing the data. Fitting
+            packages such as LMFIT (https://lmfit.github.io/lmfit-py/)
+            provide models, which instantiate functions to be fitted to
+            the data. If this attribute is provided, it is assumed that
+            all the parameters in this group are associated with this
+            model.
+        </doc>
+    </attribue>
     <field name="TERM" minOccurs="0" maxOccurs="unbounded" nameType="any">
-        <!-- maxOccurs="unbounded" is intended but is not allowed by current syntax -->
-        <doc>A parameter (also known as a term) that is used in or results from processing.</doc>
-        <attribute name="units"/>
+        <doc>
+            A parameter (also known as a term) that is used in or
+            results from processing. 
+        </doc>
+        <attribute name="units" />
+        <attribute name="error" type=NX_NUMBER>
+            <doc>
+                The standard deviation resulting from data optimization.
+            </doc>
+        </attribute>
+        <attribute name="expression">
+            <doc>
+                A string representing an expression that can be used to
+                relate the parameter to another parameter's value. The
+                format of this string is dependent on the program used
+                to optimize the parameters and is not specified by
+                NeXus.
+            </doc>
+        </attribute>
+        <attribute name="initial_value" type=NX_NUMBER>
+            <doc>
+                The initial value of the parameter.
+            </doc>
+        </attribute>
+        <attribute name="max" type=NX_NUMBER>
+            <doc>
+                The upper bound of the parameter value.
+            </doc>
+        </attribute>
+        <attribute name="min" type=NX_NUMBER>
+            <doc>
+                The lower bound of the parameter value.
+            </doc>
+        </attribute>
+        <attribute name="vary" type=NX_BOOLEAN>
+            <doc>
+                True if the parameter was varied in the fitting
+                procedure.
+            </doc>
+            <enumeration>
+                <item value=True />
+                <item value=False />
+            </enumeration
+        </attribute>
     </field>
 </definition>
 


### PR DESCRIPTION
The name of this base class suggests that it would be the ideal repository to store the results of any parameter optimization, such as least-squares fitting. To facilitate its use in this context, it is helpful to standardize a number of attributes for each parameter, which are common to most, if not all, optimizaiton procedures. For a number of years, NeXpy has been using NXparameter groups to define the parameters for a specific function, such as a Gaussian, in conjunction with the LMFIT package (https://lmfit.github.io/lmfit-py/), which calls them "models." If multiple functions are fitted simulaneously to a data set, multiple NXparameter groups are stored in a NXprocess group, which also defines the program used to produce the optimization.

An example of a NXparameter group is given here:
```
fit:NXprocess
  parameters:NXparameters
    @model = 'Lorentzian'
    amplitude = 1301.0084322223488
      @error = 83.04682658748045
      @initial_value = 1918.64
      @max = 'inf'
      @min = '-inf'
      @vary = True
   center = 109.90841596329723
      @error = 0.151393986221809
      @initial_value = 109.5
      @max = 'inf'
      @min = '-inf'
      @vary = True
.
.
.
```
The purpose of this PR is not to confine NXparameter groups to this particular use case, but to standardize the attributes when it applies. Others are welcome to suggest other uses of this group.

Until now, the NXparameter group has been an empty container, so I don't think this PR changes the standard in any substantive way - it just expands the documentation - so I don't believe a NIAC vote is required. However, it is probably still worth discussion at a Telco to get feedback.
