### PR TITLE
Feature: reusing documentation of inherited concepts (groups/fields/symbols) and validate+fix symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ YCONTRIB_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildca
 YAPPDEF_NXDL_TARGETS = $(patsubst %.yaml,%.nxdl.xml,$(subst /nyaml/,/, $(wildcard $(APPDEF_DIR)/nyaml/*.yaml)))
 
 
-.PHONY: help install style autoformat test clean prepare html pdf impatient-guide all local nxdl nyaml
+.PHONY: help install style autoformat test docdiff clean prepare html pdf impatient-guide all local nxdl nyaml
 
 help ::
 	@echo ""
@@ -27,6 +27,8 @@ help ::
 	@echo "make style              Check python coding style."
 	@echo "make autoformat         Format all files to the coding style conventions."
 	@echo "make test               Run NXDL syntax and documentation tests."
+	@echo "make docdiff            Diff the generated documentation between two git"
+	@echo "                        references. Default: REFS=\"HEAD~1 HEAD\"."
 	@echo "make clean              Remove all build files."
 	@echo "make prepare            (Re)create all build files."
 	@echo "make html               Build HTML version of manual. Requires prepare first."
@@ -57,6 +59,10 @@ autoformat ::
 
 test ::
 	$(PYTHON) -m pytest dev_tools
+
+# for example: make docdiff REFS="HEAD~3 ." NXCLASS="-c NXstress"
+docdiff ::
+	$(PYTHON) -m dev_tools docdiff $(NXCLASS) $(REFS)
 
 clean ::
 	$(RM) -rf $(BUILD_DIR)

--- a/applications/NXapm.nxdl.xml
+++ b/applications/NXapm.nxdl.xml
@@ -69,6 +69,21 @@
                 Number of mass resolution values.
             </doc>
         </symbol>
+        <symbol name="n_i">
+            <doc>Number of pixels along the i direction of a two-dimensional image.</doc>
+        </symbol>
+        <symbol name="n_j">
+            <doc>Number of pixels along the j direction of a two-dimensional image.</doc>
+        </symbol>
+        <symbol name="n_x">
+            <doc>Number of points along the x direction of a three-dimensional grid.</doc>
+        </symbol>
+        <symbol name="n_y">
+            <doc>Number of points along the y direction of a three-dimensional grid.</doc>
+        </symbol>
+        <symbol name="n_z">
+            <doc>Number of points along the z direction of a three-dimensional grid.</doc>
+        </symbol>
     </symbols>
     <doc>
         Application definition for real or simulated atom probe and field-ion microscopy experiments.

--- a/applications/NXellipsometry.nxdl.xml
+++ b/applications/NXellipsometry.nxdl.xml
@@ -51,6 +51,12 @@
                 Number of angles of incidence of the incident beam.
             </doc>
         </symbol>
+        <symbol name="N_observables">
+            <doc>Number of observables of the measured data (2nd dimension of the measured_data array), as described by 'data_type'.</doc>
+        </symbol>
+        <symbol name="N_sensors">
+            <doc>Number of sensors, one for each varied parameter.</doc>
+        </symbol>
     </symbols>
     <doc>
         This is the application definition describing ellipsometry experiments.

--- a/applications/NXstress.nxdl.xml
+++ b/applications/NXstress.nxdl.xml
@@ -43,12 +43,8 @@
         <symbol name="c_Unit">
             <doc>Converted diffractogram X units (could be the same as *x_Unit*).</doc>
         </symbol>
-        <symbol name="n_Temp">
-            <doc>number of temperatures</doc>
-        </symbol>
-		<symbol name="n_sField">
-            <doc>number of values in applied stress field</doc>
-        </symbol>
+        <symbol name="n_Temp" reused_from="NXsample"/>
+        <symbol name="n_sField" reused_from="NXsample"/>
         <symbol name="nP">
             <doc>number of scan points (only present in scanning measurements)</doc>
         </symbol>
@@ -59,6 +55,20 @@
             <doc>number of detector pixels in the second (faster) direction</doc>
         </symbol>
     </symbols>
+    <reused_concepts>
+        <doc>
+            Concepts that this application definition does not add anything to, but that
+            are documented here because they are relevant for stress and strain analysis.
+        </doc>
+        <reuse path="/ENTRY/title"/>
+        <reuse path="/ENTRY/experiment_responsible/name"/>
+        <reuse path="/ENTRY/instrument/DETECTOR/description"/>
+        <reuse path="/ENTRY/instrument/DETECTOR/dead_time"/>
+        <reuse path="/ENTRY/instrument/DETECTOR/count_time"/>
+        <reuse path="/ENTRY/SAMPLE_DESCRIPTION/chemical_formula"/>
+        <reuse path="/ENTRY/SAMPLE_DESCRIPTION/temperature"/>
+        <reuse path="/ENTRY/FIT/data_reduction_responsible/name"/>
+    </reused_concepts>
     <doc>
     Application definition for stress and strain analysis of crystalline material defined by the `EASI-STRESS consortium &lt;https://easi-stress.eu&gt;`_.
 
@@ -105,9 +115,6 @@
             <enumeration>
                 <item value="NXstress" />
             </enumeration>
-        </field>
-        <field name="title" minOccurs="0" maxOccurs="1">
-            <doc>Extended title for the entry.</doc>
         </field>
         <field name="experiment_identifier" minOccurs="0" maxOccurs="1">
             <doc>
@@ -196,10 +203,8 @@
         </field>
         <group name="experiment_responsible" type="NXuser" minOccurs="0" maxOccurs="1">
             <doc>Information about the person who performed the experiment.</doc>
-            <field name="name" type="NX_CHAR" minOccurs="0" maxOccurs="1">
-            </field>
             <field name="role" type="NX_CHAR" minOccurs="0" maxOccurs="1">
-                <doc>Role of user responsible for this entry. Suggested roes are, for example, ``local contact``, ``beamline_scientist``, ``post_doc``,…</doc>
+                <doc>Role of user responsible for this entry. Suggested roles are, for example, ``local contact``, ``beamline_scientist``, ``post_doc``,…</doc>
             </field>
         </group>
         <group name="instrument" type="NXinstrument" minOccurs="1" maxOccurs="1">
@@ -258,9 +263,6 @@
             </group>
             <group name="DETECTOR" nameType="any" type="NXdetector" minOccurs="1" maxOccurs="unbounded">
                 <doc>Zero or more of these groups describe the detectors used in the experiment.</doc>
-                <field name="description" type="NX_CHAR" minOccurs="0" maxOccurs="1">
-                    <doc>name/manufacturer/model/etc. information</doc>
-                </field>
                 <field name="type" type="NX_CHAR">
 		            <doc>
 			                Description of type such as \ :sup:`3`\ He gas cylinder, \ :sup:`3`\ He PSD, scintillator, fission chamber, proportion counter, ion chamber, CCD, pixel, image plate, CMOS, …
@@ -307,20 +309,6 @@
                     <dimensions rank="2">
                       <dim index="1" value="i" />
                       <dim index="2" value="j" />
-                    </dimensions>
-                </field>
-                <field name="dead_time" type="NX_FLOAT" units="NX_TIME" minOccurs="0" maxOccurs="1">
-                    <doc>Detector dead time</doc>
-                    <dimensions rank="3">
-                        <dim index="1" value="nP" />
-                        <dim index="2" value="i" />
-                        <dim index="3" value="j" />
-                    </dimensions>
-                </field>
-                <field name="count_time" type="NX_NUMBER" units="NX_TIME" minOccurs="0" maxOccurs="1">
-                    <doc>Elapsed actual counting time</doc>
-                    <dimensions rank="1">
-                        <dim index="1" value="nP" />
                     </dimensions>
                 </field>
                 <field name="depends_on" type="NX_CHAR" minOccurs="0" maxOccurs="1">
@@ -442,34 +430,6 @@
                     Descriptive name of sample
                 </doc>
             </field>
-            <field name="chemical_formula" minOccurs="0" maxOccurs="1">
-		        <doc>
-			        The chemical formula specified using CIF conventions.
-			        Abbreviated version of CIF standard: 
-
-			        * Only recognized element symbols may be used.
-			        * Each element symbol is followed by a 'count' number. A count of '1' may be omitted.
-			        * A space or parenthesis must separate each cluster of (element symbol + count).
-			        * Where a group of elements is enclosed in parentheses, the multiplier for the 
-			          group must follow the closing parentheses. That is, all element and group 
-			          multipliers are assumed to be printed as subscripted numbers.
-			        * Unless the elements are ordered in a manner that corresponds to their chemical 
-			          structure, the order of the elements within any group or moiety depends on 
-			          whether or not carbon is present.
-			        * If carbon is present, the order should be: 
-
-			          - C, then H, then the other elements in alphabetical order of their symbol. 
-			          - If carbon is not present, the elements are listed purely in alphabetic order of their symbol. 
-
-			        * This is the *Hill* system used by Chemical Abstracts.
-		        </doc>
-	        </field>
-            <field name="temperature" type="NX_FLOAT" units="NX_TEMPERATURE" minOccurs="0" maxOccurs="1">
-		        <doc>Sample temperature. This could be a scanned variable</doc>
-		        <dimensions rank="anyRank">
-		                	<dim index="1" value="n_Temp"/><!-- could be any length -->
-		        </dimensions>
-	        </field>
             <field name="stress_field" type="NX_FLOAT" units="NX_ANY" minOccurs="0" maxOccurs="1">
 		        <doc>Applied external stress field</doc>
 		        <dimensions>
@@ -587,8 +547,6 @@
             </field>
             <group name="data_reduction_responsible" type="NXuser" minOccurs="0" maxOccurs="1">
                 <doc>Information about the person who performed the data reduction.</doc>
-                    <field name="name" type="NX_CHAR" minOccurs="0" maxOccurs="1">
-                    </field>
                     <field name="role" type="NX_CHAR" minOccurs="0" maxOccurs="1">
                         <doc>Role of user responsible for this entry. Suggested roles are, for example, ``local contact``, ``beamline_scientist``, ``post_doc``,…</doc>
                     </field>        

--- a/applications/NXtomophase.nxdl.xml
+++ b/applications/NXtomophase.nxdl.xml
@@ -159,7 +159,7 @@
           fluctuations in the beam between frames.
 	</doc>
           <dimensions rank="1">
-            <dim index="1" value="nDarkFrames + nBrightFrames + nSampleFrame" />
+            <dim index="1" value="nDarkFrames + nBrightFrames + nSampleFrames" />
             <!-- TODO: nPhase? -->
           </dimensions>
         </field>

--- a/base_classes/NXbeam.nxdl.xml
+++ b/base_classes/NXbeam.nxdl.xml
@@ -39,6 +39,12 @@
         <symbol name="c">
             <doc>Number of moments representing beam divergence (x, y, xy, etc.)</doc>
         </symbol>
+        <symbol name="nx">
+            <doc>Number of delay points in the FROG trace.</doc>
+        </symbol>
+        <symbol name="ny">
+            <doc>Number of frequency points in the FROG trace.</doc>
+        </symbol>
     </symbols>
     <doc>
         Properties of the neutron or X-ray beam at a given location. 

--- a/base_classes/NXdetector.nxdl.xml
+++ b/base_classes/NXdetector.nxdl.xml
@@ -44,6 +44,9 @@
     <symbol name="j"><doc>number of detector pixels in the second (faster) direction</doc></symbol>
     <symbol name="k"><doc>number of detector pixels in the third (if necessary, fastest) direction</doc></symbol>
     <symbol name="tof"><doc>number of bins in the time-of-flight histogram</doc></symbol>
+    <symbol name="m">
+        <doc>number of entries in the count-rate correction lookup table</doc>
+    </symbol>
   </symbols>
 
   <doc>
@@ -731,7 +734,7 @@
       In cases where the data is of type :ref:`NXlog` this can also be an NXlog.
     </doc>
     <dimensions rank="1">
-      <dim index="1" value="np" />
+      <dim index="1" value="nP" />
     </dimensions>
   </field>
 

--- a/base_classes/NXdetector_group.nxdl.xml
+++ b/base_classes/NXdetector_group.nxdl.xml
@@ -26,6 +26,11 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     name="NXdetector_group" 
 	type="group" extends="NXobject">
+	<symbols>
+		<symbol name="i">
+			<doc>number of detectors and groups of detectors</doc>
+		</symbol>
+	</symbols>
 	<doc>
 		Logical grouping of detectors. When used, describes a group of detectors.
 

--- a/base_classes/NXevent_data.nxdl.xml
+++ b/base_classes/NXevent_data.nxdl.xml
@@ -26,6 +26,17 @@
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	name="NXevent_data" 
 	type="group" extends="NXobject">
+  <symbols>
+    <symbol name="i">
+      <doc>number of events</doc>
+    </symbol>
+    <symbol name="j">
+      <doc>number of pulses</doc>
+    </symbol>
+    <symbol name="k">
+      <doc>number of detector ends that are read out for each event</doc>
+    </symbol>
+  </symbols>
   <doc>
     NXevent_data is a special group for storing data from neutron
     detectors in event mode.  In this mode, the detector electronics

--- a/base_classes/NXfilter.nxdl.xml
+++ b/base_classes/NXfilter.nxdl.xml
@@ -30,6 +30,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+	<symbols>
+		<symbol name="n_comp">
+			<doc>number of compositions of the filter material</doc>
+		</symbol>
+		<symbol name="nsurf">
+			<doc>number of reflecting surfaces</doc>
+		</symbol>
+	</symbols>
 	<doc>
 		For band pass beam filters.
 		

--- a/base_classes/NXoff_geometry.nxdl.xml
+++ b/base_classes/NXoff_geometry.nxdl.xml
@@ -37,6 +37,9 @@
         detecting volumes
       </doc>
     </symbol>
+    <symbol name="j">
+        <doc>length of the winding order list, which is the total number of vertices of all faces</doc>
+    </symbol>
   </symbols>
 
   <doc>

--- a/base_classes/NXorientation.nxdl.xml
+++ b/base_classes/NXorientation.nxdl.xml
@@ -27,6 +27,11 @@
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     name="NXorientation" 
 	type="group" extends="NXobject">
+    <symbols>
+        <symbol name="numobj">
+            <doc>number of objects whose orientation is described</doc>
+        </symbol>
+    </symbols>
     <doc>
         legacy class - recommend to use :ref:`NXtransformations` now
         

--- a/base_classes/NXpositioner.nxdl.xml
+++ b/base_classes/NXpositioner.nxdl.xml
@@ -30,6 +30,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+    <symbols>
+        <symbol name="n">
+            <doc>number of positioner values, which is more than one when the positioner is scanned</doc>
+        </symbol>
+    </symbols>
     <doc>
         A generic positioner such as a motor or piezo-electric transducer.  
     </doc>

--- a/base_classes/NXsensor.nxdl.xml
+++ b/base_classes/NXsensor.nxdl.xml
@@ -26,6 +26,11 @@
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	name="NXsensor" 
 	type="group" extends="NXcomponent">
+	<symbols>
+		<symbol name="n">
+			<doc>number of sensor values, which is more than one when the value is a vector</doc>
+		</symbol>
+	</symbols>
 	<doc>
 		A sensor used to monitor an external condition 
 		

--- a/base_classes/NXshape.nxdl.xml
+++ b/base_classes/NXshape.nxdl.xml
@@ -26,6 +26,14 @@
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	name="NXshape" 
 	type="group" extends="NXobject">
+	<symbols>
+		<symbol name="numobj">
+			<doc>number of objects whose shape is described</doc>
+		</symbol>
+		<symbol name="nshapepar">
+			<doc>number of parameters describing the shape</doc>
+		</symbol>
+	</symbols>
 	<doc>
 		legacy class - (used by :ref:`NXgeometry`) - the shape and size of a component.
 		

--- a/base_classes/NXtranslation.nxdl.xml
+++ b/base_classes/NXtranslation.nxdl.xml
@@ -26,6 +26,11 @@
 	xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
 	name="NXtranslation" 
     type="group" extends="NXobject">
+	<symbols>
+		<symbol name="numobj">
+			<doc>number of objects whose position is described</doc>
+		</symbol>
+	</symbols>
 	<doc>
 		legacy class - (used by :ref:`NXgeometry`) - general spatial location of a component.
 	</doc>

--- a/contributed_definitions/NXapm_compositionspace_results.nxdl.xml
+++ b/contributed_definitions/NXapm_compositionspace_results.nxdl.xml
@@ -41,6 +41,12 @@
                 Total number of ions in the reconstructed dataset.
             </doc>
         </symbol>
+        <symbol name="i">
+            <doc>Number of values along the axis of the respective one-dimensional plot.</doc>
+        </symbol>
+        <symbol name="k">
+            <doc>Number of labels returned by the clustering.</doc>
+        </symbol>
     </symbols>
     <doc>
         Application definition for results of the CompositionSpace tool used in atom probe.

--- a/contributed_definitions/NXapm_paraprobe_clusterer_config.nxdl.xml
+++ b/contributed_definitions/NXapm_paraprobe_clusterer_config.nxdl.xml
@@ -42,7 +42,30 @@
                 Number of different iontypes to distinguish during clustering.
             </doc>
         </symbol>
+        <symbol name="i">
+            <doc>Number of eps respectively min_cluster_size parameter values.</doc>
+        </symbol>
+        <symbol name="j">
+            <doc>Number of min_pts respectively min_samples parameter values.</doc>
+        </symbol>
+        <symbol name="k">
+            <doc>Number of cluster_selection_epsilon parameter values.</doc>
+        </symbol>
+        <symbol name="m">
+            <doc>Number of alpha parameter values.</doc>
+        </symbol>
     </symbols>
+    <reused_concepts>
+        <doc>
+            The tomographic reconstruction that this analysis is based on is specified
+            with concepts of :ref:`NXapm_paraprobe_tool_config`.
+        </doc>
+        <reuse path="/ENTRY/cameca_to_nexus/reconstruction/file_name"/>
+        <reuse path="/ENTRY/cameca_to_nexus/reconstruction/checksum"/>
+        <reuse path="/ENTRY/cameca_to_nexus/reconstruction/algorithm"/>
+        <reuse path="/ENTRY/cameca_to_nexus/reconstruction/position"/>
+        <reuse path="/ENTRY/cameca_to_nexus/reconstruction/mass_to_charge"/>
+    </reused_concepts>
     <doc>
         Application definition for a configuration file of the paraprobe-clusterer tool.
         
@@ -63,13 +86,6 @@
                 a binary file that is formatted like a POS file but cluster labels written out using floating
                 point numbers.
             </doc>
-            <group name="reconstruction" type="NXnote">
-                <field name="file_name" type="NX_CHAR"/>
-                <field name="checksum" type="NX_CHAR"/>
-                <field name="algorithm" type="NX_CHAR"/>
-                <field name="position" type="NX_CHAR"/>
-                <field name="mass_to_charge" type="NX_CHAR"/>
-            </group>
             <group name="results" type="NXnote">
                 <doc>
                     File with the results of the cluster analyses that was computed with IVAS / AP suite

--- a/contributed_definitions/NXapm_paraprobe_clusterer_results.nxdl.xml
+++ b/contributed_definitions/NXapm_paraprobe_clusterer_results.nxdl.xml
@@ -36,6 +36,12 @@
                 Number of clusters found.
             </doc>
         </symbol>
+        <symbol name="i">
+            <doc>Number of targets, i.e. ions of the reconstruction that were considered during clustering.</doc>
+        </symbol>
+        <symbol name="k">
+            <doc>Number of labelled targets returned by the clustering backend, which is not necessarily the number of targets.</doc>
+        </symbol>
     </symbols>
     <doc>
         Application definition for a results file of the paraprobe-clusterer tool.

--- a/contributed_definitions/NXapm_paraprobe_nanochem_results.nxdl.xml
+++ b/contributed_definitions/NXapm_paraprobe_nanochem_results.nxdl.xml
@@ -83,6 +83,27 @@ The cardinality/total number of triangles in the triangle soup.-->
                 The total number of ROIs placed in a oned_profile task.
             </doc>
         </symbol>
+        <symbol name="i">
+            <doc>Number of entries of the respective array, e.g. the number of vertices or the number of features.</doc>
+        </symbol>
+        <symbol name="j">
+            <doc>Number of entries of the respective array, e.g. the number of faces or triangles.</doc>
+        </symbol>
+        <symbol name="k">
+            <doc>Number of entries of the respective array, e.g. the number of triangle normals or edges.</doc>
+        </symbol>
+        <symbol name="m">
+            <doc>The total number of ions inside a polyhedron.</doc>
+        </symbol>
+        <symbol name="n_f">
+            <doc>The total number of faces of a polyhedron.</doc>
+        </symbol>
+        <symbol name="n_v">
+            <doc>The total number of vertices of a polyhedron.</doc>
+        </symbol>
+        <symbol name="n_xyz">
+            <doc>The total number of voxels of the scalar field that is rendered via XDMF.</doc>
+        </symbol>
     </symbols>
     <doc>
         Application definition for a results file of the paraprobe-nanochem tool.

--- a/contributed_definitions/NXapm_paraprobe_surfacer_results.nxdl.xml
+++ b/contributed_definitions/NXapm_paraprobe_surfacer_results.nxdl.xml
@@ -51,6 +51,9 @@
                 The total number of XDMF values to represent all faces of tetrahedra via XDMF.
             </doc>
         </symbol>
+        <symbol name="n_v_tet">
+            <doc>The total number of vertices of the tetrahedra.</doc>
+        </symbol>
     </symbols>
     <doc>
         Application definition for a results file of the paraprobe-surfacer tool.

--- a/contributed_definitions/NXcontainer.nxdl.xml
+++ b/contributed_definitions/NXcontainer.nxdl.xml
@@ -29,6 +29,11 @@
 	type="group"
 	extends="NXcomponent"
 	>
+	<symbols>
+		<symbol name="n_comp">
+			<doc>number of compositions of the material the container is made from</doc>
+		</symbol>
+	</symbols>
 
 	<doc>
 		State of a container holding the sample under investigation.

--- a/contributed_definitions/NXmicrostructure.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure.nxdl.xml
@@ -114,6 +114,9 @@ The number of line defects.-->
                 configuration/dimensionality
             </doc>
         </symbol>
+        <symbol name="i">
+            <doc>Number of junctions of the respective type.</doc>
+        </symbol>
     </symbols>
     <doc>
         Base class to describe a microstructure, its structural aspects, associated descriptors, properties.

--- a/contributed_definitions/NXmicrostructure_score_results.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_score_results.nxdl.xml
@@ -69,6 +69,15 @@ inspect comments behind NXmicrostructure-->
                 Number of grains in the computer simulation
             </doc>
         </symbol>
+        <symbol name="n_x">
+            <doc>Number of grid points along the x direction.</doc>
+        </symbol>
+        <symbol name="n_y">
+            <doc>Number of grid points along the y direction.</doc>
+        </symbol>
+        <symbol name="n_z">
+            <doc>Number of grid points along the z direction.</doc>
+        </symbol>
     </symbols>
     <doc>
         Application definition for storing results of the SCORE cellular automata model.

--- a/contributed_definitions/NXmicrostructure_slip_system.nxdl.xml
+++ b/contributed_definitions/NXmicrostructure_slip_system.nxdl.xml
@@ -36,6 +36,9 @@
                 Number of indices used for reporting Miller (3) or Miller-Bravais indices (4).
             </doc>
         </symbol>
+        <symbol name="i">
+            <doc>Number of Miller indices describing a crystallographic plane respectively direction.</doc>
+        </symbol>
     </symbols>
     <doc>
         Base class for describing a set of crystallographic slip systems.

--- a/contributed_definitions/NXoptical_polarizer.nxdl.xml
+++ b/contributed_definitions/NXoptical_polarizer.nxdl.xml
@@ -38,6 +38,15 @@ A draft of a new base class to describe an optical polarizer
                 the polarizer is given.
             </doc>
         </symbol>
+        <symbol name="N_objects">
+            <doc>Number of objects the device is made up of.</doc>
+        </symbol>
+        <symbol name="N_shapepar">
+            <doc>Number of parameters describing the shape of the objects.</doc>
+        </symbol>
+        <symbol name="N_spectrum_coating">
+            <doc>Length of the spectrum array of the coating.</doc>
+        </symbol>
     </symbols>
     <doc>
         An optical polarizer.

--- a/contributed_definitions/NXsnsevent.nxdl.xml
+++ b/contributed_definitions/NXsnsevent.nxdl.xml
@@ -8,6 +8,29 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+  <symbols>
+    <symbol name="nvalue">
+      <doc>number of values in the log</doc>
+    </symbol>
+    <symbol name="numvalue">
+      <doc>number of values in the log</doc>
+    </symbol>
+    <symbol name="numx">
+      <doc>number of detector pixels in the x direction</doc>
+    </symbol>
+    <symbol name="numy">
+      <doc>number of detector pixels in the y direction</doc>
+    </symbol>
+    <symbol name="numpulses">
+      <doc>number of pulses</doc>
+    </symbol>
+    <symbol name="numevents">
+      <doc>number of events</doc>
+    </symbol>
+    <symbol name="numtimechannels">
+      <doc>number of time channels of the time-of-flight histogram</doc>
+    </symbol>
+  </symbols>
   <doc>This is a definition for event data from Spallation Neutron Source (SNS) at ORNL.</doc>
   <group type="NXentry" minOccurs="1">
     <group type="NXcollection" name="DASlogs">

--- a/contributed_definitions/NXsnshisto.nxdl.xml
+++ b/contributed_definitions/NXsnshisto.nxdl.xml
@@ -8,6 +8,26 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
     >
+  <symbols>
+    <symbol name="nvalue">
+      <doc>number of values in the log</doc>
+    </symbol>
+    <symbol name="numvalue">
+      <doc>number of values in the log</doc>
+    </symbol>
+    <symbol name="numx">
+      <doc>number of detector pixels in the x direction</doc>
+    </symbol>
+    <symbol name="numy">
+      <doc>number of detector pixels in the y direction</doc>
+    </symbol>
+    <symbol name="numtof">
+      <doc>number of time-of-flight bins</doc>
+    </symbol>
+    <symbol name="numtimechannels">
+      <doc>number of time channels of the time-of-flight histogram</doc>
+    </symbol>
+  </symbols>
   <doc>This is a definition for histogram data from Spallation Neutron Source (SNS) at ORNL.</doc>
   <group type="NXentry" minOccurs="1">
       <group type="NXcollection" name="DASlogs">

--- a/contributed_definitions/NXspm_scan_pattern.nxdl.xml
+++ b/contributed_definitions/NXspm_scan_pattern.nxdl.xml
@@ -22,6 +22,14 @@
 # For further information, see http://www.nexusformat.org
 -->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="base" type="group" name="NXspm_scan_pattern" extends="NXobject" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <symbol name="nTraj">
+            <doc>number of trajectory points</doc>
+        </symbol>
+        <symbol name="nD">
+            <doc>number of dimensions of the phase space in which the trajectory is defined</doc>
+        </symbol>
+    </symbols>
     <doc>
         Basic base class to define the pattern of a scan in a given scan region.
         

--- a/contributed_definitions/NXxrd.nxdl.xml
+++ b/contributed_definitions/NXxrd.nxdl.xml
@@ -25,6 +25,11 @@
 ! : additions
 ? : could or should be modified?-->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXxrd" extends="NXmonopd" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <symbol name="nDet">
+            <doc>number of detector channels of the diffractogram</doc>
+        </symbol>
+    </symbols>
     <doc>
         NXxrd on top of NXmonopd
     </doc>

--- a/contributed_definitions/NXxrd_pan.nxdl.xml
+++ b/contributed_definitions/NXxrd_pan.nxdl.xml
@@ -22,6 +22,11 @@
 # For further information, see http://www.nexusformat.org
 -->
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" category="application" type="group" name="NXxrd_pan" extends="NXxrd" xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <symbol name="nDet">
+            <doc>number of detector channels of the diffractogram</doc>
+        </symbol>
+    </symbols>
     <doc>
         NXxrd_pan is a specialization of NXxrd with extra properties
         for the PANalytical XRD data format.

--- a/dev_tools/__main__.py
+++ b/dev_tools/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 
 from .apps import dir_app
+from .apps import docdiff_app
 from .apps import impatient_app
 from .apps import manual_app
 from .apps import nxclass_app
@@ -35,6 +36,12 @@ def main(argv=None):
     test_app.nxtest_args(nxtest_parser)
     dir_app.dir_args(nxtest_parser)
 
+    docdiff_parser = subparsers.add_parser(
+        "docdiff", help="Diff the generated documentation of two git references"
+    )
+    docdiff_app.docdiff_args(docdiff_parser)
+    dir_app.dir_args(docdiff_parser)
+
     if argv is None:
         argv = sys.argv
     args = parser.parse_args(argv[1:])
@@ -44,6 +51,7 @@ def main(argv=None):
         "manual": manual_app.manual_exec,
         "impatient": impatient_app.impatient_exec,
         "nxtest": test_app.nxtest_exec,
+        "docdiff": docdiff_app.docdiff_exec,
     }.get(args.command)
 
     if app_exec is None:

--- a/dev_tools/apps/docdiff_app.py
+++ b/dev_tools/apps/docdiff_app.py
@@ -1,0 +1,333 @@
+"""Compare the generated documentation of two git references."""
+
+import contextlib
+import difflib
+import fnmatch
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Sequence
+
+from ..globals import directories
+
+# reference name for the working tree, which includes uncommitted changes
+WORKING_TREE = "."
+
+# generated files that are compared (globs relative to the sphinx source directory)
+GENERATED_PATTERNS = (
+    "classes/*/*.rst",
+    "nxdl_desc.rst",
+    "units.table",
+    "types.table",
+    "_static/nxdl_vocabulary.txt",
+)
+
+_ANSI = {
+    "+": "\033[32m",
+    "-": "\033[31m",
+    "@": "\033[36m",
+}
+_ANSI_RESET = "\033[0m"
+
+
+def docdiff_args(parser):
+    parser.add_argument(
+        "refs",
+        nargs="*",
+        metavar="REF",
+        help="Git references to compare, for example 'HEAD~2 HEAD' or a branch "
+        f"name. Use '{WORKING_TREE}' for the working tree, which includes "
+        f"uncommitted changes. Default: 'HEAD~1 HEAD'",
+    )
+    parser.add_argument(
+        "-c",
+        "--nxclass",
+        action="append",
+        metavar="NAME",
+        help="Only compare this NeXus class (for example 'NXstress'). Repeatable. "
+        "Default: all classes",
+    )
+    parser.add_argument(
+        "--context",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Number of context lines in the diff. Default: 3",
+    )
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help="Colorize the diff. Default: auto",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        metavar="FILE",
+        help="Write the diff to this file instead of stdout",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep the generated documentation of both references",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the output of the documentation generation",
+    )
+    parser.add_argument(
+        "--exit-code",
+        action="store_true",
+        help="Exit with 1 when the documentation differs",
+    )
+
+
+def docdiff_exec(args) -> int:
+    refs = args.refs or ["HEAD~1", "HEAD"]
+    if len(refs) != 2:
+        print(f"Expected two git references, got {len(refs)}", file=sys.stderr)
+        return 1
+    repo = Path(directories.get_source_root())
+    root = Path(directories.get_build_root()) / "docdiff"
+
+    generated = list()
+    try:
+        for name, ref in zip(("old", "new"), refs):
+            print(f"generate the documentation of '{ref}' ...", file=sys.stderr)
+            generated.append(
+                _generate_docs(
+                    repo, ref, root / name, args.nxclass, verbose=args.verbose
+                )
+            )
+        diff_lines = list(
+            _diff_directories(
+                *generated, *refs, GENERATED_PATTERNS, context=args.context
+            )
+        )
+    except KeyboardInterrupt:
+        # nothing is left behind when interrupted, also not with --keep
+        with contextlib.suppress(KeyboardInterrupt):
+            _remove_generated(repo, root)
+        print("\ndocdiff: interrupted", file=sys.stderr)
+        return 1
+    except Exception as e:
+        with contextlib.suppress(KeyboardInterrupt):
+            _remove_generated(repo, root)
+        if args.verbose:
+            traceback.print_exc()
+        print(f"docdiff: {e}", file=sys.stderr)
+        return 1
+    if not args.keep:
+        _remove_generated(repo, root)
+
+    nfiles = sum(line.startswith("--- ") for line in diff_lines)
+    if args.output:
+        with open(args.output, "w") as fh:
+            fh.writelines(diff_lines)
+        print(f"{nfiles} file(s) differ, diff written to {args.output}")
+    else:
+        color = args.color == "always" or (args.color == "auto" and sys.stdout.isatty())
+        sys.stdout.writelines(_colorize(diff_lines) if color else diff_lines)
+        print(f"\n{nfiles} file(s) differ", file=sys.stderr)
+    if args.keep:
+        print(
+            f"generated documentation in {root}\n"
+            "remove the git worktrees with 'git worktree prune' after deleting it",
+            file=sys.stderr,
+        )
+
+    return 1 if diff_lines and args.exit_code else 0
+
+
+def _generate_docs(
+    repo: Path,
+    ref: str,
+    dest: Path,
+    nxclasses: Optional[Sequence[str]],
+    verbose: bool = False,
+) -> Path:
+    """Generate the NeXus class documentation of a git reference. Returns the
+    directory with the generated files.
+    """
+    _remove_generated(repo, dest)
+    if ref == WORKING_TREE:
+        source_root = repo
+    else:
+        source_root = dest / "source"
+        _git(repo, "worktree", "add", "--detach", str(source_root), ref)
+    build_root = dest / "build"
+
+    if nxclasses:
+        commands = [["nxclass", name, "--prepare"] for name in nxclasses]
+    else:
+        commands = [["manual", "--prepare"]]
+    # the documentation is generated by the dev_tools of the reference itself
+    env = dict(os.environ)
+    pythonpath = [str(source_root)]
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    env.pop("NEXUS_DEF_PATH", None)
+    for command in commands:
+        _run_generator(
+            [sys.executable, "-m", "dev_tools"]
+            + command
+            + ["--build-root", str(build_root)],
+            ref,
+            source_root,
+            env,
+            verbose,
+        )
+    return build_root / "manual" / "source"
+
+
+def _run_generator(
+    command: Sequence[str], ref: str, cwd: Path, env: dict, verbose: bool
+) -> None:
+    """Run a documentation generator in its own process group, so that a CTRL-C
+    in the terminal is handled here and the process is never left behind.
+    """
+    with subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=None if verbose else subprocess.DEVNULL,
+        stderr=None if verbose else subprocess.PIPE,
+        text=not verbose,
+        start_new_session=True,
+    ) as process:
+        try:
+            _, stderr = process.communicate()
+        except BaseException:
+            _kill(process)
+            raise
+    if process.returncode:
+        raise RuntimeError(
+            f"generating the documentation of '{ref}' failed "
+            f"(exit code {process.returncode})\n{(stderr or '').strip()}"
+        )
+
+
+def _kill(process: subprocess.Popen) -> None:
+    """Kill a process and everything it started."""
+    with contextlib.suppress(BaseException):
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    with contextlib.suppress(BaseException):
+        process.kill()
+
+
+def _remove_generated(repo: Path, root: Path) -> None:
+    """Remove the generated documentation and unregister the git worktrees.
+    Interrupting this leaves nothing behind, it cannot be interrupted.
+    """
+    with _delayed_interrupt():
+        for source_root in [root / "source"] + [
+            root / name / "source" for name in ("old", "new")
+        ]:
+            if not source_root.is_dir():
+                continue
+            with contextlib.suppress(BaseException):
+                _git(
+                    repo, "worktree", "remove", "--force", str(source_root), detach=True
+                )
+        shutil.rmtree(root, ignore_errors=True)
+        with contextlib.suppress(BaseException):
+            _git(repo, "worktree", "prune", detach=True)
+
+
+@contextlib.contextmanager
+def _delayed_interrupt():
+    """Handle SIGINT (CTRL-C) when leaving the context instead of inside it."""
+    interrupted = False
+
+    def handler(*_):
+        nonlocal interrupted
+        interrupted = True
+
+    try:
+        original = signal.signal(signal.SIGINT, handler)
+    except ValueError:
+        yield  # not the main thread
+        return
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, original)
+        if interrupted:
+            raise KeyboardInterrupt
+
+
+def _git(repo: Path, *args: str, detach: bool = False) -> str:
+    """`detach` shields the git process from a CTRL-C in the terminal."""
+    result = subprocess.run(
+        ["git"] + list(args),
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=detach,
+    )
+    if result.returncode in (-signal.SIGINT, -signal.SIGTERM):
+        raise KeyboardInterrupt
+    if result.returncode:
+        raise RuntimeError(f"'git {' '.join(args)}' failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _diff_directories(
+    old_root: Path,
+    new_root: Path,
+    old_ref: str,
+    new_ref: str,
+    patterns: Sequence[str],
+    context: int = 3,
+) -> Iterator[str]:
+    """Unified diff of the generated files of two references."""
+    for relpath in _iter_generated(old_root, new_root, patterns):
+        old_lines = _read(old_root / relpath)
+        new_lines = _read(new_root / relpath)
+        if old_lines == new_lines:
+            continue
+        yield from difflib.unified_diff(
+            old_lines,
+            new_lines,
+            fromfile=f"{old_ref}:{relpath}",
+            tofile=f"{new_ref}:{relpath}",
+            n=context,
+        )
+
+
+def _iter_generated(
+    old_root: Path, new_root: Path, patterns: Sequence[str]
+) -> Iterator[Path]:
+    """Files generated for either reference, in a reproducible order."""
+    relpaths = set()
+    for root in (old_root, new_root):
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            relpath = path.relative_to(root)
+            if any(fnmatch.fnmatch(str(relpath), pattern) for pattern in patterns):
+                relpaths.add(relpath)
+    yield from sorted(relpaths)
+
+
+def _read(path: Path) -> List[str]:
+    if not path.is_file():
+        return list()
+    with open(path, "r") as fh:
+        return list(fh)
+
+
+def _colorize(lines: Sequence[str]) -> Iterator[str]:
+    for line in lines:
+        color = _ANSI.get(line[:1]) if not line.startswith(("+++", "---")) else None
+        yield f"{color}{line}{_ANSI_RESET}" if color else line

