### PR TITLE
Rhs chopper

### DIFF
--- a/base_classes/NXdisk_chopper.nxdl.xml
+++ b/base_classes/NXdisk_chopper.nxdl.xml
@@ -45,9 +45,23 @@
 		We refer to this below as the "top-dead-center signal".
 
 		Angles and positive rotation speeds are measured in an anticlockwise
-		direction when facing away from the source.
+		direction when facing away from the source unless otherwise specified in the `handedness` field.
 	</doc>
 
+	<field name="handedness">
+		<doc>
+      Direction of measurement for rotation and positions in the disk-chopper.
+      Left is the default for historical reasons and implies positive rotation and angles in an anticlockwise
+      direciton when facing away from the source.
+      Right matches the default NeXus coordinate system and implies positive rotation and angles in an anticlockwise
+      direction when looking towards the source - positive rotation matches the positive roll of the system.
+      Only one from the enumerated list (match text exactly).
+    </doc>
+		<enumeration>
+			<item value="Left" />
+			<item value="Right" />
+		</enumeration>
+	</field>
 	<field name="type">
 		<doc>Type of the disk-chopper: only one from the enumerated list (match text exactly)</doc>
 		<enumeration>
@@ -58,8 +72,7 @@
 	</field>
 	<field name="rotation_speed" type="NX_FLOAT" units="NX_FREQUENCY">
 		<doc>
-			Chopper rotation speed. Positive for anticlockwise rotation when
-			facing away from the source, negative otherwise.
+			Chopper rotation speed.
 		</doc>
 	</field>
 	<field name="slits" type="NX_INT">
@@ -74,8 +87,7 @@
 	<field name="slit_edges" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>
 			Angle of each edge of every slit from the position of the
-			top-dead-center timestamp sensor, anticlockwise when facing
-			away from the source.
+			top-dead-center timestamp sensor.
 			The first edge must be the opening edge of a slit, thus the last edge
 			may have an angle greater than 360 degrees.
 		</doc>
@@ -93,8 +105,7 @@
 	<field name="beam_position" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>
 			Angular separation of the center of the beam and the
-			top-dead-center timestamp sensor, anticlockwise when facing
-			away from the source.
+			top-dead-center timestamp sensor.
 		</doc>
 	</field>
 	<field name="radius" type="NX_FLOAT" units="NX_LENGTH">
@@ -140,9 +151,9 @@
             the source. The reference point in the x and y axis is the point on this surface which is the
             centre of the axle which the disk is spinning around. The reference plane is orthogonal to
             the z axis and its position is the reference point on that axis.
-                    
+
             Note: This reference point in almost all practical cases is not where the beam passes though.
-                    
+
             .. image:: disk_chopper/disk_chopper.png
                 :width: 40%
         </doc>

--- a/base_classes/NXdisk_chopper.nxdl.xml
+++ b/base_classes/NXdisk_chopper.nxdl.xml
@@ -45,23 +45,9 @@
 		We refer to this below as the "top-dead-center signal".
 
 		Angles and positive rotation speeds are measured in an anticlockwise
-		direction when facing away from the source unless otherwise specified in the `handedness` field.
+		direction when facing away from the source.
 	</doc>
 
-	<field name="handedness">
-		<doc>
-      Direction of measurement for rotation and positions in the disk-chopper.
-      Left is the default for historical reasons and implies positive rotation and angles in an anticlockwise
-      direciton when facing away from the source.
-      Right matches the default NeXus coordinate system and implies positive rotation and angles in an anticlockwise
-      direction when looking towards the source - positive rotation matches the positive roll of the system.
-      Only one from the enumerated list (match text exactly).
-    </doc>
-		<enumeration>
-			<item value="Left" />
-			<item value="Right" />
-		</enumeration>
-	</field>
 	<field name="type">
 		<doc>Type of the disk-chopper: only one from the enumerated list (match text exactly)</doc>
 		<enumeration>
@@ -72,7 +58,8 @@
 	</field>
 	<field name="rotation_speed" type="NX_FLOAT" units="NX_FREQUENCY">
 		<doc>
