### PR TITLE
Clarify the conventions for rotations in left and right handed coordinate system

### DIFF
--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -166,13 +166,13 @@
 				
 				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 
 				  left-hand grip rule). In a left-handed coordinate system, positive rotation about an
-				  axis is counter-clockwise when looking from the origin in the direction of the 
-				  positive axis (from the origin towards infinity).
+				  axis is clockwise when looking from the from the end of the positive axis towards
+				  its origin (from infinity towards the origin).
 				
 				* Rotations in right-handed coordinate systems are right-handed (i.e., they follow the 
 				  right-hand grip rule). In a right-handed coordinate system, positive rotation about an
-				  axis is clockwise when looking from the origin in the direction of the 
-				  positive axis (from the origin towards infinity).
+				  axis is counter-clockwise when looking from the from the end of the positive axis towards
+				  its origin (from infinity towards the origin).
 
 				Note that by using this convention, the transformation matrices in both left- and
 				right-handed coordinate systems are the same.

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -156,9 +156,11 @@
 				increasing displacement. For general axes, an appropriate direction
 				should be chosen.
 
-				Note that if the ``NXtransformation`` depends on a coordinate system
-				(i.e., its ``depends_on`` attribute points to an instance :ref:`NXcoordinate_system`),
-				for ``rotation`` axes, the rotation convention is the same as the handedness
+				By default, for ``rotation`` axes that do not explicitly depend on a coordinate system,
+				the direction should be chosen for a right-handed rotation with increasing angle.
+				If the ``NXtransformation`` depends on a coordinate system (i.e., its ``depends_on`` 
+				attribute (or a ``depends_on`` further up the transformation chain) points to an instance
+				:ref:`NXcoordinate_system`), the rotation convention is the same as the handedness
 				of the coordinate system (as defined by the determinant of its base vectors):
 				
 				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 
@@ -173,9 +175,6 @@
 
 				Note that by using this convention, the transformation matrices in both left- and
 				right-handed coordinate systems are the same.
-
-				By default, ``rotation`` axes that do not explicitly depend on a coordinate system,
-				the direction should be chosen for a right-handed rotation with increasing angle.
 			</doc>
 			<dimensions rank="1">
 				<dim index="1" value="3" />

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -163,12 +163,12 @@
 				
 				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 
 				  left-hand grip rule). In a left-handed coordinate system, positive rotation about an
-				  axis is clockwise when looking from the origin in the direction of the 
+				  axis is counter-clockwise when looking from the origin in the direction of the 
 				  positive axis (from the origin towards infinity).
 				
 				* Rotations in right-handed coordinate systems are right-handed (i.e., they follow the 
 				  right-hand grip rule). In a right-handed coordinate system, positive rotation about an
-				  axis is counter-clockwise when looking from the origin in the direction of the 
+				  axis is clockwise when looking from the origin in the direction of the 
 				  positive axis (from the origin towards infinity).
 
 				Note that by using this convention, the transformation matrices in both left- and

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -157,7 +157,8 @@
 				should be chosen.
 
 				By default, for ``rotation`` axes that do not explicitly depend on a coordinate system,
-				the direction should be chosen for a right-handed rotation with increasing angle.
+				the direction should be chosen for a right-handed rotation with increasing angle. Note,
+				McStas is a right handed coordinate system.
 
 				If the ``NXtransformation`` depends on a coordinate system (i.e., its ``depends_on`` 
 				attribute (or a ``depends_on`` further up the transformation chain) points to an instance

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -151,16 +151,31 @@
 			<doc>
 				Three values that define the axis for this transformation.
 				The axis should be normalized to unit length, making it
-				dimensionless.  For ``rotation`` axes, the direction should be
-				chosen for a right-handed rotation with increasing angle.
+				dimensionless.
 				For ``translation`` axes the direction should be chosen for
 				increasing displacement. For general axes, an appropriate direction
 				should be chosen.
 
 				Note that if the ``NXtransformation`` depends on a coordinate system
 				(i.e., its ``depends_on`` attribute points to an instance :ref:`NXcoordinate_system`),
-				the rotation is right handed in that coordinate system, even if the the coordinate system
-				itself is left-handed (as defined by the determinant of its base vectors).
+				for ``rotation`` axes, the rotation convention is the same as the handedness
+				of the coordinate system (as defined by the determinant of its base vectors):
+				
+				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 
+				  left-hand rule). In a left-handed coordinate system, positive rotation about an
+				  axis is clockwise when looking from the origin in the direction of the 
+				  positive axis (from the origin towards infinity).
+				
+				* Rotations in right-handed coordinate systems are right-handed (i.e., they follow the 
+				  right-hand rule). In a right-handed coordinate system, positive rotation about an
+				  axis is counter-clockwise when looking from the origin in the direction of the 
+				  positive axis (from the origin towards infinity).
+
+				Note that by using this convention, the transformation matrices in both left- and
+				right-handed coordinate systems are the same.
+
+				By default, ``rotation`` axes that do not explicitly depend on a coordinate system,
+				the direction should be chosen for a right-handed rotation with increasing angle.
 			</doc>
 			<dimensions rank="1">
 				<dim index="1" value="3" />

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -161,7 +161,7 @@
 
 				If the ``NXtransformation`` depends on a coordinate system (i.e., its ``depends_on`` 
 				attribute (or a ``depends_on`` further up the transformation chain) points to an instance
-				:ref:`NXcoordinate_system`), the rotation convention is the same as the handedness
+				of :ref:`NXcoordinate_system`), the rotation convention is the same as the handedness
 				of the coordinate system (as defined by the determinant of its base vectors):
 				
 				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -162,12 +162,12 @@
 				of the coordinate system (as defined by the determinant of its base vectors):
 				
 				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 
