### PR TITLE
Fixing typos in appdefs and baseclasses, removal of concepts that are now coming for free cuz of inheritance

### DIFF
--- a/applications/NXarchive.nxdl.xml
+++ b/applications/NXarchive.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/applications/NXarchive.nxdl.xml
+++ b/applications/NXarchive.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -85,7 +85,7 @@
         <field name="role" type="NX_CHAR">
           <doc>role of the user</doc></field>
         <field name="facility_user_id" type="NX_CHAR">
-          <doc>ID of the user in the facility burocracy database</doc>
+          <doc>ID of the user in the facility bureaucracy database</doc>
         </field>
       </group>
       <group type="NXinstrument" name="instrument">

--- a/applications/NXcanSAS.nxdl.xml
+++ b/applications/NXcanSAS.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2012-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2012-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -758,7 +758,7 @@
         
         Consider, carefully, the relevance to the SAS data analysis process
         when adding subgroups in this **NXinstrument** group.  Additional information
-        can be added but will likely be ignored by standardized data anlysis processes.
+        can be added but will likely be ignored by standardized data analysis processes.
         
         The NeXus :ref:`NXbeam` base class may be added as a subgroup of this **NXinstrument**
         group *or* as a subgroup of the **NXsample** group to describe properties of the beam at any 

--- a/applications/NXcanSAS.nxdl.xml
+++ b/applications/NXcanSAS.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2012-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2012-2024 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/applications/NXdirecttof.nxdl.xml
+++ b/applications/NXdirecttof.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/applications/NXdirecttof.nxdl.xml
+++ b/applications/NXdirecttof.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -55,7 +55,7 @@
        </field> 
        </group>
        <doc>
-          We definitly want the rotation_speed and energy of the chopper. Thus either 
+          We definitely want the rotation_speed and energy of the chopper. Thus either
           a fermi_chopper or a disk_chopper group is required. 
        </doc>
      </group>  

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/applications/NXlauetof.nxdl.xml
+++ b/applications/NXlauetof.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -94,7 +94,7 @@
             The orientation matrix according to Busing and
             Levy conventions. This is not strictly necessary as
             the UB can always be derived from the data.  But
-            let us bow to common usage which includes thie
+            let us bow to common usage which includes the
             UB nearly always.
 	  </doc>
           <dimensions rank="2">

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
   # NeXus - Neutron and X-ray Common Data Format
   #
-  # Copyright (C) 2013-2024 NeXus International Advisory Committee (NIAC)
+  # Copyright (C) 2013-2025 NeXus International Advisory Committee (NIAC)
   #
   # This library is free software; you can redistribute it and/or
   # modify it under the terms of the GNU Lesser General Public
@@ -383,7 +383,7 @@
                             Many detectors consist of multiple smaller modules that are
                             operated in sync and store their data in a common dataset.
                             To allow consistent parsing of the experimental geometry,
-                            this application definiton requires all detectors to
+                            this application definition requires all detectors to
                             define a detector module, even if there is only one.
 
                             This group specifies the hyperslab of data in the data
@@ -490,7 +490,7 @@
                             Distance from the sample to the beam center.
                             Normally this value is for guidance only, the proper
                             geometry can be found following the depends_on axis chain,
-                            But in appropriate cases where the dectector distance
+                            But in appropriate cases where the detector distance
                             to the sample is observable independent of the axis
                             chain, that may take precedence over the axis chain
                             calculation.
@@ -835,7 +835,7 @@
                     <field name="incident_wavelength" type="NX_FLOAT" units="NX_WAVELENGTH"
                         minOccurs="1" >
                         <doc>
-                            In the case of a monchromatic beam this is the scalar
+                            In the case of a monochromatic beam this is the scalar
                             wavelength.
 
                             Several other use cases are permitted, depending on the

--- a/applications/NXmx.nxdl.xml
+++ b/applications/NXmx.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
   # NeXus - Neutron and X-ray Common Data Format
   #