-			Chopper rotation speed.
+			Chopper rotation speed. Positive for anticlockwise rotation when
+			facing away from the source, negative otherwise.
 		</doc>
 	</field>
 	<field name="slits" type="NX_INT">
@@ -87,7 +74,8 @@
 	<field name="slit_edges" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>
 			Angle of each edge of every slit from the position of the
-			top-dead-center timestamp sensor.
+			top-dead-center timestamp sensor, anticlockwise when facing
+			away from the source.
 			The first edge must be the opening edge of a slit, thus the last edge
 			may have an angle greater than 360 degrees.
 		</doc>
@@ -105,7 +93,8 @@
 	<field name="beam_position" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>
 			Angular separation of the center of the beam and the
-			top-dead-center timestamp sensor.
+			top-dead-center timestamp sensor, anticlockwise when facing
+			away from the source.
 		</doc>
 	</field>
 	<field name="radius" type="NX_FLOAT" units="NX_LENGTH">

--- a/base_classes/NXdisk_chopper.nxdl.xml
+++ b/base_classes/NXdisk_chopper.nxdl.xml
@@ -45,9 +45,23 @@
 		We refer to this below as the "top-dead-center signal".
 
 		Angles and positive rotation speeds are measured in an anticlockwise
-		direction when facing away from the source.
+		direction when facing away from the source unless otherwise specified in the `handedness` field.
 	</doc>
 
+	<field name="handedness">
+		<doc>
+      Direction of measurement for rotation and positions in the disk-chopper.
+      Left is the default for historical reasons and implies positive rotation and angles in an anticlockwise
+      direciton when facing away from the source.
+      Right matches the default NeXus coordinate system and implies positive rotation and angles in an anticlockwise
+      direction when looking towards the source - positive rotation matches the positive roll of the system.
+      Only one from the enumerated list (match text exactly).
+    </doc>
+		<enumeration>
+			<item value="Left" />
+			<item value="Right" />
+		</enumeration>
+	</field>
 	<field name="type">
 		<doc>Type of the disk-chopper: only one from the enumerated list (match text exactly)</doc>
 		<enumeration>
@@ -58,8 +72,7 @@
 	</field>
 	<field name="rotation_speed" type="NX_FLOAT" units="NX_FREQUENCY">
 		<doc>
-			Chopper rotation speed. Positive for anticlockwise rotation when
-			facing away from the source, negative otherwise.
+			Chopper rotation speed.
 		</doc>
 	</field>
 	<field name="slits" type="NX_INT">
@@ -74,8 +87,7 @@
 	<field name="slit_edges" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>
 			Angle of each edge of every slit from the position of the
-			top-dead-center timestamp sensor, anticlockwise when facing
-			away from the source.
+			top-dead-center timestamp sensor.
 			The first edge must be the opening edge of a slit, thus the last edge
 			may have an angle greater than 360 degrees.
 		</doc>
@@ -93,8 +105,7 @@
 	<field name="beam_position" type="NX_FLOAT" units="NX_ANGLE">
 		<doc>
 			Angular separation of the center of the beam and the
-			top-dead-center timestamp sensor, anticlockwise when facing
-			away from the source.
+			top-dead-center timestamp sensor.
 		</doc>
 	</field>
 	<field name="radius" type="NX_FLOAT" units="NX_LENGTH">


### PR DESCRIPTION
The handedness of the NeXus coordinate system implies that chopper rotation should be positive when rotating clockwise facing away from the source, but the documentation states it is the exact opposite.

This cannot be corrected easily historically, as many systems should have this in place, but it is not correct to describe NeXus as using a right-handed coordinate system with this discrepancy.  It also leads to an unintuitive and ugly exception when describing an instrument.

This PR proposes a fix by including a new field, `handedness`, that defaults to `Left` unless otherwise specified, thus not breaking any existing setups or data files, but allows for another value, `Right`, which agrees with the standard NeXus coordinate basis and which arises naturally when defining a RHS with a z-axis that runs in a positive direction from source to sample.