### PR TITLE
[Bug fix] Units in `NXxps/NXbeam/beam_direction`

### DIFF
--- a/applications/NXxps.nxdl.xml
+++ b/applications/NXxps.nxdl.xml
@@ -147,7 +147,7 @@
                     </doc>
                 </field>
                 <group name="transformations" type="NXtransformations" recommended="true">
-                    <field name="beam_direction" type="NX_NUMBER" units="NX_TRANSFORMATION">
+                    <field name="beam_direction" type="NX_NUMBER" units="NX_UNITLESS">
                         <doc>
                             Beam direction in the XPS coordinate system after rotation.
                         </doc>


### PR DESCRIPTION
This fixes the units in `NXxps/NXbeam/beam_direction` such that they match with the [recently changed](https://github.com/nexusformat/definitions/pull/1562) units `NXbeam/BEAMdirection`.

@PeterC-DLS I hadn't realized you had changed the units in `NXbeam` as well. This should be an easy bug fix not requiring a vote.