### PR TITLE
use consistent XML header

### DIFF
--- a/base_classes/NXactuator.nxdl.xml
+++ b/base_classes/NXactuator.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXcalibration.nxdl.xml
+++ b/base_classes/NXcalibration.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXcomponent.nxdl.xml
+++ b/base_classes/NXcomponent.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXcoordinate_system.nxdl.xml
+++ b/base_classes/NXcoordinate_system.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXfabrication.nxdl.xml
+++ b/base_classes/NXfabrication.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXhistory.nxdl.xml
+++ b/base_classes/NXhistory.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXlens_em.nxdl.xml
+++ b/base_classes/NXlens_em.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/base_classes/NXresolution.nxdl.xml
+++ b/base_classes/NXresolution.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format

--- a/contributed_definitions/NXsubstance.nxdl.xml
+++ b/contributed_definitions/NXsubstance.nxdl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="nxdlformat.xsl"?>
 <!--
 # NeXus - Neutron and X-ray Common Data Format


### PR DESCRIPTION
As discussed in #1424, our automatic conversion tool [`nyaml`](https://github.com/FAIRmat-NFDI/nyaml) used to write XML headers with single quote (`<?xml version='1.0' encoding='UTF-8'?>`), but the standard in this repo is double quotes (`<?xml version="1.0" encoding="UTF-8"?>`). 

We have fixed this in the tool since, but there is as set of already standardized base classes from the FAIRmat proposal, where it was missed to fix the header before merging. This PR fixes these headers. 

Can be checked by running `git grep -l "xml version='1.0'" base_classes/* applications/* contributed_definitions/*` (returns nothing after this fix).