### PR TITLE
SECoP: sample environments

### DIFF
--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -27,60 +27,23 @@
 	name="NXobject" 
 	type="group">
 	<doc>
-        This is the base object of NeXus. The groups and fields contained
-        within this base class are allowed to be present in any derived base class.
-
-        The FIELDNAME refers to a defined field of the derived base class or any
-        field that is not defined by the base class.
+        This is the base object of NeXus. The groups and fields contained 
+        within this file are allowed to be present in any derived base class.
 
         If nameType="partial", the placeholders (e.g., FIELDNAME or GROUPNAME)
         can be replaced by the name of any object (field or group, 
-        respectively).
-    </doc>
+        respectively) that exists within the same group.
+	</doc>
     <group type="NXcollection" minOccurs="0" />
     <group type="NXdata" minOccurs="0" />
     <group type="NXlog" minOccurs="0" />
     <group type="NXnote" minOccurs="0" />
     <group type="NXparameters" minOccurs="0" />
-
     <group name="GROUPNAME_log" type="NXlog" nameType="partial" minOccurs="0">
         <doc>
             NXlog group containing logged values of GROUPNAME.
         </doc>
     </group>
-    <field name="FIELDNAME" minOccurs="0">
-        <doc>
-            A field that is defined by the derived base class or added without
-            existing definition. Its type can be defined by the data_type attribute
-            and a meaning could be provided by the identifier attribute.
-        </doc>
-        <attribute name="data_type" type="NX_CHAR">
-            <doc>
-            Declares the NXDL data type of the field if the field (and its
-            type) is not defined by the derived class.
-           </doc>
-        </attribute>
-        <attribute name="identifier" type="NX_CHAR">
-            <doc>
-            An identifier for a (persistent) resource.
-
-            An identifier, provided by some authority, that has been assigned to an
-            object describing this field.
-
-            See the type attribute of the identifierNAME field for examples of identifiers.
-        </doc>
-        </attribute>
-        <attribute name="units_identifier" type="NX_CHAR">
-            <doc>
-            An identifier for a (persistent) resource.
-
-            An identifier, provided by some authority, that has been assigned to an
-            object describing the units of the field.
-
-            See the type attribute of the identifierNAME field for examples of identifiers.
-        </doc>
-        </attribute>
-    </field>
     <field name="FIELDNAME_set" type="NX_NUMBER" nameType="partial" minOccurs="0">
         <doc>
             Target values of FIELDNAME. 

--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -31,7 +31,7 @@
         within this base class are allowed to be present in any derived base class.
 
         The FIELDNAME refers to a defined field of the derived base class or any
-        element that is not defined by the base class.
+        field that is not defined by the base class.
 
         If nameType="partial", the placeholders (e.g., FIELDNAME or GROUPNAME)
         can be replaced by the name of any object (field or group, 

--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -27,23 +27,60 @@
 	name="NXobject" 
 	type="group">
 	<doc>
-        This is the base object of NeXus. The groups and fields contained 
-        within this file are allowed to be present in any derived base class.
+        This is the base object of NeXus. The groups and fields contained
+        within this base class are allowed to be present in any derived base class.
+
+        The FIELDNAME refers to a defined field of the derived base class or any
+        element that is not defined by the base class.
 
         If nameType="partial", the placeholders (e.g., FIELDNAME or GROUPNAME)
         can be replaced by the name of any object (field or group, 
-        respectively) that exists within the same group.
-	</doc>
+        respectively).
+    </doc>
     <group type="NXcollection" minOccurs="0" />
     <group type="NXdata" minOccurs="0" />
     <group type="NXlog" minOccurs="0" />
     <group type="NXnote" minOccurs="0" />
     <group type="NXparameters" minOccurs="0" />
+
     <group name="GROUPNAME_log" type="NXlog" nameType="partial" minOccurs="0">
         <doc>
             NXlog group containing logged values of GROUPNAME.
         </doc>
     </group>
