### PR TITLE
NXazint contribution

### DIFF
--- a/applications/NXazint1d.nxdl.xml
+++ b/applications/NXazint1d.nxdl.xml
@@ -97,16 +97,8 @@
         <doc>
           is a normalization correction applied or not.
 
-          The normalization correction accounts for the effective number or weighted contribution of detector pixels to each integration bin.
-          
-          Note: An important aspect of the normalization strategy is how polarization and solid angle corrections are incorporated, which can vary
-          depending on the specific application, software, and its configuration options (see, for example, PyFAI documentation).
-          Additionally, the normalization strategy may include a relative or absolute calibration factor. Two common normalization approaches are:
-          "Relative normalization" to the PONI (Point Of Normal Incidence) pixel, and "Absolute calibration", which yields the number of photons
-          scattered by the sample in a given direction per unit solid angle. The type of the normalization strategy is not indicated on this level.
-          It must be concluded from the software used or its parameters.
-
-          The monitor correction is not included in the normalization correction and it is specified separately.
+          It indicates that integrated intensities and their errors were already divided by the appropriate normalization factors accounting
+          for the effective number or weighted contribution of detector pixels to each integration bin.
         </doc>
       </field>
 
@@ -279,6 +271,20 @@
       </field>
 
       <field name="norm" type="NX_NUMBER" optional="true">
+        <doc>
+            Values of the normalization correction.
+            
+            The normalization correction accounts for the effective number or weighted contribution of detector pixels to each integration bin.
+          
+            Note: An important aspect of the normalization strategy is how polarization and solid angle corrections are incorporated, which can vary
+            depending on the specific application, software, and its configuration options (see, for example, PyFAI documentation).
+            Additionally, the normalization strategy may include a relative or absolute calibration factor. Two common normalization approaches are:
+            "Relative normalization" to the PONI (Point Of Normal Incidence) pixel, and "Absolute calibration", which yields the number of photons
+            scattered by the sample in a given direction per unit solid angle. The type of the normalization strategy is not indicated on this level.
+            It must be concluded from the software used or its parameters.
+
+            The monitor correction is not included in the normalization correction and it is specified separately.
+        </doc>
         <dimensions rank="1">
           <dim index="1" value="nRad" />
         </dimensions>

--- a/applications/NXazint2d.nxdl.xml
+++ b/applications/NXazint2d.nxdl.xml
@@ -103,16 +103,8 @@
         <doc>
           is a normalization correction applied or not.
 
-          The normalization correction accounts for the effective number or weighted contribution of detector pixels to each integration bin.
-          
-          Note: An important aspect of the normalization strategy is how polarization and solid angle corrections are incorporated, which can vary
-          depending on the specific application, software, and its configuration options (see, for example, PyFAI documentation).
-          Additionally, the normalization strategy may include a relative or absolute calibration factor. Two common normalization approaches are:
-          "Relative normalization" to the PONI (Point Of Normal Incidence) pixel, and "Absolute calibration", which yields the number of photons
-          scattered by the sample in a given direction per unit solid angle. The type of the normalization strategy is not indicated on this level.
-          It must be concluded from the software used or its parameters.
-
-          The monitor correction is not included in the normalization correction and it is specified separately.
+          It indicates that integrated intensities and their errors were already divided by the appropriate normalization factors accounting
+          for the effective number or weighted contribution of detector pixels to each integration bin.
         </doc>
       </field>
 
@@ -285,6 +277,20 @@
         </field>
 
         <field name="norm" type="NX_NUMBER" optional="true">
+          <doc>
+            Values of the normalization correction.
+            
+            The normalization correction accounts for the effective number or weighted contribution of detector pixels to each integration bin.
+          
+            Note: An important aspect of the normalization strategy is how polarization and solid angle corrections are incorporated, which can vary
+            depending on the specific application, software, and its configuration options (see, for example, PyFAI documentation).
+            Additionally, the normalization strategy may include a relative or absolute calibration factor. Two common normalization approaches are:
+            "Relative normalization" to the PONI (Point Of Normal Incidence) pixel, and "Absolute calibration", which yields the number of photons
+            scattered by the sample in a given direction per unit solid angle. The type of the normalization strategy is not indicated on this level.
+            It must be concluded from the software used or its parameters.
+
+            The monitor correction is not included in the normalization correction and it is specified separately.
+          </doc>
           <dimensions rank="2">
             <dim index="1" value="nEta" />
             <dim index="2" value="nRad" />


### PR DESCRIPTION
Two application definitions for storing the result of azimuthal unwrapping of diffraction patterns: NXazint1d and NXazint2d.

An example application that creates these files at MAX IV is documented here: https://maxiv-science.github.io/azint_writer/.

An example file can be inspected [here](https://myhdf5.hdfgroup.org/view?url=https%3A%2F%2Fzenodo.org%2Frecords%2F15744977%2Ffiles%2Fnx_azint1d_azint2d.h5%3Fdownload%3D1).

Organize this contribution: https://github.com/nexuscontributions/nxazint/issues/3

HTML rendering of [NXazint1d](https://hdf5.gitlab-pages.esrf.fr/nexus/nxazint/classes/contributed_definitions/NXazint1d.html) and [NXazint2d](https://hdf5.gitlab-pages.esrf.fr/nexus/nxazint/classes/contributed_definitions/NXazint2d.html)