### PR TITLE
application - NXtomo: add 'half_acquisition' field.

### DIFF
--- a/applications/NXtomo.nxdl.xml
+++ b/applications/NXtomo.nxdl.xml
@@ -101,6 +101,19 @@
           </field>
           <field name="x_rotation_axis_pixel_position" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/> 
           <field name="y_rotation_axis_pixel_position" type="NX_FLOAT" minOccurs="0" maxOccurs="1"/> 
+          <field name="half_acquisition" type="NX_BOOLEAN" minOccurs="0" maxOccurs="1">
+            <doc>
+              In tomography, half-acquisition scanning mode allows you to double the field of view.
+              
+              In half-acquisition mode, the rotation axis is deliberately offset toward one edge of the detector.
+              And the sample is not fully covered by the detector at any given angle.
+              
+              As a consequence, a pre-processing step is required to reconstruct the complete (full-field of view) sinogram
+              before performing the tomographic reconstruction (stitching/merging of the projections acquired at complementary angles).
+              
+              Also note that acquisitions with an offset rotation center are not necessarily half-acquisitions.
+            </doc>
+          </field>
         </group>
       </group>
       <group type="NXsample" name="sample">

--- a/applications/NXtomo.nxdl.xml
+++ b/applications/NXtomo.nxdl.xml
@@ -111,7 +111,8 @@
               As a consequence, a pre-processing step is required to reconstruct the complete (full-field of view) sinogram
               before performing the tomographic reconstruction (stitching/merging of the projections acquired at complementary angles).
               
-              Also note that acquisitions with an offset rotation center are not necessarily half-acquisitions.
+              Also note that acquisitions with an offset rotation center are not necessarily half-acquisitions, and conversely,
+              if the rotation axis is not offset, the half-acquisition mode loses its purpose.
             </doc>
           </field>
         </group>


### PR DESCRIPTION
This PR propose to add the "half_acquisition" field to the NXtomo application.

* Half-acquisition scanning mode allows the field of view to be increased. Processing needs to be aware of it.
* The name half-acquisition is commonly accepted amount the community.

**Note:**
In a perfect world, the NXtomo could store pre-processed sinograms / projections directly, and this field would not be needed.
In reality, however, NXtomo applications are generated from detector raw data, with the processing embedded in the processing pipeline so that computation can happen on the fly. This makes the process less memory-intensive and this field required.