### PR TITLE
Update NX component description field

### DIFF
--- a/base_classes/NXcomponent.nxdl.xml
+++ b/base_classes/NXcomponent.nxdl.xml
@@ -37,11 +37,7 @@
     </field>
     <field name="description" type="NX_CHAR">
         <doc>
-            Ideally, use instances of ``identifierNAME`` to point to a resource
-            that provides further details.
-
-            If such a resource does not exist or should not be used, use this free text,
-            although it is not recommended.
+            Description of the component.
         </doc>
     </field>
     <field name="inputs" type="NX_CHAR">


### PR DESCRIPTION
Shouldn't refer to identifierName, as that's a separate field of NXobject.

Closes #1652