--- a/dev_tools/docs/anchor_list.py
+++ b/dev_tools/docs/anchor_list.py
@@ -118,7 +118,7 @@ class AnchorRegistry:
                 datetime=utcnow,
                 title="NeXus NXDL vocabulary.",
                 subtitle="Anchors for all NeXus fields, groups, "
-                "attributes, and links.",
+                "attributes, links, and symbols.",
                 version=get_nxdl_version(),
             ),
             terms=self._registry,

--- a/dev_tools/docs/nxdl.py
+++ b/dev_tools/docs/nxdl.py
@@ -3,8 +3,11 @@ import re
 from collections import OrderedDict
 from html import parser as HTMLParser
 from pathlib import Path
+from typing import Dict
+from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 import lxml
 
@@ -22,8 +25,64 @@ from .anchor_list import AnchorRegistry
 MIN_COLLAPSE_HINT_LINE_LENGTH = 20
 MAX_COLLAPSE_HINT_LINE_LENGTH = 80
 
+# how a concept that is shown in the documentation of a class that does not
+# define it is marked
+REUSED_MARKER = "*(reused)*"
+
+# which children are shown along with a reused concept
+REUSE_CHILDREN_MODES = ("none", "direct", "all")
+
+# maximal number of levels below a reused concept with `children="all"`
+MAX_REUSE_DEPTH = 5
+
+# maximal number of reused concepts in one class
+MAX_REUSED_CONCEPTS = 200
+
+# symbol names in a dimension size, which can be an expression like "nP+1"
+SYMBOL_PATTERN = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+
+# characters that may precede or follow inline markup in reStructuredText
+RST_INLINE_PREFIX = " \t-:/'\"<([{"
+RST_INLINE_SUFFIX = " \t-.,:;!?\\/'\")]}>"
+
 _BACKTICK_RUN = re.compile(r"`+")
 _ASTERISK_RUN = re.compile(r"\*+")