+    <field name="FIELDNAME" minOccurs="0">
+        <doc>
+            A field that is defined by the derived base class or added without
+            existing definition. Its type can be defined by the data_type attribute
+            and a meaning could be provided by the identifier attribute.
+        </doc>
+        <attribute name="data_type" type="NX_CHAR">
+            <doc>
+            Declares the NXDL data type of the field if the field (and its
+            type) is not defined by the derived class.
+           </doc>
+        </attribute>
+        <attribute name="identifier" type="NX_CHAR">
+            <doc>
+            An identifier for a (persistent) resource.
+
+            An identifier, provided by some authority, that has been assigned to an
+            object describing this field.
+
+            See the type attribute of the identifierNAME field for examples of identifiers.
+        </doc>
+        </attribute>
+        <attribute name="units_identifier" type="NX_CHAR">
+            <doc>
+            An identifier for a (persistent) resource.
+
+            An identifier, provided by some authority, that has been assigned to an
+            object describing the units of the field.
+
+            See the type attribute of the identifierNAME field for examples of identifiers.
+        </doc>
+        </attribute>
+    </field>
     <field name="FIELDNAME_set" type="NX_NUMBER" nameType="partial" minOccurs="0">
         <doc>
             Target values of FIELDNAME. 

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -436,9 +436,6 @@
 	<group name="temperature_env" type="NXenvironment">
 		<doc>Additional sample temperature environment information</doc>
 	</group>
-	<group name="magnetic_field" type="NXlog">
-		<doc>magnetic_field.value is a link to e.g. magnetic_field_env.sensor1.value</doc>
-	</group>
 	<group name="magnetic_field_log" type="NXlog"
 		deprecated="use ``magnetic_field``, see: https://github.com/nexusformat/definitions/issues/816">
 		<doc>magnetic_field_log.value is a link to e.g. magnetic_field_env.sensor1.value_log.value</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -42,6 +42,7 @@
 		<symbol name="n_resist"><doc>number of resistance values</doc></symbol>
 		<symbol name="n_volt"><doc>number of values in applied voltage</doc></symbol>
 		<symbol name="n_flow"><doc>number of flow rates</doc></symbol>
+		<symbol name="n_strainField"><doc>number of values in applied strain field</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -162,6 +163,19 @@
 		<dimensions>
 			<dim index="1" value="n_flow"/><!-- could be any length -->
 		</dimensions>
+	</field>
+	<field name="strain_field" type="NX_FLOAT" units="NX_DIMENSIONLESS">
+		<doc>Sample strain field</doc>
+		<dimensions>
+			<dim index="1" value="n_strainField"/><!-- could be any length -->
+		</dimensions>
+		<attribute name="direction">
+        	<enumeration>
+        		<item value="x"/>
+        		<item value="y"/>
+        		<item value="z"/>
+        	</enumeration>
+        </attribute>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
 		<doc>Sample changer position</doc>
@@ -416,6 +430,9 @@
 	</group>
 	<group name="stress_field_env" type="NXenvironment">
 		<doc>Additional sample stress field environment information</doc>
+	</group>
+	<group name="strain_field_env" type="NXenvironment">
+		<doc>Additional sample strain field environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -39,6 +39,7 @@
 		<symbol name="n_pH"><doc>number of pH values</doc></symbol>
 		<symbol name="n_curr"><doc>number of current values</doc></symbol>
 		<symbol name="n_cond"><doc>number of conductivity values</doc></symbol>
+		<symbol name="n_resist"><doc>number of resistance values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -140,6 +141,12 @@
 		<doc>Sample electrical conductivity</doc>
 		<dimensions>
 			<dim index="1" value="n_cond"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="resistance" type="NX_FLOAT" units="NX_RESISTANCE">
+		<doc>Sample electrical resistance</doc>
+		<dimensions>
+			<dim index="1" value="n_resist"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -380,6 +387,9 @@
 	</group>
 	<group name="conductivity_env" type="NXenvironment">
 		<doc>Additional sample conductivity environment information</doc>
