### PR TITLE
use `vary` and `initial_value` from `NXparameters` in `NXfit_function`

### DIFF
--- a/base_classes/NXfit_function.nxdl.xml
+++ b/base_classes/NXfit_function.nxdl.xml
@@ -67,26 +67,6 @@ and a BNF of valid grammar.-->
                     A description of what this parameter represents.
                 </doc>
             </attribute>
-            <attribute name="initial" type="NX_NUMBER">
-                <doc>
-                    The initial value of the parameter used in fitting.
-                </doc>
-            </attribute>
-            <attribute name="vary" type="NX_BOOLEAN">
-                <doc>
-                    True if the parameter was varied during fitting.
-                </doc>
-            </attribute>
-            <attribute name="min" type="NX_NUMBER">
-                <doc>
-                    The minimal value of the parameter, to be used as a constraint during fitting.
-                </doc>
-            </attribute>
-            <attribute name="max" type="NX_NUMBER">
-                <doc>
-                    The maximal value of the parameter, to be used as a constraint during fitting.
-                </doc>
-            </attribute>
         </field>
     </group>
 </definition>


### PR DESCRIPTION
This align `NXparameters` used in `NXfit_function` with the changes to the base class `NXparameters` applied in https://github.com/nexusformat/definitions/pull/1560.

I couldn’t make my PR point to @rayosborn's branch because it is on his own private repository, so I just pointed it to the main branch. Not sure if the whole thing needs a vote, as it is basically just clean-up.