+
+
+class ReusedConcept:
+    """A group, field or attribute that a class does not define itself but that is
+    shown in its documentation.
+
+    A class takes over everything defined by the class it ``extends`` and by the base
+    classes of the groups it uses, without repeating any of it. Only what a class
+    defines itself is shown in its documentation. The ``reused_concepts`` element of
+    NXDL points at concepts that a class takes over unchanged, so that they are shown
+    as well. Reusing a concept changes nothing about the class itself.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        is_attribute: bool,
+        parent: Optional["ReusedConcept"],
+        node: lxml.etree._Element,
+        defined_here: bool,
+    ) -> None:
+        self.name = name
+        self.is_attribute = is_attribute
+        self.parent = parent
+        self.node = node
+        self.defined_here = defined_here
+        parent_path = parent.path if parent is not None else ""
+        self.path = f"{parent_path}{'@' if is_attribute else '/'}{name}"
+        self.nxdl_path = f"{parent.nxdl_path if parent is not None else ''}/{name}"
+        self.listed = False
+        self.children_mode = "none"
+        self.children: Dict[str, "ReusedConcept"] = OrderedDict()
+
+    @property
+    def element_type(self) -> str:
+        return xml_utils.get_local_name(self.node)
 
 
 class NXClassDocGenerator:
@@ -45,6 +104,14 @@ class NXClassDocGenerator:
         self._anchor_registry = None
         self._listing_category = None
         self._use_application_defaults = None
+        self._nxclass_name = None
+        self._nxdl_file = None
+        self._root_element = None
+        self._reused_concepts = OrderedDict()
+        self._reused_index = dict()
+        self._reused_count = 0
+        self._declared_symbols = set()
+        self._used_symbols = dict()
 
     def __call__(
         self, nxdl_file: PathLike, anchor_registry: Optional[AnchorRegistry] = None
@@ -57,8 +124,8 @@ class NXClassDocGenerator:
         try:
             try:
                 self._parse_nxdl_file(nxdl_file)
-            except Exception:
-                raise NXDLParseError(nxdl_file)
+            except Exception as e:
+                raise NXDLParseError(f"{nxdl_file}: {e}") from e
         finally:
             self._reset()
         return self._rst_lines
@@ -86,6 +153,9 @@ class NXClassDocGenerator:
         self._listing_category = self._CATEGORY_TO_LISTING[category]
         self._use_application_defaults = category == "application"
         self._contribution = nxdl_file.parent.name == "contributed_definitions"
+        self._nxclass_name = nxclass_name
+        self._nxdl_file = nxdl_file
+        self._root_element = root
 
         # print ReST comments and section header
         source = os.path.relpath(nxdl_file, get_nxdl_root())
@@ -157,11 +227,25 @@ class NXClassDocGenerator:
         else:
             self._print_doc_enum("", ns, node_list[0])
             for node in node_list[0].xpath("nx:symbol", namespaces=ns):
-                doc = self._get_doc_line(ns, node)
-                self._print(f"  **{node.get('name')}**", end="")
+                name = node.get("name")
+                reused_from = node.get("reused_from")
+                self._declared_symbols.add(name)
+                if reused_from:
+                    doc = self._reused_symbol_doc(ns, node, name, reused_from)
+                    suffix = f" :ref:`⤆ </{reused_from}/{name}-symbol>` {REUSED_MARKER}"
+                else:
+                    doc = self._get_doc_line(ns, node)
+                    suffix = ""
+                self._print(
+                    f"  {self._hyperlink_target(f'/{nxclass_name}', name, 'symbol')}"
+                )
+                self._print(f"  **{name}**", end="")
                 if doc:
                     self._print(f": {doc}", end="")
-                self._print("\n")
+                self._print(f"{suffix}\n")
+
+        # concepts of other classes that are shown in the documentation of this one
+        self._parse_reused_concepts(ns, root)
 
         # print group references
         self._print("**Groups cited**:")
@@ -169,6 +253,12 @@ class NXClassDocGenerator:
         groups = []
         for node in node_list:
             g = node.get("type")
+            if g.startswith("NX") and g not in groups:
+                groups.append(g)
+        for concept in self._iter_reused_concepts():
+            if concept.element_type != "group":
+                continue
+            g = concept.node.get("type")
             if g.startswith("NX") and g not in groups:
                 groups.append(g)
         if len(groups) == 0:
@@ -186,6 +276,7 @@ class NXClassDocGenerator:
 
         # print full tree
         self._print("**Structure**:\n")
+        self._print_reuse_legend()
         for subnode in root.xpath("nx:attribute", namespaces=ns):
             optional = self._get_required_or_optional_text(subnode)
             self._print_attribute(
@@ -194,6 +285,8 @@ class NXClassDocGenerator:
         self._print_full_tree(
             ns, root, nxclass_name, self._INDENTATION_UNIT, parent_path
         )
+
+        self._check_symbols()
 
         self._print_anchor_list()
 
@@ -220,7 +313,7 @@ class NXClassDocGenerator:
         self._print("-----------------\n")
         self._print(
             "List of hypertext anchors for all groups, fields,\n"
-            "attributes, and links defined in this class.\n\n"
+            "attributes, links, and symbols defined in this class.\n\n"
         )
 
         def sorter(key):
@@ -347,31 +440,37 @@ class NXClassDocGenerator:
             return self._handle_multiline_docstring(blocks)
         return blocks[0].replace("\n", " ")
 
-    def _get_minOccurs(self, node):
+    def _get_minOccurs(self, node, use_application_defaults=None):
         """
         get the value for the ``minOccurs`` attribute
 
         :param obj node: instance of lxml.etree._Element