+	</group>
+	<group name="resistance_env" type="NXenvironment">
+		<doc>Additional sample resistance environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -414,6 +414,9 @@
 	<group name="flow_env" type="NXenvironment">
 		<doc>Additional sample flow environment information</doc>
 	</group>
+	<group name="stress_field_env" type="NXenvironment">
+		<doc>Additional sample stress field environment information</doc>
+	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>
 	</field>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -45,6 +45,7 @@
 		<symbol name="n_strainField"><doc>number of values in applied strain field</doc></symbol>
 		<symbol name="n_shearField"><doc>number of shear values</doc></symbol>
 		<symbol name="n_spField"><doc>number of values in applied surface pressure field</doc></symbol>
+		<symbol name="n_hum"><doc>number of humidity values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -204,6 +205,12 @@
         		<item value="z"/>
         	</enumeration>
         </attribute>
+	</field>
+	<field name="humidity" type="NX_FLOAT" units="NX_DIMENSIONLESS">
+		<doc>Sample humidity</doc>
+		<dimensions>
+			<dim index="1" value="n_hum"/><!-- could be any length -->
+		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
 		<doc>Sample changer position</doc>
@@ -467,6 +474,9 @@
 	</group>
 	<group name="surface_pressure_env" type="NXenvironment">
 		<doc>Additional sample surface pressure field environment information</doc>
+	</group>
+	<group name="humidity_env" type="NXenvironment">
+		<doc>Additional sample humidity environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -40,7 +40,7 @@
 		<symbol name="n_curr"><doc>number of current values</doc></symbol>
 		<symbol name="n_cond"><doc>number of conductivity values</doc></symbol>
 		<symbol name="n_resist"><doc>number of resistance values</doc></symbol>
-		<symbol name="n_volt"><doc>number of values in applied voltage</doc></symbol>
+		<symbol name="n_volt"><doc>number of voltage values</doc></symbol>
 		<symbol name="n_flow"><doc>number of flow rates</doc></symbol>
 		<symbol name="n_strainField"><doc>number of values in applied strain field</doc></symbol>
 		<symbol name="n_shearField"><doc>number of shear values</doc></symbol>
@@ -487,6 +487,9 @@
 	</group>
 	<group name="viscosity_env" type="NXenvironment">
 		<doc>Additional sample viscosity environment information</doc>
+	</group>
+	<group name="concentration_env" type="NXenvironment">
+		<doc>Additional sample concentration environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -36,6 +36,7 @@
 		<symbol name="n_mField"><doc>number of values in applied magnetic field</doc></symbol>
 		<symbol name="n_pField"><doc>number of values in applied pressure field</doc></symbol>
 		<symbol name="n_sField"><doc>number of values in applied stress field</doc></symbol>
+		<symbol name="n_pH"><doc>number of pH values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -119,6 +120,12 @@
 		<doc>Applied pressure</doc>
 		<dimensions>
 			<dim index="1" value="n_pField"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="pH" type="NX_FLOAT" units="NX_MOLAR_DENSITY">
+		<doc>Sample pH value</doc>
+		<dimensions>
+			<dim index="1" value="n_pH"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -347,6 +354,9 @@
 	</group>
 	<group name="magnetic_field_env" type="NXenvironment">
 		<doc>Additional sample magnetic environment information</doc>
+	</group>
+	<group name="pH_env" type="NXenvironment">
+		<doc>Additional sample pH environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -40,6 +40,7 @@
 		<symbol name="n_curr"><doc>number of current values</doc></symbol>
 		<symbol name="n_cond"><doc>number of conductivity values</doc></symbol>
 		<symbol name="n_resist"><doc>number of resistance values</doc></symbol>
+		<symbol name="n_volt"><doc>number of values in applied voltage</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -147,6 +148,12 @@
 		<doc>Sample electrical resistance</doc>
 		<dimensions>
 			<dim index="1" value="n_resist"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="voltage" type="NX_FLOAT" units="NX_VOLTAGE">
+		<doc>Applied voltage</doc>
+		<dimensions rank="anyRank">
+			<dim index="1" value="n_volt"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -390,6 +397,9 @@
 	</group>
 	<group name="resistance_env" type="NXenvironment">
 		<doc>Additional sample resistance environment information</doc>