-  # Copyright (C) 2013-2025 NeXus International Advisory Committee (NIAC)
+  # Copyright (C) 2013-2024 NeXus International Advisory Committee (NIAC)
   #
   # This library is free software; you can redistribute it and/or
   # modify it under the terms of the GNU Lesser General Public

--- a/base_classes/NXattenuator.nxdl.xml
+++ b/base_classes/NXattenuator.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/base_classes/NXattenuator.nxdl.xml
+++ b/base_classes/NXattenuator.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -80,7 +80,7 @@
         The reference point of the attenuator is its center in the x and y axis. The reference point on the z axis is the
         surface of the attenuator pointing towards the source.
 
-        In complex (asymmetic) geometries an NXoff_geometry group can be used to provide an unambiguous reference.
+        In complex (asymmetric) geometries an NXoff_geometry group can be used to provide an unambiguous reference.
 
         .. image:: attenuator/attenuator.png
             :width: 40%
@@ -88,7 +88,7 @@
     </field>
     <group name="shape" type="NXoff_geometry">
       <doc>
-        Shape of this component. Particulary useful to define the origin for position and orientation in non-standard cases.
+        Shape of this component. Particularly useful to define the origin for position and orientation in non-standard cases.
       </doc>
     </group>
 </definition>

--- a/base_classes/NXcomponent.nxdl.xml
+++ b/base_classes/NXcomponent.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2023-2025 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2023-2024 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/base_classes/NXcomponent.nxdl.xml
+++ b/base_classes/NXcomponent.nxdl.xml
@@ -74,7 +74,7 @@
             via the NXtransformations group.
 
             NeXus positions components by applying a set of translations and rotations
-            to apply to the component starting from 0, 0, 0. The order of these operations
+            to the component starting from 0, 0, 0. The order of these operations
             is critical and forms what NeXus calls a dependency chain. The depends_on
             field defines the path to the top most operation of the dependency chain or the
             string "." if located in the origin. Usually these operations are stored in a

--- a/base_classes/NXcomponent.nxdl.xml
+++ b/base_classes/NXcomponent.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2023-2025 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -39,7 +39,7 @@
         <doc>
             Ideally, use instances of ``identifierNAME`` to point to a resource
             that provides further details.
- 
+
             If such a resource does not exist or should not be used, use this free text,
             although it is not recommended.
         </doc>
@@ -74,15 +74,11 @@
             via the NXtransformations group.
 
             NeXus positions components by applying a set of translations and rotations
-            to the component starting from 0, 0, 0. The order of these operations
+            to apply to the component starting from 0, 0, 0. The order of these operations
             is critical and forms what NeXus calls a dependency chain. The depends_on
             field defines the path to the top most operation of the dependency chain or the
-            string "." if located in the origin. The depends_on can also point to an instance
-            of ``NX_coordinate_system`` if the transformations of the component depend on that
-            coordinate system.
-            
-            Usually these operations are stored in a NXtransformations group.
-            But NeXus allows them to be stored anywhere.
+            string "." if located in the origin. Usually these operations are stored in a
+            NXtransformations group. But NeXus allows them to be stored anywhere.
         </doc>
     </field>
     <group type="NXtransformations">
@@ -92,5 +88,4 @@
             chain may however traverse similar groups in other component groups.
         </doc>
     </group>
-    
 </definition>

--- a/base_classes/NXdata.nxdl.xml
+++ b/base_classes/NXdata.nxdl.xml
@@ -494,7 +494,7 @@
 			data. The units must be appropriate for the measurement.
 
 			This is a special case of a :ref:`AXISNAME field &lt;/NXdata/AXISNAME-field&gt;`
-			kept for backward compatiblity.
+			kept for backward compatibility.
 		</doc>
 		<dimensions rank="1">
 			<dim index="1" value="nx" />