+        :param use_application_defaults: defaults of the class defining the node
         :returns str: value of the attribute (or its default)
         """
         # TODO: can we improve on the default by examining nxdl.xsd?
-        minOccurs_default = str(int(self._use_application_defaults))
+        if use_application_defaults is None:
+            use_application_defaults = self._use_application_defaults
+        minOccurs_default = str(int(use_application_defaults))
         minOccurs = node.get("minOccurs", minOccurs_default)
         return minOccurs
 
-    def _get_required_or_optional_text(self, node):
+    def _get_required_or_optional_text(self, node, use_application_defaults=None):
         """
         make clear if a reported item is required or optional
 
         :param obj node: instance of lxml.etree._Element
+        :param use_application_defaults: defaults of the class defining the node
         :returns: formatted text
         """
+        if use_application_defaults is None:
+            use_application_defaults = self._use_application_defaults
         nxdl_element_type = nxdl_utils.get_nxdl_element_type(node)
         if nxdl_element_type in ("field", "group", "choice"):
-            optional_default = not self._use_application_defaults
+            optional_default = not use_application_defaults
             optional = node.get("optional", optional_default) in (True, "true", "1", 1)
             recommended = node.get("recommended", None) in (True, "true", "1", 1)
-            minOccurs = self._get_minOccurs(node)
+            minOccurs = self._get_minOccurs(node, use_application_defaults)
             if recommended:
                 optional_text = "(recommended) "
             elif minOccurs in ("0", 0) or optional:
@@ -383,7 +482,7 @@ class NXClassDocGenerator:
                 # TODO: add a remark to the log
                 optional_text = f"(``minOccurs={str(minOccurs)}``) "
         elif nxdl_element_type in ("attribute",):
-            optional_default = not self._use_application_defaults
+            optional_default = not use_application_defaults
             optional = node.get("optional", optional_default) in (True, "true", "1", 1)
             recommended = node.get("recommended", None) in (True, "true", "1", 1)
             optional_text = {True: "(optional) ", False: "(required) "}[optional]
@@ -452,6 +551,9 @@ class NXClassDocGenerator:
 
             # Dimension symbol
             dim = subnode.get("value")  # integer or symbol from the table
+            if dim:
+                self._register_dimension_symbols(dim, parent)
+                dim = self._link_dimension_symbols(dim)
             if not dim:
                 ref = subnode.get("ref")
                 if ref:
@@ -630,7 +732,9 @@ class NXClassDocGenerator:
                 collapse_indent + self._INDENTATION_UNIT, ns, node_list[0]
             )
 
-    def _print_attribute(self, ns, kind, node, optional, indent, parent_path):
+    def _print_attribute(
+        self, ns, kind, node, optional, indent, parent_path, reused=False
+    ):
         name = node.get("name")
         formatted_name = nxdl_utils.get_rst_formatted_name(node)
         index_name = name
@@ -638,8 +742,12 @@ class NXClassDocGenerator:
             f"{indent}" f"{self._hyperlink_target(parent_path, name, 'attribute')}"
         )
         self._print(f"{indent}.. index:: {index_name} ({kind} attribute)\n")
+        if reused:
+            reference = f"{self._reused_ref(node, 'attribute')} {REUSED_MARKER}"
+        else:
+            reference = self.get_first_parent_ref(f"{parent_path}/{name}", "attribute")
         self._print(
-            f"{indent}{formatted_name}: {optional}{self._format_type(node)}{self._format_units(node)} {self.get_first_parent_ref(f'{parent_path}/{name}', 'attribute')}\n"
+            f"{indent}{formatted_name}: {optional}{self._format_type(node)}{self._format_units(node)} {reference}\n"
         )
         self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
         self._print_doc_enum(indent, ns, node)
@@ -660,9 +768,27 @@ class NXClassDocGenerator:
         :param indent: to keep track of indentation level
         :param parent_path: NX class path of parent nodes
         """
