### PR TITLE
tests: improve output of "pytest -v"

### DIFF
--- a/dev_tools/tests/test_docs.py
+++ b/dev_tools/tests/test_docs.py
@@ -6,6 +6,7 @@ from ..docs import XSDDocGenerator
 from ..docs import nxdl_indices
 from ..globals.directories import get_xsd_file
 from ..nxdl import iter_definitions
+from .utils import pytest_path_param_id
 
 
 @pytest.fixture(scope="module")
@@ -26,17 +27,23 @@ def anchor_registry_write(tmpdir_factory):
     reg.write()
 
 
-@pytest.mark.parametrize("nxdl_file", list(iter_definitions()))
+@pytest.mark.parametrize(
+    "nxdl_file", list(iter_definitions()), ids=pytest_path_param_id
+)
 def test_nxdl_generate_doc(nxdl_file, doc_generator):
     assert doc_generator(nxdl_file)
 
 
-@pytest.mark.parametrize("nxdl_file", list(iter_definitions()))
+@pytest.mark.parametrize(
+    "nxdl_file", list(iter_definitions()), ids=pytest_path_param_id
+)
 def test_nxdl_anchor_list(nxdl_file, doc_generator, anchor_registry):
     assert doc_generator(nxdl_file, anchor_registry=anchor_registry)
 
 
-@pytest.mark.parametrize("nxdl_file", list(iter_definitions()))
+@pytest.mark.parametrize(
+    "nxdl_file", list(iter_definitions()), ids=pytest_path_param_id
+)
 def test_nxdl_anchor_write_list(nxdl_file, doc_generator, anchor_registry_write):
     assert doc_generator(nxdl_file, anchor_registry=anchor_registry_write)
 

--- a/dev_tools/tests/test_nxdl.py
+++ b/dev_tools/tests/test_nxdl.py
@@ -4,6 +4,7 @@ from ..nxdl import find_definition
 from ..nxdl import iter_definitions
 from ..nxdl import nxdl_schema
 from ..nxdl import validate_definition
+from .utils import pytest_path_param_id
 
 
 def test_iter_definitions():
@@ -25,6 +26,8 @@ def xml_schema():
     return nxdl_schema()
 
 
-@pytest.mark.parametrize("nxdl_file", list(iter_definitions()))
+@pytest.mark.parametrize(
+    "nxdl_file", list(iter_definitions()), ids=pytest_path_param_id
+)
 def test_nxdl_syntax(nxdl_file, xml_schema):
     validate_definition(nxdl_file, xml_schema)

--- a/dev_tools/tests/utils.py
+++ b/dev_tools/tests/utils.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+def pytest_path_param_id(path: Path) -> str:
+    return f"{path.parent.name}/{path.name}"


### PR DESCRIPTION


```
pytest -v
```

currently gives

```
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file0] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file1] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file2] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file3] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file4] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file5] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file6] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file7] PASSED                                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[nxdl_file8] PASSED                                        [  0%]
...
```

and after this PR

```
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXapm.nxdl.xml] PASSED                       [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXarchive.nxdl.xml] PASSED                   [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXarpes.nxdl.xml] PASSED                     [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXazint1d.nxdl.xml] PASSED                   [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXazint2d.nxdl.xml] PASSED                   [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXcanSAS.nxdl.xml] PASSED                    [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXdirecttof.nxdl.xml] PASSED                 [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXellipsometry.nxdl.xml] PASSED              [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXem.nxdl.xml] PASSED                        [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXfluo.nxdl.xml] PASSED                      [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXindirecttof.nxdl.xml] PASSED               [  0%]
dev_tools/tests/test_docs.py::test_nxdl_generate_doc[applications/NXiqproc.nxdl.xml] PASSED                    [  0%]
```