-				  left-hand rule). In a left-handed coordinate system, positive rotation about an
+				  left-hand grip rule). In a left-handed coordinate system, positive rotation about an
 				  axis is clockwise when looking from the origin in the direction of the 
 				  positive axis (from the origin towards infinity).
 				
 				* Rotations in right-handed coordinate systems are right-handed (i.e., they follow the 
-				  right-hand rule). In a right-handed coordinate system, positive rotation about an
+				  right-hand grip rule). In a right-handed coordinate system, positive rotation about an
 				  axis is counter-clockwise when looking from the origin in the direction of the 
 				  positive axis (from the origin towards infinity).
 

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -95,7 +95,7 @@
 		group is equally possible.
 
 
-		Following the section on the general dscription of axis in NXtransformations is a section which
+		Following the section on the general description of axis in NXtransformations is a section which
 		documents the fields commonly used within NeXus for positioning purposes and their meaning. Whenever
 		there is a need for positioning a beam line component please use the existing names. Use as many fields
 		as needed in order to position the component. Feel free to add more axis if required. In the description
@@ -111,7 +111,7 @@
 
 		NOTE
 
-		NXtransformations follows the **active** transformation convention. This means that the transformation describes
+		``NXtransformations`` follows the **active** transformation convention. This means that the transformation describes
 		how an object is moved or rotated within the coordinate system. In other words, the transformation
 		actively changes the position or orientation of the object itself. This is in contrast to a **passive** transformation,
 		which changes the frame of reference or coordinate system, while the object remains fixed. In case it is needed 
@@ -136,7 +136,7 @@
 				in which case the values are angular rotations around the axis.
 
 				If this attribute is omitted, this is an axis for which there
-				is no motion to be specifies, such as the direction of gravity,
+				is no motion to be specified, such as the direction of gravity,
 				or the direction to the source, or a basis vector of a
 				coordinate frame. In this case the value of the ``AXISNAME`` field
 				is not used and can be set to the number ``NaN``.
@@ -158,6 +158,7 @@
 
 				By default, for ``rotation`` axes that do not explicitly depend on a coordinate system,
 				the direction should be chosen for a right-handed rotation with increasing angle.
+
 				If the ``NXtransformation`` depends on a coordinate system (i.e., its ``depends_on`` 
 				attribute (or a ``depends_on`` further up the transformation chain) points to an instance
 				:ref:`NXcoordinate_system`), the rotation convention is the same as the handedness

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -166,12 +166,12 @@
 				
 				* Rotations in left-handed coordinate systems are left-handed (i.e., they follow the 
 				  left-hand grip rule). In a left-handed coordinate system, positive rotation about an
-				  axis is clockwise when looking from the from the end of the positive axis towards
+				  axis is clockwise when looking from a point on the positive axis towards
 				  its origin (from infinity towards the origin).
 				
 				* Rotations in right-handed coordinate systems are right-handed (i.e., they follow the 
 				  right-hand grip rule). In a right-handed coordinate system, positive rotation about an
-				  axis is counter-clockwise when looking from the from the end of the positive axis towards
+				  axis is counter-clockwise when looking from a point on the positive axis towards
 				  its origin (from infinity towards the origin).
 
 				Note that by using this convention, the transformation matrices in both left- and


### PR DESCRIPTION
There was a long-ish [discussion](https://github.com/nexusformat/definitions/pull/1415#discussion_r2075856637) in #1415 about which rotation convention to apply for left- and right-handed coordinate systems. Initially, it was agreed that if the `NXtransformation` depends on a coordinate system (i.e., its ``depends_on`` attribute points to an instance `NXcoordinate_system`), the rotation is **always** right handed in that coordinate system, even if the the coordinate system itself is left-handed (as defined by the determinant of its base vectors.

@PeterC-DLS suggested that this should not be the case. Rather, the rotation conventions **should** follow the handedness of the coordinate system because then the matrices don't have to be changed. So:

- Rotations in left-handed coordinate systems are left-handed (i.e., they follow the left-hand rule). In a left-handed coordinate system, positive rotation about an axis is clockwise when looking from the end of the positive axis in the direction of the origin (from infinity towards the origin).

- Rotations in right-handed coordinate systems are right-handed (i.e., the follow the right-hand rule). In a right-handed coordinate system, positive rotation about an axis is counter-clockwise when looking from the end of the positive axis in the direction of the origin (from infinity towards the origin).

Most importantly, the matrix transformation does not depend on handness and the same matrices can be used for left- and right-handed coordinate system (same Rodrigues' formula). Only the **interpretation** (“positive” direction of rotation) is different because the coordinate systems are mirror images! This will it also easier for most existing tools around ``NXtransformations``  to work with left-handed coordinate systems.

This is also the convention that most graphic packages and math/physics textbooks follow, from what I could gather.

I am not sure if a vote is needed for these documentation changes, but they should definitely be discussed.