### PR TITLE
Deprecate thumbnail's type attribute for #1605

### DIFF
--- a/base_classes/NXentry.nxdl.xml
+++ b/base_classes/NXentry.nxdl.xml
@@ -208,7 +208,7 @@
 			A small image that is representative of the entry. An example of this is a 640x480
 			jpeg image automatically produced by a low resolution plot of the NXdata.
 		</doc>
-		<attribute name="type">
+		<attribute name="type" deprecated="Use the `type` field instead">
 			<doc>The mime type should be an ``image/*``</doc>
 			<enumeration>
 				<!--


### PR DESCRIPTION
`NXnote` has a `type` field