### PR TITLE
Adding FIELDNAME field to NXobject

### DIFF
--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -31,7 +31,7 @@
         within this base class are allowed to be present in any derived base class.
 
         The FIELDNAME refers to a defined field of the derived base class or any
-        element that is not defined by the base class.
+        field that is not defined by the base class.
 
         If nameType="partial", the placeholders (e.g., FIELDNAME or GROUPNAME)
         can be replaced by the name of any object (field or group, 

--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -27,23 +27,60 @@
 	name="NXobject" 
 	type="group">
 	<doc>
-        This is the base object of NeXus. The groups and fields contained 
-        within this file are allowed to be present in any derived base class.
+        This is the base object of NeXus. The groups and fields contained
+        within this base class are allowed to be present in any derived base class.
+
+        The FIELDNAME refers to a defined field of the derived base class or any
+        element that is not defined by the base class.
 
         If nameType="partial", the placeholders (e.g., FIELDNAME or GROUPNAME)
         can be replaced by the name of any object (field or group, 
-        respectively) that exists within the same group.
-	</doc>
+        respectively).
+    </doc>
     <group type="NXcollection" minOccurs="0" />
     <group type="NXdata" minOccurs="0" />
     <group type="NXlog" minOccurs="0" />
     <group type="NXnote" minOccurs="0" />
     <group type="NXparameters" minOccurs="0" />
+
     <group name="GROUPNAME_log" type="NXlog" nameType="partial" minOccurs="0">
         <doc>
             NXlog group containing logged values of GROUPNAME.
         </doc>
     </group>
+    <field name="FIELDNAME" minOccurs="0">
+        <doc>
+            A field that is defined by the derived base class or added without
+            existing definition. Its type can be defined by the data_type attribute
+            and a meaning could be provided by the identifier attribute.
+        </doc>
+        <attribute name="data_type" type="NX_CHAR">
+            <doc>
+            Declares the NXDL data type of the field if the field (and its
+            type) is not defined by the derived class.
+           </doc>
+        </attribute>
+        <attribute name="identifier" type="NX_CHAR">
+            <doc>
+            An identifier for a (persistent) resource.
+
+            An identifier, provided by some authority, that has been assigned to an
+            object describing this field.
+
+            See the type attribute of the identifierNAME field for examples of identifiers.
+        </doc>
+        </attribute>
+        <attribute name="units_identifier" type="NX_CHAR">
+            <doc>
+            An identifier for a (persistent) resource.
+
+            An identifier, provided by some authority, that has been assigned to an
+            object describing the units of the field.
+
+            See the type attribute of the identifierNAME field for examples of identifiers.
+        </doc>
+        </attribute>
+    </field>
     <field name="FIELDNAME_set" type="NX_NUMBER" nameType="partial" minOccurs="0">
         <doc>
             Target values of FIELDNAME. 


### PR DESCRIPTION
Adds the field 'FIELDNAME' with attributes for data_type, identifier, and units_identifier to improve machine-readability of NeXus terms and non-NeXus terms, solving issue #1569. Might also be related to #1335 and #1398.
