### PR TITLE
NXobject: add IRI as valid persistent identifier type

### DIFF
--- a/base_classes/NXobject.nxdl.xml
+++ b/base_classes/NXobject.nxdl.xml
@@ -181,6 +181,8 @@
 				</item>
 				<item value="PURL">
 					<doc>
+						DEPRECATED: use IRI instead
+
 						Persistent Uniform Resource Locator.
 						
 						A Persistent Uniform Resource Locator (PURL) is a type of URL designed to provide a stable, long-term reference to a web 
@@ -190,6 +192,27 @@
 						
 						Syntax: https://purl.org/foo/bar
 						Example: https://purl.org/dc/elements/1.1/title
+					</doc>
+				</item>
+				<item value="IRI">
+					<doc>
+						Internationalized Resource identifier
+
+						An identifier that conform to RFC 3987.  IRIs are
+						similar to URIs but support non-ASCII characters.
+
+						All non-ASCII code points in the IRI should next be
+						encoded as UTF-8, and the resulting bytes
+						percent-encoded, to produce a valid URI.
+
+						This type is recommended for concepts in ontologies.
+						Service should support Content-Negotiation, to allow clients
+						to request information about the resource in a semantic
+						data format.
+
+						Syntax: scheme://domain:port/path?query_string#fragment_id
+						Example: https://example.org/résumé.html is written
+							https://example.org/r%E9sum%E9.html
 					</doc>
 				</item>
 				<item value="ROR">


### PR DESCRIPTION
Allow `IRI` as a persistent identifier type.

Deprecate PURL in favour of IRI.