+	</group>
+	<group name="voltage_env" type="NXenvironment">
+		<doc>Additional sample voltage environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -46,6 +46,7 @@
 		<symbol name="n_shearField"><doc>number of shear values</doc></symbol>
 		<symbol name="n_spField"><doc>number of values in applied surface pressure field</doc></symbol>
 		<symbol name="n_hum"><doc>number of humidity values</doc></symbol>
+		<symbol name="n_vis"><doc>number of viscosity values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -210,6 +211,12 @@
 		<doc>Sample humidity</doc>
 		<dimensions>
 			<dim index="1" value="n_hum"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="viscosity" type="NX_FLOAT" units="NX_PRESSURE_TIME">
+		<doc>Sample viscosity</doc>
+		<dimensions>
+			<dim index="1" value="n_vis"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -477,6 +484,9 @@
 	</group>
 	<group name="humidity_env" type="NXenvironment">
 		<doc>Additional sample humidity environment information</doc>
+	</group>
+	<group name="viscosity_env" type="NXenvironment">
+		<doc>Additional sample viscosity environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -38,6 +38,7 @@
 		<symbol name="n_sField"><doc>number of values in applied stress field</doc></symbol>
 		<symbol name="n_pH"><doc>number of pH values</doc></symbol>
 		<symbol name="n_curr"><doc>number of current values</doc></symbol>
+		<symbol name="n_cond"><doc>number of conductivity values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -131,8 +132,14 @@
 	</field>
 	<field name="current" type="NX_FLOAT" units="NX_CURRENT">
 		<doc>Applied current</doc>
-		<dimensions rank="anyRank">
+		<dimensions>
 			<dim index="1" value="n_curr"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="conductivity" type="NX_FLOAT" units="NX_CONDUCTIVITY">
+		<doc>Sample electrical conductivity</doc>
+		<dimensions>
+			<dim index="1" value="n_cond"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -370,6 +377,9 @@
 	</group>
 	<group name="current_env" type="NXenvironment">
 		<doc>Additional sample current environment information</doc>
+	</group>
+	<group name="conductivity_env" type="NXenvironment">
+		<doc>Additional sample conductivity environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -358,6 +358,9 @@
 	<group name="pH_env" type="NXenvironment">
 		<doc>Additional sample pH environment information</doc>
 	</group>
+	<group name="electric_field_env" type="NXenvironment">
+		<doc>Additional sample electric field environment information</doc>
+	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>
 	</field>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -44,6 +44,7 @@
 		<symbol name="n_flow"><doc>number of flow rates</doc></symbol>
 		<symbol name="n_strainField"><doc>number of values in applied strain field</doc></symbol>
 		<symbol name="n_shearField"><doc>number of shear values</doc></symbol>
+		<symbol name="n_spField"><doc>number of values in applied surface pressure field</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -182,6 +183,19 @@
 		<doc>Sample shear stress field</doc>
 		<dimensions>
 			<dim index="1" value="n_shearField"/><!-- could be any length -->
+		</dimensions>
+		<attribute name="direction">
+        	<enumeration>
+        		<item value="x"/>
+        		<item value="y"/>
+        		<item value="z"/>
+        	</enumeration>
+        </attribute>
+	</field>
+	<field name="surface_pressure" type="NX_FLOAT" units="NX_PRESSURE">
+		<doc>Sample surface pressure field</doc>
+		<dimensions>
+			<dim index="1" value="n_spField"/><!-- could be any length -->
 		</dimensions>
 		<attribute name="direction">
         	<enumeration>
@@ -450,6 +464,9 @@
 	</group>
 	<group name="shear_field_env" type="NXenvironment">
 		<doc>Additional sample shear stress field environment information</doc>
