### PR TITLE
Add NXgoniometer base class

### DIFF
--- a/base_classes/NXgoniometer.nxdl.xml
+++ b/base_classes/NXgoniometer.nxdl.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="nxdlformat.xsl" ?>
+<!--
+# NeXus - Neutron and X-ray Common Data Format
+# 
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# For further information, see http://www.nexusformat.org
+-->
+<definition xmlns="http://definition.nexusformat.org/nxdl/3.1" category="base"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
+	name="NXgoniometer" 
+	type="group" extends="NXobject"
+	>
+
+	<doc>
+		Goniometer angles used during a measurement. The goniometers
+		used at neutron and x-ray facilities are typically four-circle
+		or six-circle goniometers, or variants of either one. There are
+		a number of conventions defining the names of these angles, so
+		the group should contain a :ref:`NXcite` group, which provides
+		links relevant to this goniometer.
+	</doc>
+
+    <group name="convention" type="NXcite" >
+        <doc>
+            A reference to a publication or online documentation that
+            describe the convention used in this group to define the
+            names of angles.
+        </doc>
+    </group>
+    <field name="goniometer">
+        <doc>
+            The common name for the type of goniometer used in these
+            measurements.
+        </doc>
+    </field>
+	<field name="chi" type="NX_FLOAT" units="NX_ANGLE" />
+	<field name="omega" type="NX_FLOAT" units="NX_ANGLE" />
+	<field name="phi" type="NX_FLOAT" units="NX_ANGLE" />
+	<field name="theta" type="NX_FLOAT" units="NX_ANGLE" />
+	<field name="xs" type="NX_FLOAT" units="NX_LENGTH">
+        <doc>
+            The translation of the sample from the center of rotation
+            along the x-axis defined by the local coordinate system.
+        </doc>
+    </field>
+	<field name="ys" type="NX_FLOAT" units="NX_LENGTH">
+        <doc>
+            The translation of the sample from the center of rotation
+            along the y-axis defined by the local coordinate system.
+        </doc>
+    </field>
+	<field name="zs" type="NX_FLOAT" units="NX_LENGTH">
+        <doc>
+            The translation of the sample from the center of rotation
+            along the z-axis defined by the local coordinate system.
+        </doc>
+    </field>
+
+</definition>

--- a/base_classes/NXgoniometer.nxdl.xml
+++ b/base_classes/NXgoniometer.nxdl.xml
@@ -29,19 +29,27 @@
 	>
 
 	<doc>
-		Goniometer angles used during a measurement. The goniometers
-		used at neutron and x-ray facilities are typically four-circle
-		or six-circle goniometers, or variants of either one. There are
-		a number of conventions defining the names of these angles, so
-		the group should contain a :ref:`NXcite` group, which provides
-		links relevant to this goniometer.
+		Goniometer rotation angles and sample translations used during a
+		measurement. The goniometers used at neutron and x-ray
+		facilities are typically four-circle or six-circle goniometers,
+		or variants of either one. There is no universally recognized
+		naming convention for angles and translations, so the group
+		should contain a :ref:`NXcite` group, which describes how the
+		angles are defined.
 	</doc>
 
-    <group name="convention" type="NXcite" >
+    <group name="convention" type="NXcite">
         <doc>
             A reference to a publication or online documentation that
             describe the convention used in this group to define the
-            names of angles.
+            names of angles and sample translations.
+        </doc>
+    </group>
+    <group type="NXcoordinate_system">
+        <doc>
+            The coordinate system used by the translation fields. This
+            group should be present if these fields do not use the
+            default NeXus Coordinate System.
         </doc>
     </group>
     <field name="goniometer">

--- a/base_classes/NXgoniometer.nxdl.xml
+++ b/base_classes/NXgoniometer.nxdl.xml
@@ -50,27 +50,17 @@
             measurements.
         </doc>
     </field>
-	<field name="chi" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="omega" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="phi" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="theta" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="xs" type="NX_FLOAT" units="NX_LENGTH">
+	<field name="ROTATION_ANGLE" type="NX_FLOAT" units="NX_ANGLE" nameType="any">
         <doc>
-            The translation of the sample from the center of rotation
-            along the x-axis defined by the local coordinate system.
+            One of the goniometer rotation angles defined by the
+            specified convention.
         </doc>
     </field>
-	<field name="ys" type="NX_FLOAT" units="NX_LENGTH">
-        <doc>
-            The translation of the sample from the center of rotation
-            along the y-axis defined by the local coordinate system.
-        </doc>
-    </field>
-	<field name="zs" type="NX_FLOAT" units="NX_LENGTH">
-        <doc>
-            The translation of the sample from the center of rotation
-            along the z-axis defined by the local coordinate system.
-        </doc>
-    </field>
+    <field name="SAMPLE_TRANSLATION" type="NX_FLOAT" units="NX_LENGTH" nameType="any">
+    <doc>
+        The translation of the sample from the centre of rotation of the
+        goniometer angles along one of the coordinate axes.
+    </doc>
+</field>
 
 </definition>


### PR DESCRIPTION
This PR adds a new base class that allows the goniometer angles used in a (usually single crystal) measurement to be defined according to a variety of naming conventions defined by an NXcite group. This group is used unofficially in the NXRefine package used for reducing single crystal diffuse scattering (https://nexpy.github.io/nxrefine). In recent years, the NeXus convention has been to define a set of NXtransformations that obviate the need to define the meaning of such angles. This has the advantate that there is no universally accepted standard for naming goniometer angles. However, there are two disadvantages to this approach:

1. It is less intuitive for the user to check these angles against their own records of the experiment.
2. It assumes that the transformations defined in the file are the correct ones.

As an example of the second problem, in NXRefine, we discovered that out initial assumptions about the chain of transformation matrices was incorrect because the detector was decoupled from any two-theta arm. In stable experimental configurations, the transformation approach should work, but when experimenting with different goniometer and detector configurations, as well as different data reduction procedures, there are advantages in simply storing the angles as recorded by the beamline motors.

As a new base class, this requires formal approval by the NIAC.