+        # Reused concepts are shown where the class would define them: attributes
+        # right after the ones of the class itself, fields before the first group
+        # and groups last.
+        reused = self._reused_index.get(parent_path, ())
+        reused_attributes = [c for c in reused if c.element_type == "attribute"]
+        reused_fields = [c for c in reused if c.element_type in ("field", "link")]
+        reused_groups = [c for c in reused if c.element_type == "group"]
+        for concept in reused_attributes:
+            self._print_reused_concept(ns, concept, indent)
+        fields_printed = False
+
         # Process children in document order to preserve XML ordering.
         for node in parent.xpath("nx:field|nx:group|nx:choice|nx:link", namespaces=ns):
             nxdl_element_type = nxdl_utils.get_nxdl_element_type(node)
+            if not fields_printed and xml_utils.get_local_name(node) in (
+                "group",
+                "choice",
+            ):
+                fields_printed = True
+                for concept in reused_fields:
+                    self._print_reused_concept(ns, concept, indent)
 
             if nxdl_element_type == "field":
                 name = node.get("name")
@@ -698,6 +824,10 @@ class NXClassDocGenerator:
                         indent + self._INDENTATION_UNIT,
                         parent_path + "/" + name,
                     )
+
+                self._print_reused_concepts(
+                    ns, indent + self._INDENTATION_UNIT, parent_path + "/" + name
+                )
 
             elif nxdl_element_type == "group":
                 name = node.get("name", "")
@@ -798,6 +928,389 @@ class NXClassDocGenerator:
 
             else:
                 raise ValueError(f"Unknown node type: {nxdl_element_type}")