@@ -506,7 +506,7 @@
 			data. The units must be appropriate for the measurement.
 
 			This is a special case of a :ref:`AXISNAME field &lt;/NXdata/AXISNAME-field&gt;`
-			kept for backward compatiblity.
+			kept for backward compatibility.
 		</doc>
 		<dimensions rank="1">
 			<dim index="1" value="ny" />
@@ -518,7 +518,7 @@
 			data. The units must be appropriate for the measurement.
 
 			This is a special case of a :ref:`AXISNAME field &lt;/NXdata/AXISNAME-field&gt;`
-			kept for backward compatiblity.
+			kept for backward compatibility.
 		</doc>
 		<dimensions rank="1">
 			<dim index="1" value="nz" />

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -715,7 +715,7 @@
   <field name="image_key" type="NX_INT" >
     <doc>
       This field allow to distinguish different types of exposure to the same detector "data" field.
-      Some techniques require frequent (re-)calibration inbetween measuremnts and this way of
+      Some techniques require frequent (re-)calibration inbetween measurements and this way of
       recording the different measurements preserves the chronological order with is important for
       correct processing.
 

--- a/base_classes/NXentry.nxdl.xml
+++ b/base_classes/NXentry.nxdl.xml
@@ -70,7 +70,7 @@
 			   do not use an application definition.
 			   It is recommended strongly that all NeXus data files provide
 			   a NXdata group.
-			   It is permissable to omit the NXdata group only when
+			   It is permissible to omit the NXdata group only when
 			   defining the default plot is not practical or possible
 			   from the available data.
 
@@ -118,7 +118,7 @@
 		<doc>Brief summary of the collection, including grouping criteria.</doc>
 	</field>
 	<field name="entry_identifier">
-		<doc>unique identifier for the measurement, defined by the facility.</doc>
+		<doc>Unique identifier for the measurement, defined by the facility.</doc>
 	</field>
 	<field name="entry_identifier_uuid">
 		<doc>UUID identifier for the measurement.</doc>

--- a/base_classes/NXhistory.nxdl.xml
+++ b/base_classes/NXhistory.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2022-2024 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/base_classes/NXlog.nxdl.xml
+++ b/base_classes/NXlog.nxdl.xml
@@ -46,7 +46,7 @@
 		the logged or streamed  values and the times at which they were measured as elapsed time since a starting
 		time recorded in ISO8601 format. The time units are
 		specified in the units attribute. An optional scaling attribute
-		can be used to accomodate non standard clocks.
+		can be used to accommodate non standard clocks.
 
 
 		This method of storing logged data helps to distinguish instances in which a variable contains signal or

--- a/base_classes/NXpdb.nxdl.xml
+++ b/base_classes/NXpdb.nxdl.xml
@@ -63,9 +63,9 @@
 		should always be presented as a 1-dimensional array.  The columns 
 		in an unlooped PDB category should be presented as scalar values.  
 		If a PDB category specifies particular units for columns, the same 
-		units should beused for the corresponding fields.
+		units should be used for the corresponding fields.
 
-		A PDB entry is unambigous when all information is carried as text.
+		A PDB entry is unambiguous when all information is carried as text.
 		All text data should be presented as quoted strings, with the quote
 		marks except for the null values "." or "?"
 
@@ -81,7 +81,7 @@
 		but may be used to provide internal documentation.
 
 		The nesting of NXpdb groups and datasets that correspond to a CIF with
-		two categories and one saveframe, including the NXpdb_class attribues is::
+		two categories and one saveframe, including the NXpdb_class attributes is::
 
 			(datablock1):NXpdb
 			   @NXpdb_class:CBF_cbfdb

--- a/base_classes/NXpid_controller.nxdl.xml
+++ b/base_classes/NXpid_controller.nxdl.xml
@@ -45,7 +45,7 @@
          
         A classic PID controller only implements the P, I and D terms and the values of the K_p, K_i and K_d constants are sufficient to fully
         describe the behaviour of the feedback system implemented by such a PID controller. The inclusion of a Feed Forward term in a feedback system