+	</group>
+	<group name="surface_pressure_env" type="NXenvironment">
+		<doc>Additional sample surface pressure field environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -41,6 +41,7 @@
 		<symbol name="n_cond"><doc>number of conductivity values</doc></symbol>
 		<symbol name="n_resist"><doc>number of resistance values</doc></symbol>
 		<symbol name="n_volt"><doc>number of values in applied voltage</doc></symbol>
+		<symbol name="n_flow"><doc>number of flow rates</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -154,6 +155,12 @@
 		<doc>Applied voltage</doc>
 		<dimensions>
 			<dim index="1" value="n_volt"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="flow" type="NX_FLOAT" units="NX_FLOW">
+		<doc>Sample flow rate</doc>
+		<dimensions>
+			<dim index="1" value="n_flow"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -403,6 +410,9 @@
 	</group>
 	<group name="voltage_env" type="NXenvironment">
 		<doc>Additional sample voltage environment information</doc>
+	</group>
+	<group name="flow_env" type="NXenvironment">
+		<doc>Additional sample flow environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -37,6 +37,7 @@
 		<symbol name="n_pField"><doc>number of values in applied pressure field</doc></symbol>
 		<symbol name="n_sField"><doc>number of values in applied stress field</doc></symbol>
 		<symbol name="n_pH"><doc>number of pH values</doc></symbol>
+		<symbol name="n_curr"><doc>number of current values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -126,6 +127,12 @@
 		<doc>Sample pH value</doc>
 		<dimensions>
 			<dim index="1" value="n_pH"/><!-- could be any length -->
+		</dimensions>
+	</field>
+	<field name="current" type="NX_FLOAT" units="NX_CURRENT">
+		<doc>Applied current</doc>
+		<dimensions rank="anyRank">
+			<dim index="1" value="n_curr"/><!-- could be any length -->
 		</dimensions>
 	</field>
 	<field name="changer_position" type="NX_INT" units="NX_UNITLESS">
@@ -360,6 +367,9 @@
 	</group>
 	<group name="electric_field_env" type="NXenvironment">
 		<doc>Additional sample electric field environment information</doc>
+	</group>
+	<group name="current_env" type="NXenvironment">
+		<doc>Additional sample current environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -43,6 +43,7 @@
 		<symbol name="n_volt"><doc>number of values in applied voltage</doc></symbol>
 		<symbol name="n_flow"><doc>number of flow rates</doc></symbol>
 		<symbol name="n_strainField"><doc>number of values in applied strain field</doc></symbol>
+		<symbol name="n_shearField"><doc>number of shear values</doc></symbol>
 	</symbols>
 
 	<doc>
@@ -168,6 +169,19 @@
 		<doc>Sample strain field</doc>
 		<dimensions>
 			<dim index="1" value="n_strainField"/><!-- could be any length -->
+		</dimensions>
+		<attribute name="direction">
+        	<enumeration>
+        		<item value="x"/>
+        		<item value="y"/>
+        		<item value="z"/>
+        	</enumeration>
+        </attribute>
+	</field>
+	<field name="shear_field" type="NX_FLOAT" units="NX_PRESSURE">
+		<doc>Sample shear stress field</doc>
+		<dimensions>
+			<dim index="1" value="n_shearField"/><!-- could be any length -->
 		</dimensions>
 		<attribute name="direction">
         	<enumeration>
@@ -433,6 +447,9 @@
 	</group>
 	<group name="strain_field_env" type="NXenvironment">
 		<doc>Additional sample strain field environment information</doc>
+	</group>
+	<group name="shear_field_env" type="NXenvironment">
+		<doc>Additional sample shear stress field environment information</doc>
 	</group>
 	<field name="external_DAC" type="NX_FLOAT" units="NX_ANY">
 		<doc>value sent to user's sample setup</doc>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -152,7 +152,7 @@
 	</field>
 	<field name="voltage" type="NX_FLOAT" units="NX_VOLTAGE">
 		<doc>Applied voltage</doc>
-		<dimensions rank="anyRank">
+		<dimensions>
 			<dim index="1" value="n_volt"/><!-- could be any length -->
 		</dimensions>
 	</field>

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -386,6 +386,9 @@
 	<group name="pH_env" type="NXenvironment">
 		<doc>Additional sample pH environment information</doc>
 	</group>
