### PR TITLE
docs: fix collapse summary truncation

### DIFF
--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -585,7 +585,7 @@ class NXClassDocGenerator:
     @staticmethod
     def _has_unbalanced_runs(text: str, pattern: "re.Pattern[str]") -> bool:
         """Whether text has an odd number of matching delimiter runs, e.g. a `role` or ``literal``
-        cut off before its closing backticks."""
+        cut off before its closing delimiters."""
         stack: List[str] = []
         for run in pattern.findall(text):
             if stack and stack[-1] == run:

--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -22,6 +22,9 @@ from .anchor_list import AnchorRegistry
 MIN_COLLAPSE_HINT_LINE_LENGTH = 20
 MAX_COLLAPSE_HINT_LINE_LENGTH = 80
 
+_BACKTICK_RUN = re.compile(r"`+")
+_ASTERISK_RUN = re.compile(r"\*+")
+
 
 class NXClassDocGenerator:
     """Generate documentation in reStructuredText markup
@@ -576,8 +579,41 @@ class NXClassDocGenerator:
             for single_line in lines:
                 if len(single_line) > 2 and single_line[0] != "." and not fnd:
                     fnd = True
-                    line = single_line[:max_characters]
+                    line = self._truncate_rst_line(single_line, max_characters)
         return (length, line, blocks)
+
+    @staticmethod
+    def _has_unbalanced_runs(text: str, pattern: "re.Pattern[str]") -> bool:
+        """Whether text has an odd number of matching delimiter runs, e.g. a `role` or ``literal``
+        cut off before its closing backticks."""
+        stack: List[str] = []
+        for run in pattern.findall(text):
+            if stack and stack[-1] == run:
+                stack.pop()
+            else:
+                stack.append(run)
+        return bool(stack)
+
+    @staticmethod
+    def _truncate_rst_line(text: str, max_length: int) -> str:
+        """Truncate text to at most max_length characters without leaving unterminated RST inline
+        markup (a role/link cut mid-``target``) or a dangling implicit hyperlink reference (word_).
+        """
+        candidate = text[:max_length]
+        while candidate:
+            stripped = candidate.rstrip()
+            if (
+                not stripped.endswith("_")
+                and not NXClassDocGenerator._has_unbalanced_runs(
+                    stripped, _BACKTICK_RUN
+                )
+                and not NXClassDocGenerator._has_unbalanced_runs(
+                    stripped, _ASTERISK_RUN
+                )
+            ):
+                return candidate
+            candidate = candidate.rsplit(" ", 1)[0] if " " in candidate else ""
+        return candidate
 
     def _print_doc_enum(self, indent, ns, node, required=False):
         collapse_indent = indent


### PR DESCRIPTION
### The problem: doc build fails

CI is currently broken. `make local` is failing because the collapse-summary truncation`long_doc()` in dev_tools/docs/nxdl.py, currently a blind `single_line[:max_characters] slice`, is cutting doc text mid RST inline-markup.

Examples:

<img width="552" height="69" alt="image" src="https://github.com/user-attachments/assets/c6ac93a3-7c1d-48b5-a1a4-9c340de1dbb4" />

<img width="587" height="80" alt="image" src="https://github.com/user-attachments/assets/bec6c2c2-86e5-47f0-977e-c4a6b55a1542" />

### Traceback

This produces 28 docutils warnings (fatal under -W) and one Unknown target name error.

<details>
<summary>Errors regarding "start-string without end-string" due to truncation... </summary>

```bash
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXapm.rst:2517: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXcanSAS.rst:1569: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXmpes.rst:335: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXmpes.rst:434: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXmpes_arpes.rst:690: WARNING: Inline literal start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXmx.rst:579: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXmx.rst:621: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXstress.rst:1205: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXstress.rst:1494: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXstress.rst:1527: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/applications/NXxeuler.rst:20: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXapm_charge_state_analysis.rst:84: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXatom.rst:247: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXcalibration.rst:172: WARNING: Inline literal start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXdata.rst:315: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXdata.rst:419: WARNING: Inline literal start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXdata.rst:522: WARNING: Inline literal start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXdetector_module.rst:132: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXfit.rst:145: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXfit.rst:203: WARNING: Inline literal start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/base_classes/NXimage.rst:103: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXapm_paraprobe_nanochem_config.rst:403: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXmicrostructure_ipf.rst:50: ERROR: Unknown target name: "axis". [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXmicrostructure_odf.rst:166: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXmicrostructure_score_config.rst:758: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXregion.rst:119: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXsolid_geometry.rst:57: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXxpcs.rst:392: WARNING: Inline literal start-string without end-string. [docutils]
/home/runner/work/definitions/definitions/build/manual/source/classes/contributed_definitions/NXxpcs.rst:486: WARNING: Inline literal start-string without end-string. [docutils]
```
</details>

### The solution: fix long_doc truncation

This PR strips the partial RST inline-markups.

Examples:

<img width="486" height="69" alt="image" src="https://github.com/user-attachments/assets/4b28fe3e-7492-4e35-9240-77971676d0ea" />

<img width="536" height="69" alt="image" src="https://github.com/user-attachments/assets/6b36904c-23d9-4d55-85b1-cb173adb122b" />