+
+        if not fields_printed:
+            for concept in reused_fields:
+                self._print_reused_concept(ns, concept, indent)
+        for concept in reused_groups:
+            self._print_reused_concept(ns, concept, indent)
+
+    def _parse_reused_concepts(self, ns, root) -> None:
+        """Parse the ``reused_concepts`` element: concepts of other classes that are
+        shown in the documentation of this class.
+        """
+        node_list = root.xpath("nx:reused_concepts", namespaces=ns)
+        if not node_list:
+            return
+        if len(node_list) > 1:
+            raise ValueError(f"Invalid reused_concepts list in {self._nxclass_name}")
+
+        listed = list()
+        for node in node_list[0].xpath("nx:reuse", namespaces=ns):
+            path = node.get("path")
+            children_mode = node.get("children", "none")
+            if children_mode not in REUSE_CHILDREN_MODES:
+                raise ValueError(
+                    f"'{path}': children='{children_mode}' is not one of "
+                    f"{', '.join(REUSE_CHILDREN_MODES)}"
+                )
+            concept = None
+            concepts = self._reused_concepts
+            for name, is_attribute in self._split_reuse_path(path):
+                key = f"@{name}" if is_attribute else name
+                child = concepts.get(key)
+                if child is None:
+                    child = self._create_reused_concept(concept, name, is_attribute)
+                    concepts[key] = child
+                concept = child
+                concepts = concept.children
+            if concept.listed:
+                raise ValueError(f"'{path}' is reused more than once")
+            if concept.defined_here:
+                raise ValueError(
+                    f"'{path}' is defined by {self._nxclass_name} itself: remove the "
+                    "definition or remove it from the 'reused_concepts' list"
+                )
+            concept.listed = True
+            concept.children_mode = children_mode
+            listed.append(concept)
+
+        for concept in listed:
+            self._expand_reused_concept(ns, concept, concept.children_mode, 1)
+        self._index_reused_concepts(self._reused_concepts, f"/{self._nxclass_name}")
+
+    @staticmethod
+    def _split_reuse_path(path: str) -> List[Tuple[str, bool]]:
+        """Split a ``reuse`` path into ``(name, is_attribute)`` per level."""
+        if not path or not path.startswith("/"):
+            raise ValueError(f"reuse path '{path}' must start with '/'")
+        segments = list()
+        for part in path[1:].split("/"):
+            names = part.split("@")
+            if len(names) > 2 or not all(names):
+                raise ValueError(f"'{path}' is not a valid reuse path")
+            segments.append((names[0], False))
+            if len(names) == 2:
+                segments.append((names[1], True))
+        return segments
+
+    def _create_reused_concept(
+        self, parent: Optional[ReusedConcept], name: str, is_attribute: bool
+    ) -> ReusedConcept:
+        nxdl_path = f"{parent.nxdl_path if parent is not None else ''}/{name}"
+        elist = nxdl_utils.get_inherited_nodes(nxdl_path, None, self._root_element)[2]
+        if not elist:
+            raise ValueError(f"'{nxdl_path}' does not exist in {self._nxclass_name}")
+        node = elist[0]
+        element_type = xml_utils.get_local_name(node)
+        if element_type == "choice":
+            raise ValueError(
+                f"'{nxdl_path}' is a choice, which cannot be highlighted in the "
+                "documentation"
+            )
+        if is_attribute != (element_type == "attribute"):
+            raise ValueError(
+                f"'{nxdl_path}' is a {element_type}: an attribute is separated from "
+                "its parent with '@', anything else with '/'"
+            )
+        defined_name = nxdl_utils.get_node_name(node)
+        if defined_name != name:
+            raise ValueError(
+                f"'{nxdl_path}' must be spelled '{defined_name}' as in the class that defines it"
+            )
+        # nodes of the class being documented have an empty 'nxdlbase'
+        defined_here = not node.get("nxdlbase")
+        if not defined_here:
+            self._check_not_renamed(parent, node, name, nxdl_path)
+        return ReusedConcept(name, is_attribute, parent, node, defined_here)
+
+    def _check_not_renamed(
+        self, parent: Optional[ReusedConcept], node, name: str, nxdl_path: str
+    ) -> None:
+        """A concept that this class redefines under another name, such as a group
+        with a flexible name that the class names itself, is not the same concept."""
+        if parent is None:
+            parent_node = self._root_element
+        elif parent.defined_here:
+            parent_node = parent.node
+        else:
+            # this class does not define the parent, so it cannot redefine its children
+            return
+        own_node, _ = nxdl_utils.get_best_child(
+            parent_node,
+            None,
+            name,
+            nxdl_utils.get_nx_class(node),
+            nxdl_utils.get_nxdl_element_type(node),
+        )
+        if own_node is None:
+            return
+        own_name = nxdl_utils.get_node_name(own_node)
+        if own_name != name:
+            raise ValueError(
+                f"'{nxdl_path}' is redefined by {self._nxclass_name} as "
+                f"'{own_name}': reuse that concept instead"
+            )
+
+    def _expand_reused_concept(
+        self, ns, concept: ReusedConcept, children_mode: str, level: int
+    ) -> None:
+        """Add the children of a reused concept that are shown as well."""
+        if children_mode == "none" or concept.element_type not in ("group", "field"):
+            return
+        if level > MAX_REUSE_DEPTH:
+            raise ValueError(
+                f"'{concept.nxdl_path}' shows more than {MAX_REUSE_DEPTH} levels of "
+                "children: list the concepts to be shown instead of using "
+                "children='all'"
+            )
+        child_mode = "all" if children_mode == "all" else "none"
+        for name, node in self._reused_children_nodes(ns, concept).items():
+            if name in concept.children:
+                continue
+            child = ReusedConcept(name, False, concept, node, not node.get("nxdlbase"))
+            if child.defined_here or self._reused_cycle(child):
+                # documented where it is defined or already documented above
+                continue
+            child.listed = True
+            child.children_mode = child_mode
+            concept.children[name] = child
+            self._reused_count += 1
+            if self._reused_count > MAX_REUSED_CONCEPTS:
+                raise ValueError(
+                    f"more than {MAX_REUSED_CONCEPTS} concepts are reused: list the "
+                    "concepts to be shown instead of using children='all'"
+                )
+            self._expand_reused_concept(ns, child, child_mode, level + 1)
+
+    def _reused_children_nodes(self, ns, concept: ReusedConcept) -> Dict:
+        """The groups, fields and links of a reused concept, including those of the
+        class it is typed as but excluding those that every group takes over from
+        NXobject."""
+        elist = nxdl_utils.get_inherited_nodes(
+            concept.nxdl_path, None, self._root_element
+        )[2]
+        nodes = OrderedDict()
+        for elem in elist:
+            if elem.get("name") == "NXobject":
+                # every group has these, showing them everywhere is noise
+                continue
+            for child in elem.xpath("nx:field|nx:group|nx:link", namespaces=ns):
+                name = nxdl_utils.get_node_name(child)
+                if name not in nodes:
+                    nodes[name] = nxdl_utils.set_nxdlpath(child, elem)
+        return nodes
+
+    @staticmethod
+    def _reused_cycle(concept: ReusedConcept) -> bool:
+        """A concept or its group type is already reused by one of its own ancestors
+        (like NXsample in NXsample)."""
+
+        def source(concept):
+            return concept.node.get("nxdlbase"), concept.node.get("nxdlpath")
+
+        key = source(concept)
+        nxclass_name = (
+            concept.node.get("type") if concept.element_type == "group" else None
+        )
+        parent = concept.parent
+        while parent is not None:
+            if source(parent) == key:
+                return True
+            if nxclass_name is not None and parent.node.get("type") == nxclass_name:
+                return True
+            parent = parent.parent
+        return False
+
+    def _index_reused_concepts(self, concepts, doc_parent_path: str) -> None:
+        """Index the concepts by the path at which they are documented. The children
+        of a concept that this class defines are documented below that definition."""
+        for concept in concepts.values():
+            if concept.defined_here:
+                self._index_reused_concepts(
+                    concept.children, f"{doc_parent_path}/{concept.name}"
+                )
+            else:
+                self._reused_index.setdefault(doc_parent_path, list()).append(concept)
+
+    def _iter_reused_concepts(self, concepts=None) -> Iterator[ReusedConcept]:
+        if concepts is None:
+            concepts = self._reused_concepts
+        for concept in concepts.values():
+            if not concept.defined_here:
+                yield concept
+            yield from self._iter_reused_concepts(concept.children)
+
+    def _print_reuse_legend(self) -> None:
+        if not self._reused_concepts:
+            return
+        # the same indentation as the structure tree, else the tree ends up
+        # inside the note
+        indent = self._INDENTATION_UNIT
+        self._print(
+            f"{indent}.. note:: The ⤆ link points at the class a concept comes from. "
+            f"Items marked {REUSED_MARKER} are not defined by this class at all: they "
+            "are used exactly as that class defines them. Items with a ⤆ link but no "
+            "marker are defined by this class, which may change what they mean.\n"
+        )
+
+    def _print_reused_concepts(self, ns, indent: str, parent_path: str) -> None:
+        for concept in self._reused_index.get(parent_path, ()):
+            self._print_reused_concept(ns, concept, indent)
+
+    def _print_reused_concept(self, ns, concept: ReusedConcept, indent: str) -> None:
+        node = concept.node
+        element_type = concept.element_type
+        name = concept.name
+        tag = "field" if element_type == "link" else element_type
+        doc_parent_path = f"/{self._nxclass_name}" + (
+            concept.parent.path if concept.parent is not None else ""
+        )
+        # occurrences follow the defaults of the class that defines the concept
+        use_application_defaults = node.get("nxdlbase_class") == "application"
+        optional_text = self._get_required_or_optional_text(
+            node, use_application_defaults
+        )
+
+        if element_type == "attribute":
+            self._print_attribute(
+                ns,
+                concept.parent.element_type if concept.parent is not None else "file",
+                node,
+                optional_text,
+                indent,
+                doc_parent_path,
+                reused=True,
+            )
+            return
+
+        marker = f"{self._reused_ref(node, tag)} {REUSED_MARKER}"
+        formatted_name = nxdl_utils.get_rst_formatted_name(node)
+        self._print(f"{indent}{self._hyperlink_target(doc_parent_path, name, tag)}")
+        if element_type == "group":
+            typ = node.get("type", "untyped (this is an error; please report)")
+            if typ.startswith("NX"):
+                typ = f":ref:`{typ}`"
+            self._print(f"{indent}{formatted_name}: {optional_text}{typ} {marker}\n")
+        elif element_type == "link":
+            self._print(
+                f"{indent}{formatted_name}: "
+                ":ref:`link<Design-Links>` "
+                f"(suggested target: ``{node.get('target')}``)"
+                f" {marker}\n"
+            )
+        else:
+            self._print(f"{indent}.. index:: {name} (field)\n")
+            self._print(
+                f"{indent}{formatted_name}: "
+                f"{optional_text}"
+                f"{self._format_type(node)}"
+                f"{self._analyze_dimensions(ns, node)}"
+                f"{self._format_units(node)}"
+                f" {marker}"
+                "\n"
+            )
+
+        self._print_if_deprecated(ns, node, indent + self._INDENTATION_UNIT)
+
+        if concept.listed:
+            self._print_doc_enum(indent, ns, node)
+            for subnode in node.xpath("nx:attribute", namespaces=ns):
+                if f"@{subnode.get('name')}" in concept.children:
+                    continue
+                nxdl_utils.set_nxdlpath(subnode, node)
+                optional = self._get_required_or_optional_text(
+                    subnode, use_application_defaults
+                )
+                self._print_attribute(
+                    ns,
+                    element_type,
+                    subnode,
+                    optional,
+                    indent + self._INDENTATION_UNIT,
+                    f"/{self._nxclass_name}{concept.path}",
+                    reused=True,
+                )
+
+        for child in concept.children.values():
+            self._print_reused_concept(ns, child, indent + self._INDENTATION_UNIT)
+
+    @staticmethod
+    def _reused_ref(node, tag: str) -> str:
+        """Reference to the concept in the class that defines it."""
+        nxdlbase = node.get("nxdlbase")
+        nxdlpath = node.get("nxdlpath")
+        if not nxdlbase or not nxdlpath:
+            return ""
+        nxclass_name = Path(nxdlbase).name.split(".")[0]
+        if tag == "attribute":
+            pos = nxdlpath.rfind("/")
+            nxdlpath = f"{nxdlpath[:pos]}@{nxdlpath[pos + 1:]}"
+        return f":ref:`⤆ </{nxclass_name}{nxdlpath}-{tag}>`"
+
+    def _reused_symbol_doc(self, ns, node, name: str, nxclass_name: str) -> str:
+        """Documentation of a symbol that is taken from another class."""
+        if node.xpath("nx:doc", namespaces=ns):
+            raise ValueError(
+                f"symbol '{name}' has a 'doc' element as well as "
+                f"reused_from='{nxclass_name}'"
+            )
+        nxdl_file = nxdl_utils.find_definition_file(nxclass_name)
+        if nxdl_file is None:
+            raise ValueError(
+                f"symbol '{name}' is reused from unknown class '{nxclass_name}'"
+            )
+        root = xml_utils.read_xml_file(nxdl_file)
+        for symbol in root.xpath("nx:symbols/nx:symbol", namespaces=ns):
+            if symbol.get("name") == name:
+                return self._get_doc_line(ns, symbol)
+        raise ValueError(f"'{nxclass_name}' does not define the symbol '{name}'")
+
+    def _link_dimension_symbols(self, size: str) -> str:
+        """Turn the symbols in the size of a dimension into links to the symbol
+        table of this class.
+        """
+        parts = []
+        end = 0
+        for match in SYMBOL_PATTERN.finditer(size):
+            name = match.group()
+            if name not in self._declared_symbols:
+                continue
+            before = size[end : match.start()]
+            parts.append(before)
+            if before and before[-1] not in RST_INLINE_PREFIX:
+                parts.append("\\ ")
+            parts.append(f":ref:`{name} </{self._nxclass_name}/{name}-symbol>`")
+            end = match.end()
+            if end < len(size) and size[end] not in RST_INLINE_SUFFIX:
+                parts.append("\\ ")
+        parts.append(size[end:])
+        return "".join(parts)
+
+    def _register_dimension_symbols(self, size: str, node) -> None:
+        """Register the symbols used in the size of a dimension."""
+        for symbol in SYMBOL_PATTERN.findall(size):
+            self._used_symbols.setdefault(symbol, nxdl_utils.get_node_name(node))
+
+    def _check_symbols(self) -> None:
+        """All symbols that appear in the documentation must be in the symbol table."""
+        missing = {
+            symbol: used_by
+            for symbol, used_by in self._used_symbols.items()
+            if symbol not in self._declared_symbols
+        }
+        if not missing:
+            return
+        details = ", ".join(
+            f"'{symbol}' (dimension of '{used_by}')"
+            for symbol, used_by in sorted(missing.items())
+        )
+        raise ValueError(
+            f"{self._nxclass_name} documents symbols that are missing from its symbol "
+            f"table: {details}. Add them to the 'symbols' element, with a 'doc' element "
+            "or with a 'reused_from' attribute naming the class that documents the "
+            "symbol."
+        )
 
     def _print(self, *args, end="\n"):
         # TODO: change instances of \t to proper indentation

