### PR TITLE
add stagnant_contributions dir

### DIFF
--- a/stagnant_contributions/readme.txt
+++ b/stagnant_contributions/readme.txt
@@ -1,0 +1,3 @@
+# stagnant_contributions is a directory intended to hold definitions that are not used
+# but may have been used or have had development done to them.
+


### PR DESCRIPTION
stagnant_contributions is a directory intended to hold definitions that are not used but may have been used or have had development done to them.


closes #1644 