### PR TITLE
Remove extraneous transformation type attributes from beam directions

### DIFF
--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -370,16 +370,12 @@
             Direction (and location) for the beam. The location of the beam can be given by
             any point which it passes through as its offset attribute.
         </doc>
-        <field name="DIRECTION" nameType="any" units="NX_TRANSFORMATION" type="NX_NUMBER">
+        <field name="BEAMdirection" nameType="partial" units="NX_UNITLESS" type="NX_NUMBER">
             <doc>
                 Direction of beam vector, its value is ignored. If missing, then the beam direction is defined as [0,0,1]
-                and passes through the origin
+                and passes through the origin. Note, this field should be referenced by the parent group's ``depends_on`` field; also,
+                as this field is a direction, its ``transformation_type`` attribute should be omitted.
             </doc>
-            <attribute name="transformation_type">
-                <enumeration>
-                    <item value="translation" />
-                </enumeration>
-            </attribute>
             <attribute name="vector" type="NX_NUMBER">
                 <doc>
                     Three values that define the direction of beam vector
@@ -397,25 +393,16 @@
                 </doc>
             </attribute>
         </field>
-        <field name="reference_plane" units="NX_TRANSFORMATION" type="NX_NUMBER">
+        <field name="reference_plane" units="NX_UNITLESS" type="NX_NUMBER">
             <doc>
                 Direction of normal to reference plane used to measure azimuth relative to the beam, its value is ignored.
                 This also defines the parallel and perpendicular components of the beam's polarization.
-                If missing, then the reference plane normal is defined as [0,1,0] and passes through the origin
+                If missing, then the reference plane normal is defined as [0,1,0].
+                Note, as this field is a direction, its ``transformation_type`` attribute should be omitted.
             </doc>
-            <attribute name="transformation_type">
-                <enumeration>
-                    <item value="translation" />
-                </enumeration>
-            </attribute>
             <attribute name="vector" type="NX_NUMBER">
                 <doc>
                     Three values that define the direction of reference plane normal
-                </doc>
-            </attribute>
-            <attribute name="offset" type="NX_NUMBER">
-                <doc>
-                    Not required as beam direction offset locates the plane
                 </doc>
             </attribute>
             <attribute name="depends_on" type="NX_CHAR">


### PR DESCRIPTION
Also add note on beam direction being referenced by a depends_on