--- a/dev_tools/tests/test_docdiff.py
+++ b/dev_tools/tests/test_docdiff.py
@@ -1,0 +1,100 @@
+"""Diffing the generated documentation of two git references."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ..__main__ import main
+from ..apps import docdiff_app
+from ..globals import directories
+
+
+def _has_git_repository() -> bool:
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=directories.get_source_root(),
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    return True
+
+
+@pytest.fixture
+def build_root(tmp_path):
+    original = directories.get_build_root()
+    yield tmp_path
+    directories.set_build_root(original)
+
+
+@pytest.mark.skipif(not _has_git_repository(), reason="not a git repository")
+def test_docdiff_same_reference(build_root, capsys):
+    exit_code = main(
+        [
+            "dev_tools",
+            "docdiff",
+            "--nxclass",
+            "NXentry",
+            "--color",
+            "never",
+            "--exit-code",
+            "--build-root",
+            str(build_root),
+            "HEAD",
+            "HEAD",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert not captured.out
+    assert "0 file(s) differ" in captured.err
+    assert not list(build_root.glob("docdiff/*"))
+
+
+@pytest.mark.skipif(not _has_git_repository(), reason="not a git repository")
+def test_docdiff_unknown_reference(build_root, capsys):
+    exit_code = main(
+        [
+            "dev_tools",
+            "docdiff",
+            "--build-root",
+            str(build_root),
+            "no-such-reference",
+            "HEAD",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "invalid reference" in captured.err
+    assert not (build_root / "docdiff").exists()
+
+
+@pytest.mark.skipif(not _has_git_repository(), reason="not a git repository")
+def test_docdiff_cleanup(build_root):
+    """Left-overs of an interrupted run are removed."""
+    repo = Path(directories.get_source_root())
+    root = build_root / "docdiff"
+    source_root = root / "old" / "source"
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(source_root), "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    (root / "new").mkdir()
+
+    docdiff_app._remove_generated(repo, root)
+
+    assert not root.exists()
+    worktrees = subprocess.run(
+        ["git", "worktree", "list"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert str(source_root) not in worktrees

--- a/dev_tools/tests/test_reused_concepts.py
+++ b/dev_tools/tests/test_reused_concepts.py
@@ -1,0 +1,293 @@
+"""Showing concepts of other classes in the documentation of a NeXus class."""
+
+from pathlib import Path
+from typing import List
+from typing import Optional
+
+import pytest
+
+from ..docs import NXClassDocGenerator
+from ..globals.errors import NXDLParseError
+from ..nxdl import nxdl_schema
+from ..nxdl import validate_definition
+
+_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<definition name="NXtest_reused_concepts" extends="NXobject" type="group" category="application"
+    xmlns="http://definition.nexusformat.org/nxdl/3.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+{symbols}{reused}    <doc>Definition to test the reuse of concepts of other classes.</doc>
+    <group type="NXentry">
+        <doc>The entry.</doc>
+{content}    </group>
+</definition>
+"""
+
+
+def _count_reused(rst: str) -> int:
+    """Number of concepts marked as reused, excluding the legend."""
+    return rst.count("*(reused)*") - 1
+
+
+@pytest.fixture(scope="module")
+def doc_generator():
+    return NXClassDocGenerator()
+
+
+@pytest.fixture(scope="module")
+def xml_schema():
+    return nxdl_schema()
+
+
+@pytest.fixture
+def generate_doc(tmp_path, doc_generator, xml_schema, monkeypatch):
+    """Generate the documentation of a test definition."""
+    monkeypatch.setattr("dev_tools.docs.nxdl.get_nxdl_root", lambda: tmp_path)
+
+    def generate(
+        reuse: Optional[List[str]] = None,
+        symbols: Optional[List[str]] = None,
+        content: str = "",
+    ) -> str:
+        if reuse:
+            lines = "".join(f"        {line}\n" for line in reuse)
+            reused = f"    <reused_concepts>\n{lines}    </reused_concepts>\n"
+        else:
+            reused = ""
+        if symbols:
+            lines = "".join(f"        {line}\n" for line in symbols)
+            symbols = f"    <symbols>\n{lines}    </symbols>\n"
+        else:
+            symbols = ""
+        nxdl_file = Path(tmp_path) / "NXtest_reused_concepts.nxdl.xml"
+        nxdl_file.write_text(
+            _TEMPLATE.format(symbols=symbols, reused=reused, content=content)
+        )
+        validate_definition(nxdl_file, xml_schema)
+        return "".join(doc_generator(nxdl_file))
+
+    return generate
+
+
+def test_reused_ancestors(generate_doc):
+    """Groups in between are documented as well, without their documentation."""
+    rst = generate_doc(['<reuse path="/ENTRY/INSTRUMENT/SOURCE/type"/>'])
+
+    assert ":bolditalic:`INSTRUMENT`: (optional) :ref:`NXinstrument`" in rst
+    assert ":bolditalic:`SOURCE`: (optional) :ref:`NXsource`" in rst
+    assert "**type**: (optional) :ref:`NX_CHAR <NX_CHAR>`" in rst
+    assert _count_reused(rst) == 3
+    assert ":ref:`⤆ </NXsource/type-field>`" in rst
+
+    # only the listed concept is documented
+    assert "type of radiation source" in rst
+    assert "Collection of the components of the instrument" not in rst
+
+
+def test_reused_no_children(generate_doc):
+    rst = generate_doc(['<reuse path="/ENTRY/INSTRUMENT/SOURCE"/>'])
+
+    assert ":bolditalic:`SOURCE`: (optional) :ref:`NXsource`" in rst
+    assert "**type**" not in rst
+
+
+def test_reused_direct_children(generate_doc):
+    rst = generate_doc(
+        ['<reuse path="/ENTRY/INSTRUMENT/SOURCE/geometry" children="direct"/>']
+    )
+
+    assert "**component_index**: (optional)" in rst
+    # the children of NXgeometry/SHAPE are not documented
+    assert ":bolditalic:`SHAPE`: (optional) :ref:`NXshape`" in rst
+    assert "**size**" not in rst
+
+
+def test_reused_all_children(generate_doc):
+    rst = generate_doc(
+        ['<reuse path="/ENTRY/INSTRUMENT/SOURCE/geometry" children="all"/>'],
+        symbols=[
+            '<symbol name="numobj" reused_from="NXshape"/>',
+            '<symbol name="nshapepar" reused_from="NXshape"/>',
+        ],
+    )
+
+    assert ":bolditalic:`SHAPE`: (optional) :ref:`NXshape`" in rst
+    assert "**size**: (optional)" in rst
+
+
+def test_reused_too_many_children(generate_doc):
+    with pytest.raises(NXDLParseError, match="concepts are reused"):
+        generate_doc(['<reuse path="/ENTRY/INSTRUMENT/SOURCE" children="all"/>'])
+
+
+def test_reused_subset_of_children(generate_doc):
+    rst = generate_doc(
+        [
+            '<reuse path="/ENTRY/INSTRUMENT/SOURCE/type"/>',
+            '<reuse path="/ENTRY/INSTRUMENT/SOURCE/probe"/>',
+        ]
+    )
+
+    assert "**type**: (optional)" in rst
+    assert "**probe**: (optional)" in rst
+    assert "**name**: (optional)" not in rst
+
+
+def test_reused_attribute(generate_doc):
+    rst = generate_doc(['<reuse path="/ENTRY@default"/>'])
+
+    assert "**@default**: (optional) :ref:`NX_CHAR <NX_CHAR>`" in rst
+    assert ":ref:`⤆ </NXentry@default-attribute>` *(reused)*" in rst
+
+
+def test_reused_below_defined_group(generate_doc):
+    """A concept is documented below the group that defines it."""
+    content = """        <group name="instrument" type="NXinstrument">
+            <doc>The instrument.</doc>
+        </group>
+"""
+    rst = generate_doc(['<reuse path="/ENTRY/instrument/SOURCE"/>'], content=content)
+
+    _, _, below = rst.partition("**instrument**: (required) :ref:`NXinstrument`")
+    assert ":bolditalic:`SOURCE`: (optional) :ref:`NXsource`" in below
+    assert _count_reused(rst) == 1
+
+
+def test_reused_defined_concept(generate_doc):
+    content = """        <field name="title" type="NX_CHAR">
+            <doc>The title.</doc>
+        </field>
+"""
+    with pytest.raises(
+        NXDLParseError, match="is defined by NXtest_reused_concepts itself"
+    ):
+        generate_doc(['<reuse path="/ENTRY/title"/>'], content=content)
+
+
+def test_reused_unknown_concept(generate_doc):
+    with pytest.raises(NXDLParseError, match="does not exist in"):
+        generate_doc(['<reuse path="/ENTRY/does_not_exist"/>'])
+
+
+def test_reused_renamed_concept(generate_doc):
+    """A concept that this class redefines under another name is a different one."""
+    content = """        <group name="my_sample" nameType="any" type="NXsample">
+            <doc>The sample.</doc>
+        </group>
+"""
+    with pytest.raises(NXDLParseError, match="is redefined by .* as 'my_sample'"):
+        generate_doc(['<reuse path="/ENTRY/SAMPLE"/>'], content=content)
+
+    # the concept as this class knows it can be reused instead
+    rst = generate_doc(
+        ['<reuse path="/ENTRY/my_sample/chemical_formula"/>'], content=content
+    )
+    assert "**chemical_formula**: (optional)" in rst
+
+
+def test_reused_invalid_path(generate_doc):
+    with pytest.raises(NXDLParseError, match="must start with '/'"):
+        generate_doc(['<reuse path="ENTRY/INSTRUMENT"/>'])
+
+
+def test_reused_wrong_separator(generate_doc):
+    with pytest.raises(NXDLParseError, match="is a group"):
+        generate_doc(['<reuse path="/ENTRY@INSTRUMENT"/>'])
+
+
+def test_reused_listed_twice(generate_doc):
+    with pytest.raises(NXDLParseError, match="reused more than once"):
+        generate_doc(
+            [
+                '<reuse path="/ENTRY/INSTRUMENT/SOURCE"/>',
+                '<reuse path="/ENTRY/INSTRUMENT/SOURCE"/>',
+            ]
+        )
+
+
+def test_symbols_of_reused_concept(generate_doc):
+    reuse = ['<reuse path="/ENTRY/INSTRUMENT/DETECTOR/dead_time"/>']
+
+    with pytest.raises(NXDLParseError, match="missing from its symbol table"):
+        generate_doc(reuse)
+
+    rst = generate_doc(
+        reuse,
+        symbols=[
+            '<symbol name="nP" reused_from="NXdetector"/>',
+            '<symbol name="i" reused_from="NXdetector"/>',
+            '<symbol name="j"><doc>Number of columns.</doc></symbol>',
+        ],
+    )
+    assert (
+        "**nP**: number of scan points (only present in scanning measurements) "
+        ":ref:`⤆ </NXdetector/nP-symbol>` *(reused)*" in rst
+    )
+    assert ".. _/NXtest_reused_concepts/j-symbol:" in rst
+    assert "**j**: Number of columns." in rst
+    cls = "/NXtest_reused_concepts"
+    assert (
+        "(Rank: 3, Dimensions: "
+        f"[:ref:`nP <{cls}/nP-symbol>`, "
+        f":ref:`i <{cls}/i-symbol>`, "
+        f":ref:`j <{cls}/j-symbol>`])" in rst
+    )
+
+
+def test_symbol_links_in_dimensions(generate_doc):
+    """Symbols in a dimension size link to the symbol table."""
+    content = """        <field name="data" type="NX_NUMBER">
+            <doc>The data.</doc>
+            <dimensions rank="2">
+                <dim index="1" value="2n_data"/>
+                <dim index="2" value="n_data+1"/>
+            </dimensions>
+        </field>
+"""
+    rst = generate_doc(
+        content=content,
+        symbols=['<symbol name="n_data"><doc>Number of points.</doc></symbol>'],
+    )
+
+    ref = ":ref:`n_data </NXtest_reused_concepts/n_data-symbol>`"
+    # the escapes keep the inline markup valid next to a digit and a "+"
+    assert f"(Rank: 2, Dimensions: [2\\ {ref}, {ref}\\ +1])" in rst
+
+
+def test_symbols_of_defined_concept(generate_doc):
+    content = """        <field name="data" type="NX_NUMBER">
+            <doc>The data.</doc>
+            <dimensions rank="1">
+                <dim index="1" value="n_data"/>
+            </dimensions>
+        </field>
+"""
+    with pytest.raises(NXDLParseError, match="'n_data' \\(dimension of 'data'\\)"):
+        generate_doc(content=content)
+
+    rst = generate_doc(
+        symbols=['<symbol name="n_data"><doc>Number of points.</doc></symbol>'],
+        content=content,
+    )
+    assert "**n_data**: Number of points." in rst
+
+
+def test_symbol_reused_from_unknown_class(generate_doc):
+    with pytest.raises(NXDLParseError, match="unknown class 'NXdoes_not_exist'"):
+        generate_doc(symbols=['<symbol name="nP" reused_from="NXdoes_not_exist"/>'])
+
+
+def test_symbol_not_in_reused_class(generate_doc):
+    with pytest.raises(NXDLParseError, match="does not define the symbol 'nP'"):
+        generate_doc(symbols=['<symbol name="nP" reused_from="NXsource"/>'])
+
+
+def test_symbol_reused_with_doc(generate_doc):
+    with pytest.raises(
+        NXDLParseError, match="has a 'doc' element as well as reused_from"
+    ):
+        generate_doc(
+            symbols=[
+                '<symbol name="nP" reused_from="NXdetector"><doc>Points.</doc></symbol>'
+            ]
+        )

