### PR TITLE
1368 nxdltypes invalid xml schema

### DIFF
--- a/dev_tools/docs/xsd_units.py
+++ b/dev_tools/docs/xsd_units.py
@@ -43,8 +43,11 @@ def generate_xsd_units_doc(
         if node_name is None:
             continue
         if "nxdl:" + node_name in members:
-            content = _extract_xsd_doc(node, ns)
+            doc = _extract_xsd_doc(node, ns)
             examples = _extract_xsd_examples(node, ns)
+
+            # Replacing other whitespace characters to remove Sphinx warnings.
+            content = " ".join(doc.split())
 
             if len(examples) == 1:
                 content += f",\n\texample: {examples[0]}"

--- a/dev_tools/docs/xsd_units.py
+++ b/dev_tools/docs/xsd_units.py
@@ -43,16 +43,19 @@ def generate_xsd_units_doc(
         if node_name is None:
             continue
         if "nxdl:" + node_name in members:
-            words = node.xpath("xs:annotation/xs:documentation", namespaces=ns)[0]
-            examples = []
-            for example in words.iterchildren():
-                nm = example.attrib.get("name")
-                if nm is not None and nm == "example":
-                    examples.append("``" + example.text + "``")
-            a = words.text
-            if len(examples) > 0:
-                a = " ".join(a.split()) + ",\n\texample(s): " + " | ".join(examples)
-            db[node_name] = a
+            doc = _extract_xsd_doc(node, ns)
+            examples = _extract_xsd_examples(node, ns)
+
+            content = " ".join(doc.split())
+
+            if len(examples) == 1:
+                examples_str = examples[0]
+                content += f",\n\texample: {examples_str}"
+            elif examples:
+                examples_str = " | ".join(examples)
+                content += f",\n\texample(s): {examples_str}"
+
+            db[node_name] = content
 
             # for item in node.xpath("xs:restriction//xs:enumeration", namespaces=ns):
             #    key = "%s" % item.get("value")
@@ -69,3 +72,23 @@ def generate_xsd_units_doc(
             rst_lines.append(f"    {line}\n")
         rst_lines.append("\n")
     return rst_lines
+
+
+def _extract_xsd_doc(node, ns):
+    """
+    Extracts documentation text from an XSD annotation.
+    """
+    doc_nodes = node.xpath("xs:annotation/xs:documentation", namespaces=ns)
+    if not doc_nodes:
+        return ""
+
+    return " ".join(doc_nodes[0].itertext()).strip()
+
+
+def _extract_xsd_examples(node, ns):
+    """
+    Extracts examples from an XSD annotation.
+    """
+    examples = node.xpath("xs:annotation/xs:appinfo/example/text()", namespaces=ns)
+
+    return [f"``{ex}``" for ex in examples if ex]

--- a/dev_tools/docs/xsd_units.py
+++ b/dev_tools/docs/xsd_units.py
@@ -53,7 +53,7 @@ def generate_xsd_units_doc(
                 content += f",\n\texample: {examples_str}"
             elif examples:
                 examples_str = " | ".join(examples)
-                content += f",\n\texample(s): {examples_str}"
+                content += f",\n\texamples: {examples_str}"
 
             db[node_name] = content
 

--- a/dev_tools/docs/xsd_units.py
+++ b/dev_tools/docs/xsd_units.py
@@ -43,14 +43,11 @@ def generate_xsd_units_doc(
         if node_name is None:
             continue
         if "nxdl:" + node_name in members:
-            doc = _extract_xsd_doc(node, ns)
+            content = _extract_xsd_doc(node, ns)
             examples = _extract_xsd_examples(node, ns)
 
-            content = " ".join(doc.split())
-
             if len(examples) == 1:
-                examples_str = examples[0]
-                content += f",\n\texample: {examples_str}"
+                content += f",\n\texample: {examples[0]}"
             elif examples:
                 examples_str = " | ".join(examples)
                 content += f",\n\texamples: {examples_str}"

--- a/dev_tools/nxdl/__init__.py
+++ b/dev_tools/nxdl/__init__.py
@@ -8,3 +8,4 @@ from .discover import find_definition  # noqa F401
 from .discover import iter_definitions  # noqa F401
 from .syntax import nxdl_schema  # noqa F401
 from .syntax import validate_definition  # noqa F401
+from .syntax import validate_nxdl  # noqa F401

--- a/dev_tools/nxdl/syntax.py
+++ b/dev_tools/nxdl/syntax.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from typing import Optional
 
 import lxml.etree
+import xmlschema
 
 from ..globals import errors
 from ..globals.directories import get_xsd_file
@@ -12,24 +13,34 @@ def nxdl_schema() -> lxml.etree.XMLSchema:
     return lxml.etree.XMLSchema(lxml.etree.parse(get_xsd_file()))
 
 
+def validate_nxdl():
+    """Validate the NXDL schema itself.
+
+    :raises XMLSchemaParseError:
+    """
+    xsd_path = get_xsd_file()
+    _ = xmlschema.XMLSchema(xsd_path)
+
+
 def validate_definition(
-    xml_file_name: PathLike,
+    xml_path: PathLike,
     xml_schema: Optional[lxml.etree.XMLSchema] = None,
 ):
-    xml_file_name = str(xml_file_name)
-    with _handle_xml_error(xml_file_name, lxml.etree.XMLSyntaxError):
-        xml_tree = lxml.etree.parse(xml_file_name)
+    """Validate an NXDL instance (NeXus definition)."""
+    xml_path = str(xml_path)
+    with _handle_xml_error(xml_path, lxml.etree.XMLSyntaxError):
+        xml_tree = lxml.etree.parse(xml_path)
     if xml_schema is None:
         xml_schema = nxdl_schema()
-    with _handle_xml_error(xml_file_name, lxml.etree.DocumentInvalid):
+    with _handle_xml_error(xml_path, lxml.etree.DocumentInvalid):
         xml_schema.assertValid(xml_tree)
 
 
 @contextmanager
-def _handle_xml_error(xml_file_name: str, *exception_types):
+def _handle_xml_error(xml_path: str, *exception_types):
     try:
         yield
     except exception_types as e:
         raise errors.XMLSyntaxError(
-            "\n  " + "\n  ".join([xml_file_name] + str(e).rsplit(":", 1))
+            "\n  " + "\n  ".join([xml_path] + str(e).rsplit(":", 1))
         ) from e

--- a/dev_tools/tests/test_nxdl.py
+++ b/dev_tools/tests/test_nxdl.py
@@ -4,6 +4,7 @@ from ..nxdl import find_definition
 from ..nxdl import iter_definitions
 from ..nxdl import nxdl_schema
 from ..nxdl import validate_definition
+from ..nxdl import validate_nxdl
 from .utils import pytest_path_param_id
 
 
@@ -26,8 +27,12 @@ def xml_schema():
     return nxdl_schema()
 
 
+def test_nxdl_syntax():
+    validate_nxdl()
+
+
 @pytest.mark.parametrize(
     "nxdl_file", list(iter_definitions()), ids=pytest_path_param_id
 )
-def test_nxdl_syntax(nxdl_file, xml_schema):
+def test_nexus_syntax(nxdl_file, xml_schema):
     validate_definition(nxdl_file, xml_schema)

--- a/manual/source/nxdl-types.rst
+++ b/manual/source/nxdl-types.rst
@@ -20,7 +20,7 @@ with any of these data types. The default type ``NX_CHAR`` is applied in cases
 where a field or attribute is defined in an NXDL specification without explicit assignment of a ``type``.
 
 ..  Generated from ../nxdlTypes.xsd via a custom Python tool
-    ../../utils/types2rst.py ../../nxdlTypes.xsd > types.table
+    dev_tools.docs.xsd_units.generate_xsd_units_doc
 
 .. index::
    seealso: binary data; NX_BINARY

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -90,12 +90,14 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of angle
-				<xs:element name="example">rad</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>rad</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
-	
+
 	<xs:simpleType name="NX_ANY">
 		<xs:annotation>
 			<xs:documentation>
@@ -109,9 +111,11 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of area
-				<xs:element name="example">m^2</xs:element>
-				<xs:element name="example">barns</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>m^2</example>
+				<example>barns</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -130,8 +134,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of area (alias of NX_AREA)
-				<xs:element name="example">barn</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>barn</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:union memberTypes="nxdl:NX_AREA" />
 	</xs:simpleType>
@@ -140,8 +146,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of electrical charge
-				<xs:element name="example">C</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>C</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -150,8 +158,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of electrical current
-				<xs:element name="example">A</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>A</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -161,8 +171,10 @@
 			<xs:documentation>
 				units for fields where the units cancel out
 				(NOTE: not the same as NX_UNITLESS)
-				<xs:element name="example">m/m</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>m/m</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -172,8 +184,10 @@
 			<xs:documentation>
 				units of emittance (``length * angle``) of a
 				radiation source
-				<xs:element name="example">nm*rad</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>nm*rad</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -182,9 +196,11 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of energy
-				<xs:element name="example">J</xs:element>
-				<xs:element name="example">keV</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>J</example>
+				<example>keV</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -193,8 +209,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of flux
-				<xs:element name="example">1/s/cm^2</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>1/s/cm^2</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -203,8 +221,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of frequency
-				<xs:element name="example">Hz</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>Hz</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -213,8 +233,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of length
-				<xs:element name="example">m</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>m</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -223,8 +245,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of mass
-				<xs:element name="example">g</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>g</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -233,8 +257,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of mass density
-				<xs:element name="example">g/cm^3</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>g/cm^3</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -243,8 +269,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of molecular weight
-				<xs:element name="example">g/mol</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>g/mol</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -253,8 +281,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of 1/length^2
-				<xs:element name="example">1/m^2</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>1/m^2</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -263,8 +293,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of 1/length
-				<xs:element name="example">1/m</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>1/m</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -274,8 +306,10 @@
 			<xs:documentation>
 				units of time, period of pulsed source
 				(alias to `NX_TIME`)
-				<xs:element name="example">us</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>us</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -284,8 +318,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of power
-				<xs:element name="example">W</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>W</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -294,8 +330,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of pressure
-				<xs:element name="example">Pa</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>Pa</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -315,8 +353,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of scattering length density
-				<xs:element name="example">m/m^3</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>m/m^3</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<!-- isn't this an alias of NX_PER_AREA?
 			Could also be alias of NX_LENGTH (cm^2/atom) -->
@@ -328,9 +368,11 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of solid angle
-				<xs:element name="example">sr</xs:element>
-				<xs:element name="example">steradian</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>sr</example>
+				<example>steradian</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -339,8 +381,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of temperature
-				<xs:element name="example">K</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>K</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -349,8 +393,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of time
-				<xs:element name="example">s</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>s</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -360,8 +406,10 @@
 			<xs:documentation>
 				units of (neutron) time of flight
 				(alias to `NX_TIME`)
-				<xs:element name="example">s</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>s</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -398,8 +446,10 @@
 			<xs:documentation>
 				for fields that don't have a unit (e.g. hkl) so that they don't
 				inherit the wrong units (NOTE: not the same as NX_DIMENSIONLESS)
-				<xs:element name="example">""</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>""</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -408,8 +458,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of voltage
-				<xs:element name="example">V</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>V</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -418,8 +470,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of volume
-				<xs:element name="example">m^3</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>m^3</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -428,8 +482,10 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of wavelength
-				<xs:element name="example">angstrom</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>angstrom</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -438,9 +494,11 @@
 		<xs:annotation>
 			<xs:documentation>
 				units of wavenumber or Q
-				<xs:element name="example">1/nm</xs:element>
-				<xs:element name="example">1/angstrom</xs:element>
 			</xs:documentation>
+			<xs:appinfo>
+				<example>1/nm</example>
+				<example>1/angstrom</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<!-- isn't this an alias of NX_PER_LENGTH? -->
 		<!-- <xs:union memberTypes="nxdl:NX_PER_LENGTH" /> -->

--- a/nxdlTypes.xsd
+++ b/nxdlTypes.xsd
@@ -93,6 +93,7 @@
 			</xs:documentation>
 			<xs:appinfo>
 				<example>rad</example>
+				<example>deg</example>
 			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
@@ -126,6 +127,9 @@
 				units of quantity of item(s) such as number of photons,
 				neutrons, pulses, or other counting events
 			</xs:documentation>
+			<xs:appinfo>
+				<example>""</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>
@@ -345,6 +349,9 @@
 
 				units of clock pulses (alias to `NX_NUMBER`)
 			</xs:documentation>
+			<xs:appinfo>
+				<example>""</example>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string" />
 	</xs:simpleType>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 lxml
 pyyaml
 nyaml>=0.2.2
+xmlschema
 
 # Documentation building
 sphinx<9


### PR DESCRIPTION
The current XSD files are not strictly valid: [xs:element](https://www.w3schools.com/xml/el_element.asp) under [xs:documentation](https://www.w3schools.com/xml/el_documentation.asp) [cannot contain character data](https://github.com/sissaschool/xmlschema/issues/390#issuecomment-1986452747).

We use this to provide machine-readable examples to the NXDL units for doc generation

```xml
<xs:simpleType name="NX_ANGLE">
    <xs:annotation>
        <xs:documentation>
            units of angle
            <xs:element name="example">rad</xs:element>
        </xs:documentation>
    </xs:annotation>
    <xs:restriction base="xs:string" />
</xs:simpleType>
```

But [xs:annotation](https://www.w3schools.com/xml/el_annotation.asp) has [xs:appinfo](https://www.w3schools.com/xml/el_appinfo.asp) for machine-readable content

```xml
<xs:simpleType name="NX_ANGLE">
    <xs:annotation>
        <xs:documentation>
            units of angle
        </xs:documentation>
        <xs:appinfo>
            <example>rad</example>
        </xs:appinfo>
    </xs:annotation>
    <xs:restriction base="xs:string" />
</xs:simpleType>
```

This PR:

- Use `xs:appinfo` in nxdlTypes.xsd
- Add validation of the xsd files themselves to the unit tests