+	<group name="pressure_env" type="NXenvironment">
+		<doc>Additional sample pressure environment information</doc>
+	</group>
 	<group name="electric_field_env" type="NXenvironment">
 		<doc>Additional sample electric field environment information</doc>
 	</group>

--- a/base_classes/NXsensor.nxdl.xml
+++ b/base_classes/NXsensor.nxdl.xml
@@ -40,6 +40,11 @@
 	<field name="short_name">
 		<doc>Short name of sensor used e.g. on monitor display program</doc>
 	</field>
+	<field name="description">
+		<doc>
+			Description of the sensor
+		</doc>
+	</field>
 	<field name="attached_to">
 		<doc>where sensor is attached to ("sample" | "can")</doc>
 	</field>

--- a/base_classes/NXsensor.nxdl.xml
+++ b/base_classes/NXsensor.nxdl.xml
@@ -110,8 +110,8 @@
 	</field>
 	<field name="value" type="NX_FLOAT" units="NX_ANY">
 		<doc>
-			nominal setpoint or average value 
-			- need [n] as may be a vector
+			Average value of the sensor - need [n] as may be a vector.
+			For a nominal setpoint use the generally defined value_set field.
 		</doc>
 		<dimensions>
 			<dim index="1" value="n"/>
@@ -119,7 +119,7 @@
 	</field>
 	<field name="value_deriv1" type="NX_FLOAT" units="NX_ANY">
 		<doc>
-			Nominal/average first derivative of value 
+			Average first derivative of value
 			e.g. strain rate 
 			- same dimensions as "value" (may be a vector)
 		</doc>
@@ -129,7 +129,7 @@
 	</field>
 	<field name="value_deriv2" type="NX_FLOAT" units="NX_ANY">
 		<doc>
-			Nominal/average second derivative of value
+			Average second derivative of value
 			- same dimensions as "value" (may be a vector)
 		</doc>
 		<dimensions>

--- a/base_classes/NXsensor.nxdl.xml
+++ b/base_classes/NXsensor.nxdl.xml
@@ -65,6 +65,9 @@
 			<item value="strain" />
 			<item value="shear" />
 			<item value="surface_pressure" />
+			<item value="humidity" />
+			<item value="viscosity" />
+			<item value="concentration" />
 		</enumeration>
 	</field>
 	<field name="type">

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -55,6 +55,7 @@
 			nxdl:NX_CROSS_SECTION
 			nxdl:NX_CHARGE
 			nxdl:NX_CONDUCTIVITY
+			nxdl:NX_COUNT
 			nxdl:NX_CURRENT
 			nxdl:NX_DIMENSIONLESS
 			nxdl:NX_EMITTANCE
@@ -72,7 +73,7 @@
 			nxdl:NX_POWER 
 			nxdl:NX_PRESSURE
 			nxdl:NX_PULSES
-			nxdl:NX_COUNT
+			nxdl:NX_RESISTANCE
 			nxdl:NX_SCATTERING_LENGTH_DENSITY
 			nxdl:NX_SOLID_ANGLE
 			nxdl:NX_TEMPERATURE
@@ -332,7 +333,17 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
-	
+
+	<xs:simpleType name="NX_RESISTANCE">
+		<xs:annotation>
+			<xs:documentation>
+				units of electrical resistance
+				<xs:element name="example">ohm</xs:element>
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
 	<xs:simpleType name="NX_SCATTERING_LENGTH_DENSITY">
 		<xs:annotation>
 			<xs:documentation>

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -73,6 +73,7 @@
 			nxdl:NX_PERIOD
 			nxdl:NX_POWER 
 			nxdl:NX_PRESSURE
+			nxdl:NX_PRESSURE_TIME
 			nxdl:NX_PULSES
 			nxdl:NX_RESISTANCE
 			nxdl:NX_SCATTERING_LENGTH_DENSITY