-        is a modern adaptation that aids optimisation of the automated control. It is not present in all PID controllers, but it is also not uncommon.
+        is a modern adaptation that aids optimization of the automated control. It is not present in all PID controllers, but it is also not uncommon.
          
         Note that the ``NXpid_controller`` is designed to be a child object of the actuator that its output is connected to. The parent object
         representing the actuator is likely to be represented by an ``NXactuator`` or ``NXpositioner`` base class, but there is a wide variety

--- a/base_classes/NXresolution.nxdl.xml
+++ b/base_classes/NXresolution.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2014-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2022-2024 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -94,19 +94,6 @@
              entered by the `formula_...` fields. This should be an english description of the math used.
         </doc>
     </field>
-    <attribute name="default">
-        <doc>
-             .. index:: plotting
-             
-             Declares which child group contains a path leading
-             to a :ref:`NXdata` group.
-             
-             It is recommended (as of NIAC2014) to use this attribute
-             to help define the path to the default dataset to be plotted.
-             See https://www.nexusformat.org/2014_How_to_find_default_data.html
-             for a summary of the discussion.
-        </doc>
-    </attribute>
     <group type="NXcalibration">
         <doc>
              For storing details and data of a calibration to derive a resolution from data.

--- a/base_classes/NXsample.nxdl.xml
+++ b/base_classes/NXsample.nxdl.xml
@@ -248,7 +248,7 @@
 	<group type="NXsample_component">
 		<doc>
 			One group per sample component
-			This is the perferred way of recording per component information over the n_comp arrays
+			This is the preferred way of recording per component information over the n_comp arrays
 		</doc>
 	</group>
 	<field name="component">

--- a/base_classes/NXsensor.nxdl.xml
+++ b/base_classes/NXsensor.nxdl.xml
@@ -155,20 +155,6 @@
                          This group describes the shape of the sensor when necessary.
                 </doc>
         </group>
-    <group type="NXfabrication"/>
-    <attribute name="default">
-        <doc>
-            .. index:: plotting
-            
-            Declares which child group contains a path leading 
-            to a :ref:`NXdata` group.
-            
-            It is recommended (as of NIAC2014) to use this attribute
-            to help define the path to the default dataset to be plotted.
-            See https://www.nexusformat.org/2014_How_to_find_default_data.html
-            for a summary of the discussion.
-        </doc>
-    </attribute>
     <field name="depends_on" type="NX_CHAR">
         <doc>
             .. todo::

--- a/base_classes/NXsubentry.nxdl.xml
+++ b/base_classes/NXsubentry.nxdl.xml
@@ -186,4 +186,3 @@
 	<group type="NXparameters" />
 	<group type="NXprocess" />
 </definition>
-

--- a/base_classes/NXtransformations.nxdl.xml
+++ b/base_classes/NXtransformations.nxdl.xml
@@ -99,7 +99,7 @@
 		documents the fields commonly used within NeXus for positioning purposes and their meaning. Whenever
 		there is a need for positioning a beam line component please use the existing names. Use as many fields
 		as needed in order to position the component. Feel free to add more axis if required. In the description
-		given below, only those atttributes which are defined through the name are specified. Add the other attributes
+		given below, only those attributes which are defined through the name are specified. Add the other attributes
 		of the full set:
 
 		* vector
@@ -127,7 +127,7 @@
 			by HDF5.
 
 			The values given should be the start points of exposures for the corresponding
-			frames.  The end points should be given in ``AXISNAME_end``.
+			frames. The end points should be given in ``AXISNAME_end``.
 		</doc>
 		<attribute name="transformation_type" optional="true">
 			<doc>


### PR DESCRIPTION
Fixing typos that we spotted on the FAIRmat side given that we use cspell as a spellchecker. These typos were observed when comparing of the FAIRmat-NFDI fairmat branch 1e8c433 with NIAC main ecc9361