--- a/manual/source/classes/index.rst
+++ b/manual/source/classes/index.rst
@@ -14,7 +14,7 @@ application definitions (groupings of objects for a particular technique) and
 contributed_definitions (proposed definitions from the community)
 
 The complete :index:`!vocabulary` of terms used in NeXus NXDL files (names of
-groups, fields, attributes, and links) is available for :ref:`download
+groups, fields, attributes, links, and symbols) is available for :ref:`download
 <classes.vocabulary.downloads>`.
 
 .. rubric:: :styleh2:`Base classes`

--- a/manual/source/defs_intro.rst
+++ b/manual/source/defs_intro.rst
@@ -63,6 +63,8 @@ readbility and comprehension for those whom are new to an NXDL file, the followi
 guidelines are strongly encouraged:
 
 * All symbols used in the application definition are defined in a single ``Symbols`` table.
+  This is enforced when building the documentation: every symbol that appears as the size
+  of a dimension must be in the ``Symbols`` table of the same NXDL file.
 * The :ref:`name <validItemName>` of a symbol uses camel case without any white space or underscores.
 
   examples: 
@@ -113,6 +115,51 @@ guidelines are strongly encouraged:
 			<field name="title"  minOccurs="0" maxOccurs="1"/>  	
 		...
 							
+
+When a :ref:`reused concept <Design-ReusedConcepts>` has dimensions expressed in symbols
+of the class that defines it, those symbols are taken over with the ``reused_from``
+attribute instead of repeating their documentation:
+
+.. code-block:: xml
+    :linenos:
+
+		<symbols>
+			<symbol name="nP" reused_from="NXdetector"/>
+		</symbols>
+
+.. _Design-ReusedConcepts:
+
+Reusing concepts of other classes
+=================================
+
+A class takes over everything defined by the class it ``extends`` and by the base
+classes of the groups it uses, without repeating any of it.  Only what a class defines
+itself is shown in its documentation.  When a group, field or attribute of another
+class is worth showing without changing anything about it, list it in the
+``reused_concepts`` list instead of repeating its definition:
+
+.. code-block:: xml
+    :linenos:
+
+		<reused_concepts>
+			<reuse path="/ENTRY/INSTRUMENT/SOURCE/type"/>
+			<reuse path="/ENTRY/INSTRUMENT/SOURCE/probe"/>
+			<reuse path="/ENTRY/SAMPLE/TRANSFORMATIONS" children="direct"/>
+		</reused_concepts>
+
+Each ``path`` starts at the root of the class and spells every name as in the class that
+defines it (an attribute is separated from its parent by ``@``, anything else by ``/``).
+The groups in between are shown as well, whether they are defined by this class or not.
+The ``children`` attribute selects which children of a reused group or field are shown
+too: ``none`` (the default), ``direct`` or ``all``.  Show a subset of the children by
+listing them separately.
+
+Reused concepts are marked *(reused)* in the documentation and link to the class that
+defines them.  The class itself is not affected: reusing a concept changes neither the
+class nor the validation of data files.  Define a concept in the class itself instead
+of reusing it whenever anything about it changes, including its documentation.  It is
+an error to reuse a concept that the class defines itself, or one that does not exist in
+the class.
 
 Annotated Structure
 ===================

--- a/manual/source/examples/NXwoni.nxdl.xml
+++ b/manual/source/examples/NXwoni.nxdl.xml
@@ -25,6 +25,14 @@
     xmlns="http://definition.nexusformat.org/nxdl/3.1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd">
+    <symbols>
+        <symbol name="i">
+            <doc>number of wavelengths</doc>
+        </symbol>
+        <symbol name="ndet">
+            <doc>number of detectors</doc>
+        </symbol>
+    </symbols>
     <doc> Instrument definition for the fictional WONI powder
         diffractometer at HYNES.
     </doc>

--- a/nxdl.xsd
+++ b/nxdl.xsd
@@ -238,10 +238,20 @@ https://stackoverflow.com/a/48980995/1046449 -->
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="reused_concepts" type="nx:reusedConceptsType" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Use a ``reused_concepts`` list to show groups, fields and attributes
+						that this class takes over from other classes without redefining
+						them.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:group ref="nx:groupGroup" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-						In addition to an optional ``symbols`` list,
+						In addition to an optional ``symbols`` list
+						and an optional ``reused_concepts`` list,
 						a ``definition`` may contain any of the items
 						allowed in a ``group``.
 					</xs:documentation>
@@ -1215,6 +1225,114 @@ https://stackoverflow.com/a/48980995/1046449 -->
 								Mnemonic variable name for this array index symbol.
 							</xs:documentation>
 						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="reused_from" use="optional" type="nx:validNXClassName">
+						<xs:annotation>
+							<xs:documentation>
+								Name of the NeXus class from which the documentation of this
+								``symbol`` is taken.  Use this when a concept that is reused by
+								this class (see the ``reused_concepts`` element) has dimensions
+								expressed in symbols of that class.  A ``symbol`` with a
+								``reused_from`` attribute must not have a ``doc`` element:
+								provide a ``doc`` element instead when the meaning of the
+								symbol differs from the meaning it has in that class.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:complexType name="reusedConceptsType">
+		<xs:annotation>
+			<xs:documentation>
+				A class takes over everything defined by the class it ``extends`` and by the
+				base classes of the groups it uses, without repeating any of it.  Only what
+				a class defines itself is shown in its documentation.  A ``reused_concepts``
+				list points at concepts that a class reuses unchanged but that are worth
+				showing in its documentation anyway.  For example::
+
+					<reused_concepts>
+						<reuse path="/ENTRY/INSTRUMENT/SOURCE/type"/>
+						<reuse path="/ENTRY/INSTRUMENT/SOURCE/probe"/>
+						<reuse path="/ENTRY/SAMPLE/beam" children="direct"/>
+					</reused_concepts>
+
+				The documentation of each ``reuse`` path is rendered at its place in the
+				structure of this class, marked as reused and with a link to the class that
+				defines it.  Groups and fields in between (``INSTRUMENT`` and ``SOURCE`` in
+				the example above) are shown as well, even when they are neither defined by
+				this class nor listed here.  Nothing else changes: reusing a concept has no
+				effect on the class or on the validation of data files.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="doc" type="nx:docType" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Describe the purpose of this list of reused concepts.
+						This documentation will go into the manual.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="reuse" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>
+						One group, field or attribute of another class to be shown in
+						the documentation of this class.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="path" use="required" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>
+								Path of the concept, relative to the root of this class and
+								starting with ``/``.  Each name in the path must be spelled as
+								in the class that defines it (for example
+								``/ENTRY/INSTRUMENT/SOURCE/type``).  Attributes are separated
+								from their parent by ``@``.
+
+								It is an error when the concept at this path does not exist in
+								this class or when this class defines it itself: remove the
+								definition or remove this ``reuse`` element.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="children" use="optional" default="none">
+						<xs:annotation>
+							<xs:documentation>
+								Which children of the reused group or field are shown in the
+								documentation as well.  Show a subset of the children by
+								listing them separately.  Children that every group takes over from
+								:ref:`NXobject` are never shown, they can only be listed.
+							</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="none">
+									<xs:annotation>
+										<xs:documentation>
+											No children are shown (default).
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
+								<xs:enumeration value="direct">
+									<xs:annotation>
+										<xs:documentation>
+											The direct children are shown, but not their children.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
+								<xs:enumeration value="all">
+									<xs:annotation>
+										<xs:documentation>
+											All children are shown recursively.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:enumeration>
+							</xs:restriction>
+						</xs:simpleType>
 					</xs:attribute>
 				</xs:complexType>
 			</xs:element>


### PR DESCRIPTION
Following https://github.com/nexusformat/definitions/pull/1039#discussion_r2353123236.

## PR description

### Features

1. Avoid duplicating `.nxdl.xml` content to "reuse" documentation of inherited concepts from base class it extends or children.
2. Allow reusing symbols from inherited classes (base class it extends or children).
3. Ensure all symbols are defined (fixed all broken symbol tables).
4. Symbols are now links. Also added to "Hypertext Anchors" on each page.
5. Add `make docdiff` to make a diff
   - of generated files (`classes/*/*.rst, nxdl_desc.rst, units.table, types.table, _static/nxdl_vocabulary.txt`)
   - between two git references
   - HEAD~1 vs. HEAD by default.
   - I used it for this PR and decided to add it to the `dev_tools`.

### Changes

- `NXstress` and `NXapm_paraprobe_clusterer_config` use the new `<reused_concepts>...</reused_concepts>` to demonstrate its usage.
- All other `.nxdl.xml` files that changed have fixes regarding their symbols table. Since this PR now validates it.

Many other classes could use this new `reused_concepts` feature but I won't do it in this PR.

## Examples

### Reused symbols

<kbd>
<img width="814" height="416" alt="image" src="https://github.com/user-attachments/assets/9f37b5ec-bdca-4857-a125-cf2861625509" />
</kbd>

### Reused fields/groups/attributes


Every page as a note that explains the difference between `⤆ (reused)` and `⤆` to the reader.

<kbd>
<img width="831" height="333" alt="image" src="https://github.com/user-attachments/assets/db2ab692-3631-4401-ad9d-188fc37d8e62" />
</kbd>


This tells me that `title` and `name` are identical to the ones in the base classes. But `role` might be different.

<kbd>
<img width="678" height="300" alt="image" src="https://github.com/user-attachments/assets/9d992622-d829-4149-a61b-899da8885a56" />
</kbd>