@@ -333,7 +334,17 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
-	
+
+	<xs:simpleType name="NX_PRESSURE_TIME">
+		<xs:annotation>
+			<xs:documentation>
+				units of pressure multiplied by time
+				<xs:element name="example">Pa * s</xs:element>
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
 	<xs:simpleType name="NX_PULSES">
 		<xs:annotation>
 			<xs:documentation>

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -63,6 +63,7 @@
 			nxdl:NX_LENGTH
 			nxdl:NX_MASS
 			nxdl:NX_MASS_DENSITY
+			nxdl:NX_MOLAR_DENSITY
 			nxdl:NX_MOLECULAR_WEIGHT
 			nxdl:NX_PER_AREA
 			nxdl:NX_PER_LENGTH
@@ -234,6 +235,16 @@
 			<xs:documentation>
 				units of mass density
 				<xs:element name="example">g/cm^3</xs:element>
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
+	<xs:simpleType name="NX_MOLAR_DENSITY">
+		<xs:annotation>
+			<xs:documentation>
+				units of molar concentration
+				<xs:element name="example">mol/L</xs:element>
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -54,6 +54,7 @@
 			nxdl:NX_AREA
 			nxdl:NX_CROSS_SECTION
 			nxdl:NX_CHARGE
+			nxdl:NX_CONDUCTIVITY
 			nxdl:NX_CURRENT
 			nxdl:NX_DIMENSIONLESS
 			nxdl:NX_EMITTANCE
@@ -116,7 +117,17 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
-	
+
+	<xs:simpleType name="NX_CONDUCTIVITY">
+		<xs:annotation>
+			<xs:documentation>
+				units of electrical conductivity
+				<xs:element name="example">S/m</xs:element>
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
 	<xs:simpleType name="NX_COUNT">
 		<xs:annotation>
 			<xs:documentation>

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -60,6 +60,7 @@
 			nxdl:NX_DIMENSIONLESS
 			nxdl:NX_EMITTANCE
 			nxdl:NX_ENERGY
+			nxdl:NX_FLOW
 			nxdl:NX_FLUX
 			nxdl:NX_FREQUENCY
 			nxdl:NX_LENGTH
@@ -201,7 +202,17 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
-	
+
+	<xs:simpleType name="NX_FLOW">
+		<xs:annotation>
+			<xs:documentation>
+				units of volumetric or mass flow rate
+				<xs:element name="example">m^3/s, kg/s</xs:element>
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string" />
+	</xs:simpleType>
+
 	<xs:simpleType name="NX_FLUX">
 		<xs:annotation>
 			<xs:documentation>


### PR DESCRIPTION
This PR solves issues #1315, #1329, #1342, #1365, #1571 and replaces PR #1330 and #1328. Moreover, #1326 and #1327, respectively, are redundant since SECoP agreed that having any number of NXenvironment groups in NXsample is sufficient. The reason for this PR is that jkotan, who creates most of the issues and PRs, is no longer so heavily involved in the SECoP project.

This PR implements SECoP changes that require to implement complex sample environment systems, a clear definition of the sample's state, and the sample environments defining the sample's state. Up to now this is only achieved for some sample conditions, e.g. the temperature by defining the field temperature and temperature_env in NXsample as well as the 'temperature' value in NXsensor/measurement. To achieve this on a wider level, three more optional values (humidity, viscosity, concentration) are added to NXsensor/measurement and missing CONDITION fields (including units type if required) and CONDITION_env are added to NXsample, namely:

- pH, pH_env, NX_MOLAR_DENSITY
- electric_field_env
- current, current_env
- conductivity, conductivity_env, NX_CONDUCTIVITY
- resistance, resistance_env, NX_RESISTANCE
- voltage, voltage_env
- pressure_env
- flow, flow_env, NX_FLOW
- stress_field_env
- strain_field, strain_field_env
- shear_field, shear_field_env
- surface_pressure, surface_pressure_env
- humidity, humidity_env
- viscosity, viscosity_env, NX_PRESSURE_TIME
- concentration_env

To my understanding, this PR is just a coherent implementation of the logic that is already inherent in NeXus.